### PR TITLE
New scroll to zoom logic in BQ

### DIFF
--- a/src/main/java/betterquesting/api/storage/BQ_Settings.java
+++ b/src/main/java/betterquesting/api/storage/BQ_Settings.java
@@ -20,4 +20,7 @@ public class BQ_Settings
 	public static boolean questNotices = true;
 	public static boolean dirtyMode = true;
 	public static float scrollMultiplier = 0.1F;
+
+	public static float zoomSpeed = 1.25f;
+	public static float zoomTimeInMs = 100f;
 }

--- a/src/main/java/betterquesting/api/storage/BQ_Settings.java
+++ b/src/main/java/betterquesting/api/storage/BQ_Settings.java
@@ -23,4 +23,7 @@ public class BQ_Settings
 
 	public static float zoomSpeed = 1.25f;
 	public static float zoomTimeInMs = 100f;
+
+	public static boolean zoomInToCursor = true;
+	public static boolean zoomOutToCursor = false;
 }

--- a/src/main/java/betterquesting/api2/client/gui/controls/io/FloatSimpleIO.java
+++ b/src/main/java/betterquesting/api2/client/gui/controls/io/FloatSimpleIO.java
@@ -54,10 +54,10 @@ public class FloatSimpleIO implements IValueIO<Float>
                 s = v;
                 return v;
             }
-            
-            long d = System.currentTimeMillis() - t;
+            long tmpMillis = System.currentTimeMillis();
+            long d = tmpMillis - t;
             s = RenderUtils.lerpFloat(s, v, (float)MathHelper.clamp_double(d * (double)lerpSpd, 0D, 1D));
-            if(d > 0) t = System.currentTimeMillis(); // Required if read out more than once in 1ms
+            if(d > 0) t = tmpMillis; // Required if read out more than once in 1ms
             return s;
         }
         

--- a/src/main/java/betterquesting/api2/client/gui/panels/lists/CanvasQuestLine.java
+++ b/src/main/java/betterquesting/api2/client/gui/panels/lists/CanvasQuestLine.java
@@ -36,11 +36,12 @@ public class CanvasQuestLine extends CanvasScrolling
     
     private final int buttonId;
     private IQuestLine lastQL;
+    private int zoomToFitMargin = 24;
     
     public CanvasQuestLine(IGuiRect rect, int buttonId)
     {
         super(rect);
-        this.setupAdvanceScroll(true, true, 24);
+        this.setupAdvanceScroll(true, true, 3000);
         this.enableBlocking(false);
         this.buttonId = buttonId;
     }
@@ -193,10 +194,10 @@ public class CanvasQuestLine extends CanvasScrolling
             }
         }
         
-        minX -= margin;
-        minY -= margin;
-        maxX += margin;
-        maxY += margin;
+        minX -= zoomToFitMargin;
+        minY -= zoomToFitMargin;
+        maxX += zoomToFitMargin;
+        maxY += zoomToFitMargin;
         
         this.setZoom(Math.min(getTransform().getWidth()/(float)(maxX - minX), getTransform().getHeight()/(float)(maxY - minY)));
         this.refreshScrollBounds();

--- a/src/main/java/betterquesting/api2/client/gui/panels/lists/CanvasScrolling.java
+++ b/src/main/java/betterquesting/api2/client/gui/panels/lists/CanvasScrolling.java
@@ -217,13 +217,28 @@ public class CanvasScrolling implements IGuiCanvas
 		
 		if(lsz != zs)
         {
-//        	if(lsz < zs)
-//        	{
-//
-//			} else
-			{
+        	boolean zoomIn = lsz < zs;
+        	if((zoomIn && !BQ_Settings.zoomInToCursor) || (!zoomIn && !BQ_Settings.zoomOutToCursor))
+        	{
 				float change = zs / lsz; // This could probably crash if someone allowed the zoom driver to go to zero. Not really my fault to be fair
 
+				int csx = getScrollX();
+				int csy = getScrollY();
+				float swcx = scrollWindow.w/2F;
+				float swcy = scrollWindow.h/2F;
+				swcx -= swcx / change;
+				swcy -= swcy / change;
+
+				this.refreshScrollBounds(); // NOTE: This runs updatePanelPcroll() too. Hence why the math above is done first before the scroll bounds are changed
+
+				if(scrollBounds.getWidth() > 0)
+					scrollX.writeValue(((csx + swcx) - scrollBounds.getX()) / (float)scrollBounds.getWidth());
+
+				if(scrollBounds.getHeight() > 0)
+					scrollY.writeValue(((csy + swcy) - scrollBounds.getY()) / (float)scrollBounds.getHeight());
+
+			} else
+			{
 				int csx = getScrollX();
 				int csy = getScrollY();
 
@@ -240,6 +255,7 @@ public class CanvasScrolling implements IGuiCanvas
 
 				if(scrollBounds.getWidth() > 0)
 					scrollX.writeValue(((csx + swcx*dw) - scrollBounds.getX()) / (float)scrollBounds.getWidth());
+
 				if(scrollBounds.getHeight() > 0)
 					scrollY.writeValue(((csy + swcy*dh) - scrollBounds.getY()) / (float)scrollBounds.getHeight());
 
@@ -247,9 +263,6 @@ public class CanvasScrolling implements IGuiCanvas
 
             lsx = getScrollX();
             lsy = getScrollY();
-
-			System.out.format("lsx: %d, lsy: %d\r\n\r\n", lsx, lsy);
-
             lsz = zs;
 
         } else if(lsx != getScrollX() || lsy != getScrollY()) // We can skip this if the above case ran

--- a/src/main/java/betterquesting/api2/client/gui/panels/lists/CanvasScrolling.java
+++ b/src/main/java/betterquesting/api2/client/gui/panels/lists/CanvasScrolling.java
@@ -230,10 +230,13 @@ public class CanvasScrolling implements IGuiCanvas
 				float swcx = (mx - tx) / (float)transform.getWidth();
 				float swcy = (my - ty) / (float)transform.getHeight();
 
-				float dw = scrollWindow.getWidth() * change - scrollWindow.getWidth();
-				float dh = scrollWindow.getHeight() * change - scrollWindow.getHeight();
+				float dw = scrollWindow.getWidth();
+				float dh = scrollWindow.getHeight() ;
 
 				this.refreshScrollBounds(); // NOTE: This runs updatePanelScroll() too. Hence why the math above is done first before the scroll bounds are changed
+
+				dw -= scrollWindow.getWidth();
+				dh -= scrollWindow.getHeight();
 
 				if(scrollBounds.getWidth() > 0)
 					scrollX.writeValue(((csx + swcx*dw) - scrollBounds.getX()) / (float)scrollBounds.getWidth());

--- a/src/main/java/betterquesting/handlers/ConfigHandler.java
+++ b/src/main/java/betterquesting/handlers/ConfigHandler.java
@@ -30,6 +30,9 @@ public class ConfigHandler
 		BQ_Settings.zoomSpeed = config.getFloat("Zoom Speed", Configuration.CATEGORY_GENERAL, 1.25F, 1.05F, 3F, "Zoom Speed");
 
 		BQ_Settings.zoomTimeInMs = config.getFloat("Zoom smoothness in ms", Configuration.CATEGORY_GENERAL, 100F, 0F, 2000F, "Zoom smoothness in ms");
+
+		BQ_Settings.zoomInToCursor = config.getBoolean("Zoom in on cursor", Configuration.CATEGORY_GENERAL, true, "Zoom in on cursor. If false, zooms in on center of screen.");
+		BQ_Settings.zoomOutToCursor = config.getBoolean("Zoom out on cursor", Configuration.CATEGORY_GENERAL, true, "Zoom out on cursor. If false, zooms out on center of screen.");
 		config.save();
 	}
 }

--- a/src/main/java/betterquesting/handlers/ConfigHandler.java
+++ b/src/main/java/betterquesting/handlers/ConfigHandler.java
@@ -26,6 +26,10 @@ public class ConfigHandler
 		BQ_Settings.guiHeight = config.getInt("Max GUI Height", Configuration.CATEGORY_GENERAL, -1, -1, Integer.MAX_VALUE, "Clamps the max UI height (-1 to disable)");
 		
 		BQ_Settings.scrollMultiplier = config.getFloat("Scroll multiplier", Configuration.CATEGORY_GENERAL, 1F, 0F, 10F, "Scrolling multiplier");
+
+		BQ_Settings.zoomSpeed = config.getFloat("Zoom Speed", Configuration.CATEGORY_GENERAL, 1.25F, 1.05F, 3F, "Zoom Speed");
+
+		BQ_Settings.zoomTimeInMs = config.getFloat("Zoom smoothness in ms", Configuration.CATEGORY_GENERAL, 100F, 0F, 2000F, "Zoom smoothness in ms");
 		config.save();
 	}
 }


### PR DESCRIPTION
This changes the zoom logic in the main quest tree view to be multiplicative and more configurable. It also gives the option (enabled by default) to scroll to/from cursor, making it easier to zoom in on a particular quest/area.