### PR TITLE
Repeatable quests improvements

### DIFF
--- a/src/main/java/betterquesting/api/enums/EnumQuestState.java
+++ b/src/main/java/betterquesting/api/enums/EnumQuestState.java
@@ -5,5 +5,6 @@ public enum EnumQuestState
 	LOCKED,
 	UNLOCKED,
 	UNCLAIMED,
-	COMPLETED;
+	COMPLETED,
+	REPEATABLE
 }

--- a/src/main/java/betterquesting/api/questing/IQuest.java
+++ b/src/main/java/betterquesting/api/questing/IQuest.java
@@ -7,6 +7,7 @@ import betterquesting.api.questing.tasks.ITask;
 import betterquesting.api2.storage.IDatabaseNBT;
 import betterquesting.api2.storage.INBTProgress;
 import betterquesting.api2.storage.INBTSaveLoad;
+import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
@@ -17,7 +18,7 @@ import java.util.UUID;
 
 public interface IQuest extends INBTSaveLoad<NBTTagCompound>, INBTProgress<NBTTagCompound>, IPropertyContainer
 {
-	EnumQuestState getState(UUID uuid);
+	EnumQuestState getState(EntityPlayer player);
 	
 	@Nullable
 	NBTTagCompound getCompletionInfo(UUID uuid);

--- a/src/main/java/betterquesting/api2/cache/QuestCache.java
+++ b/src/main/java/betterquesting/api2/cache/QuestCache.java
@@ -116,7 +116,8 @@ public class QuestCache implements IExtendedEntityProperties
         List<Integer> tmpActive = new ArrayList<>();
         List<QResetTime> tmpReset = new ArrayList<>();
         List<Integer> tmpAutoClaim = new ArrayList<>();
-        
+
+        long currentTime = System.currentTimeMillis();
         for(DBEntry<IQuest> entry : questDB)
         {
             if(entry.getValue().isUnlocked(uuid) || entry.getValue().getProperty(NativeProps.LOCKED_PROGRESS)) // Unlocked or actively processing progression data
@@ -132,7 +133,8 @@ public class QuestCache implements IExtendedEntityProperties
                     if(repeat >= 0 && entry.getValue().hasClaimed(uuid))
                     {
                         long altTime = ue.getLong("timestamp");
-                        if(repeat > 1 && !entry.getValue().getProperty(NativeProps.REPEAT_REL)) altTime -= (altTime % repeat);
+                        if (altTime > currentTime) altTime = currentTime;
+                        if (repeat > 1 && !entry.getValue().getProperty(NativeProps.REPEAT_REL)) altTime -= (altTime % repeat);
                         tmpReset.add(new QResetTime(entry.getID(), altTime + (repeat * 50)));
                     }
                     

--- a/src/main/java/betterquesting/api2/client/gui/controls/PanelButtonQuest.java
+++ b/src/main/java/betterquesting/api2/client/gui/controls/PanelButtonQuest.java
@@ -41,7 +41,7 @@ public class PanelButtonQuest extends PanelButtonStorage<DBEntry<IQuest>>
         this.rect = rect;
         
         player = Minecraft.getMinecraft().thePlayer;
-        EnumQuestState qState = value == null ? EnumQuestState.LOCKED : value.getValue().getState(QuestingAPI.getQuestingUUID(player));
+        EnumQuestState qState = value == null ? EnumQuestState.LOCKED : value.getValue().getState(player);
         IGuiTexture txFrame = null;
         IGuiColor txIconCol = null;
         boolean main = value == null ? false : value.getValue().getProperty(NativeProps.MAIN);
@@ -66,6 +66,10 @@ public class PanelButtonQuest extends PanelButtonStorage<DBEntry<IQuest>>
                 txFrame = main ? PresetTexture.QUEST_MAIN_3.getTexture() : PresetTexture.QUEST_NORM_3.getTexture();
                 txIconCol = PresetColor.QUEST_ICON_COMPLETE.getColor();
                 break;
+			case REPEATABLE:
+				txFrame = main ? PresetTexture.QUEST_MAIN_4.getTexture() : PresetTexture.QUEST_NORM_4.getTexture();
+				txIconCol = PresetColor.QUEST_ICON_REPEATABLE.getColor();
+				break;
         }
         
         IGuiTexture btnTx = new GuiTextureColored(txFrame, txIconCol);
@@ -108,15 +112,23 @@ public class PanelButtonQuest extends PanelButtonStorage<DBEntry<IQuest>>
 		if(quest.isComplete(playerID))
 		{
 			list.add(ChatFormatting.GREEN + QuestTranslation.translate("betterquesting.tooltip.complete"));
-			
-			if(!quest.hasClaimed(playerID))
+
+			boolean hasClaimed = quest.hasClaimed(playerID);
+			boolean canClaim = quest.canClaim(player);
+			if(!hasClaimed && canClaim)
 			{
 				list.add(ChatFormatting.GRAY + QuestTranslation.translate("betterquesting.tooltip.rewards_pending"));
+			} else if(!hasClaimed){
+				list.add(ChatFormatting.GRAY + QuestTranslation.translate("betterquesting.tooltip.repeatable"));
 			} else if(quest.getProperty(NativeProps.REPEAT_TIME) > 0)
 			{
 				long time = getRepeatSeconds(quest, player);
 				DecimalFormat df = new DecimalFormat("00");
 				String timeTxt = "";
+				if (time < 0){
+					timeTxt += "-";
+					time = time * -1;
+				}
 				
 				if(time >= 3600)
 				{

--- a/src/main/java/betterquesting/api2/client/gui/controls/PanelButtonQuest.java
+++ b/src/main/java/betterquesting/api2/client/gui/controls/PanelButtonQuest.java
@@ -129,6 +129,9 @@ public class PanelButtonQuest extends PanelButtonStorage<DBEntry<IQuest>>
 				timeTxt += df.format(time%60) + "s";
 				
 				list.add(ChatFormatting.GRAY + QuestTranslation.translate("betterquesting.tooltip.repeat", timeTxt));
+				if(QuestSettings.INSTANCE.getProperty(NativeProps.EDIT_MODE)){
+					list.add(ChatFormatting.RED + QuestTranslation.translate("betterquesting.tooltip.repeat_with_edit_mode"));
+				}
 			}
 		} else if(!quest.isUnlocked(playerID))
 		{

--- a/src/main/java/betterquesting/api2/client/gui/panels/lists/CanvasQuestLine.java
+++ b/src/main/java/betterquesting/api2/client/gui/panels/lists/CanvasQuestLine.java
@@ -126,7 +126,7 @@ public class CanvasQuestLine extends CanvasScrolling
             if(reqList.size() <= 0) continue;
             
             boolean main = quest.getValue().getProperty(NativeProps.MAIN);
-            EnumQuestState qState = quest.getValue().getState(pid);
+            EnumQuestState qState = quest.getValue().getState(player);
             IGuiLine lineRender = null;
             IGuiColor txLineCol = null;
             

--- a/src/main/java/betterquesting/api2/client/gui/themes/presets/PresetColor.java
+++ b/src/main/java/betterquesting/api2/client/gui/themes/presets/PresetColor.java
@@ -39,8 +39,9 @@ public enum PresetColor
 	QUEST_ICON_LOCKED("quest_icon_locked"),
 	QUEST_ICON_UNLOCKED("quest_icon_unlocked"),
 	QUEST_ICON_PENDING("quest_icon_pending"),
-	QUEST_ICON_COMPLETE("quest_icon_complete");
-	
+	QUEST_ICON_COMPLETE("quest_icon_complete"),
+	QUEST_ICON_REPEATABLE("quest_icon_repeatable");
+
 	private final ResourceLocation key;
 	
 	PresetColor(String key)
@@ -89,6 +90,7 @@ public enum PresetColor
 		reg.setDefaultColor(QUEST_ICON_UNLOCKED.key, new GuiColorPulse(quickMix(192, 0, 0, 255), quickMix(96, 0, 0, 255), 1F, 0F));
 		reg.setDefaultColor(QUEST_ICON_PENDING.key, new GuiColorPulse(quickMix(0, 255, 255, 255), quickMix(0, 128, 128, 255), 1F, 0F));
 		reg.setDefaultColor(QUEST_ICON_COMPLETE.key, new GuiColorStatic(0, 255, 0, 255));
+		reg.setDefaultColor(QUEST_ICON_REPEATABLE.key, new GuiColorPulse(quickMix(255, 69, 0, 255), quickMix(255, 96, 0, 255), 1F, 0F));
 	}
 	
 	/**

--- a/src/main/java/betterquesting/api2/client/gui/themes/presets/PresetTexture.java
+++ b/src/main/java/betterquesting/api2/client/gui/themes/presets/PresetTexture.java
@@ -56,19 +56,22 @@ public enum PresetTexture
 	QUEST_NORM_1("quest_norm_1"),
 	QUEST_NORM_2("quest_norm_2"),
 	QUEST_NORM_3("quest_norm_3"),
-	
+	QUEST_NORM_4("quest_norm_4"),
+
 	// Main quest frame
 	QUEST_MAIN_0("quest_main_0"),
 	QUEST_MAIN_1("quest_main_1"),
 	QUEST_MAIN_2("quest_main_2"),
 	QUEST_MAIN_3("quest_main_3"),
-	
+	QUEST_MAIN_4("quest_main_4"),
+
 	// Auxiliary quest frame (not normally used)
 	QUEST_AUX_0("quest_aux_0"),
 	QUEST_AUX_1("quest_aux_1"),
 	QUEST_AUX_2("quest_aux_2"),
 	QUEST_AUX_3("quest_aux_3"),
-	
+	QUEST_AUX_4("quest_aux_4"),
+
 	TEXT_BOX_0("text_box_0"),
 	TEXT_BOX_1("text_box_1"),
 	TEXT_BOX_2("text_box_2");
@@ -139,17 +142,20 @@ public enum PresetTexture
 		reg.setDefaultTexture(QUEST_NORM_1.key, new SlicedTexture(TX_QUEST, new GuiRectangle(0, 24, 24, 24), new GuiPadding(8, 8, 8, 8)).setSliceMode(SliceMode.SLICED_STRETCH));
 		reg.setDefaultTexture(QUEST_NORM_2.key, new SlicedTexture(TX_QUEST, new GuiRectangle(0, 48, 24, 24), new GuiPadding(8, 8, 8, 8)).setSliceMode(SliceMode.SLICED_STRETCH));
 		reg.setDefaultTexture(QUEST_NORM_3.key, new SlicedTexture(TX_QUEST, new GuiRectangle(0, 72, 24, 24), new GuiPadding(8, 8, 8, 8)).setSliceMode(SliceMode.SLICED_STRETCH));
-		
+		reg.setDefaultTexture(QUEST_NORM_4.key, new SlicedTexture(TX_QUEST, new GuiRectangle(0, 72, 24, 24), new GuiPadding(8, 8, 8, 8)).setSliceMode(SliceMode.SLICED_STRETCH));
+
 		reg.setDefaultTexture(QUEST_MAIN_0.key, new SlicedTexture(TX_QUEST, new GuiRectangle(24, 0, 24, 24), new GuiPadding(8, 8, 8, 8)).setSliceMode(SliceMode.STRETCH));
 		reg.setDefaultTexture(QUEST_MAIN_1.key, new SlicedTexture(TX_QUEST, new GuiRectangle(24, 24, 24, 24), new GuiPadding(8, 8, 8, 8)).setSliceMode(SliceMode.STRETCH));
 		reg.setDefaultTexture(QUEST_MAIN_2.key, new SlicedTexture(TX_QUEST, new GuiRectangle(24, 48, 24, 24), new GuiPadding(8, 8, 8, 8)).setSliceMode(SliceMode.STRETCH));
 		reg.setDefaultTexture(QUEST_MAIN_3.key, new SlicedTexture(TX_QUEST, new GuiRectangle(24, 72, 24, 24), new GuiPadding(8, 8, 8, 8)).setSliceMode(SliceMode.STRETCH));
-		
+		reg.setDefaultTexture(QUEST_MAIN_4.key, new SlicedTexture(TX_QUEST, new GuiRectangle(24, 72, 24, 24), new GuiPadding(8, 8, 8, 8)).setSliceMode(SliceMode.STRETCH));
+
 		reg.setDefaultTexture(QUEST_AUX_0.key, new SlicedTexture(TX_QUEST, new GuiRectangle(48, 0, 24, 24), new GuiPadding(8, 8, 8, 8)).setSliceMode(SliceMode.SLICED_STRETCH));
 		reg.setDefaultTexture(QUEST_AUX_1.key, new SlicedTexture(TX_QUEST, new GuiRectangle(48, 24, 24, 24), new GuiPadding(8, 8, 8, 8)).setSliceMode(SliceMode.SLICED_STRETCH));
 		reg.setDefaultTexture(QUEST_AUX_2.key, new SlicedTexture(TX_QUEST, new GuiRectangle(48, 48, 24, 24), new GuiPadding(8, 8, 8, 8)).setSliceMode(SliceMode.SLICED_STRETCH));
 		reg.setDefaultTexture(QUEST_AUX_3.key, new SlicedTexture(TX_QUEST, new GuiRectangle(48, 72, 24, 24), new GuiPadding(8, 8, 8, 8)).setSliceMode(SliceMode.SLICED_STRETCH));
-		
+		reg.setDefaultTexture(QUEST_AUX_4.key, new SlicedTexture(TX_QUEST, new GuiRectangle(48, 72, 24, 24), new GuiPadding(8, 8, 8, 8)).setSliceMode(SliceMode.SLICED_STRETCH));
+
 		reg.setDefaultTexture(TEXT_BOX_0.key, new SlicedTexture(TX_SIMPLE, new GuiRectangle(0, 28, 8, 8), new GuiPadding(1, 1, 1, 1)).setSliceMode(SliceMode.SLICED_STRETCH));
 		reg.setDefaultTexture(TEXT_BOX_1.key, new SlicedTexture(TX_SIMPLE, new GuiRectangle(8, 28, 8, 8), new GuiPadding(1, 1, 1, 1)).setSliceMode(SliceMode.SLICED_STRETCH));
 		reg.setDefaultTexture(TEXT_BOX_2.key, new SlicedTexture(TX_SIMPLE, new GuiRectangle(16, 28, 8, 8), new GuiPadding(1, 1, 1, 1)).setSliceMode(SliceMode.SLICED_STRETCH));

--- a/src/main/java/betterquesting/client/gui2/GuiThemes.java
+++ b/src/main/java/betterquesting/client/gui2/GuiThemes.java
@@ -120,14 +120,17 @@ public class GuiThemes extends GuiScreenCanvas
 				new GuiTextureColored(PresetTexture.QUEST_NORM_1.getTexture(), PresetColor.QUEST_ICON_UNLOCKED.getColor()),
 				new GuiTextureColored(PresetTexture.QUEST_NORM_2.getTexture(), PresetColor.QUEST_ICON_PENDING.getColor()),
 				new GuiTextureColored(PresetTexture.QUEST_NORM_3.getTexture(), PresetColor.QUEST_ICON_COMPLETE.getColor()),
+				new GuiTextureColored(PresetTexture.QUEST_NORM_4.getTexture(), PresetColor.QUEST_ICON_REPEATABLE.getColor()),
 				new GuiTextureColored(PresetTexture.QUEST_MAIN_0.getTexture(), PresetColor.QUEST_ICON_LOCKED.getColor()),
 				new GuiTextureColored(PresetTexture.QUEST_MAIN_1.getTexture(), PresetColor.QUEST_ICON_UNLOCKED.getColor()),
 				new GuiTextureColored(PresetTexture.QUEST_MAIN_2.getTexture(), PresetColor.QUEST_ICON_PENDING.getColor()),
 				new GuiTextureColored(PresetTexture.QUEST_MAIN_3.getTexture(), PresetColor.QUEST_ICON_COMPLETE.getColor()),
+				new GuiTextureColored(PresetTexture.QUEST_MAIN_4.getTexture(), PresetColor.QUEST_ICON_REPEATABLE.getColor()),
 				new GuiTextureColored(PresetTexture.QUEST_AUX_0.getTexture(), PresetColor.QUEST_ICON_LOCKED.getColor()),
 				new GuiTextureColored(PresetTexture.QUEST_AUX_1.getTexture(), PresetColor.QUEST_ICON_UNLOCKED.getColor()),
 				new GuiTextureColored(PresetTexture.QUEST_AUX_2.getTexture(), PresetColor.QUEST_ICON_PENDING.getColor()),
 				new GuiTextureColored(PresetTexture.QUEST_AUX_3.getTexture(), PresetColor.QUEST_ICON_COMPLETE.getColor()));
+				new GuiTextureColored(PresetTexture.QUEST_AUX_4.getTexture(), PresetColor.QUEST_ICON_REPEATABLE.getColor());
 		PanelGeneric pqp = new PanelGeneric(new GuiTransform(new Vector4f(0.25F, 0.5F, 0.25F, 0.5F), -12, -12, 24, 24, 0), icoSlides);
 		preCanIn2.addPanel(pqp);
 		

--- a/src/main/java/betterquesting/client/themes/ThemeLegacy.java
+++ b/src/main/java/betterquesting/client/themes/ThemeLegacy.java
@@ -126,6 +126,7 @@ public class ThemeLegacy implements IGuiTheme
 	    COLOR_MAP.put(PresetColor.QUEST_ICON_UNLOCKED.getKey(), new GuiColorPulse(incomplete, darkenColor(locked), 1F, 0F));
 	    COLOR_MAP.put(PresetColor.QUEST_ICON_PENDING.getKey(), new GuiColorPulse(pending, darkenColor(locked), 1F, 0F));
 	    COLOR_MAP.put(PresetColor.QUEST_ICON_COMPLETE.getKey(), new GuiColorPulse(complete, darkenColor(locked), 1F, 0F));
+	    COLOR_MAP.put(PresetColor.QUEST_ICON_REPEATABLE.getKey(), new GuiColorPulse(complete, darkenColor(locked), 1F, 0F));
 		return this;
 	}
 	

--- a/src/main/java/betterquesting/questing/QuestInstance.java
+++ b/src/main/java/betterquesting/questing/QuestInstance.java
@@ -40,31 +40,31 @@ public class QuestInstance implements IQuest
 {
 	private final TaskStorage tasks = new TaskStorage();
 	private final RewardStorage rewards = new RewardStorage();
-	
+
 	private final HashMap<UUID, NBTTagCompound> completeUsers = new HashMap<>();
     private int[] preRequisites = new int[0];
-	
+
 	private final PropertyContainer qInfo = new PropertyContainer();
-	
+
 	public QuestInstance()
 	{
 		this.setupProps();
 	}
-	
+
 	private void setupProps()
 	{
 		setupValue(NativeProps.NAME, "New Quest");
 		setupValue(NativeProps.DESC, "No Description");
-		
+
 		setupValue(NativeProps.ICON, new BigItemStack(Items.nether_star));
-		
+
 		setupValue(NativeProps.SOUND_COMPLETE);
 		setupValue(NativeProps.SOUND_UPDATE);
 		//setupValue(NativeProps.SOUND_UNLOCK);
-		
+
 		setupValue(NativeProps.LOGIC_QUEST, EnumLogic.AND);
 		setupValue(NativeProps.LOGIC_TASK, EnumLogic.AND);
-		
+
 		setupValue(NativeProps.REPEAT_TIME, -1);
 		setupValue(NativeProps.REPEAT_REL, true);
 		setupValue(NativeProps.LOCKED_PROGRESS, false);
@@ -75,24 +75,24 @@ public class QuestInstance implements IQuest
 		setupValue(NativeProps.SIMULTANEOUS, false);
 		setupValue(NativeProps.VISIBILITY, EnumQuestVisibility.NORMAL);
 	}
-	
+
 	private <T> void setupValue(IPropertyType<T> prop)
 	{
 		this.setupValue(prop, prop.getDefault());
 	}
-	
+
 	private <T> void setupValue(IPropertyType<T> prop, T def)
 	{
 		qInfo.setProperty(prop, qInfo.getProperty(prop, def));
 	}
-	
+
 	@Override
 	public void update(EntityPlayer player)
 	{
 		UUID playerID = QuestingAPI.getQuestingUUID(player);
-		
+
         int done = 0;
-        
+
         for(DBEntry<ITask> entry : tasks.getEntries())
         {
             if(entry.getValue().isComplete(playerID))
@@ -100,7 +100,7 @@ public class QuestInstance implements IQuest
                 done++;
             }
         }
-        
+
         if(tasks.size() <= 0 || qInfo.getProperty(NativeProps.LOGIC_TASK).getResult(done, tasks.size()))
         {
             setComplete(playerID, System.currentTimeMillis());
@@ -109,7 +109,7 @@ public class QuestInstance implements IQuest
             resetUser(playerID, false);
         }
 	}
-	
+
 	/**
 	 * Fired when someone clicks the detect button for this quest
 	 */
@@ -120,7 +120,7 @@ public class QuestInstance implements IQuest
         QuestCache qc = (QuestCache)player.getExtendedProperties(QuestCache.LOC_QUEST_CACHE.toString());
         if(qc == null) return;
         int questID = QuestDatabase.INSTANCE.getID(this);
-		
+
 		if(isComplete(playerID) && (qInfo.getProperty(NativeProps.REPEAT_TIME) < 0 || rewards.size() <= 0))
 		{
 			return;
@@ -128,21 +128,21 @@ public class QuestInstance implements IQuest
 		{
 			return;
 		}
-		
+
 		if(isUnlocked(playerID) || QuestSettings.INSTANCE.getProperty(NativeProps.EDIT_MODE))
 		{
 			int done = 0;
 			boolean update = false;
-            
+
             ParticipantInfo partInfo = new ParticipantInfo(player);
             DBEntry<IQuest> dbe = new DBEntry<>(questID, this);
-			
+
 			for(DBEntry<ITask> entry : tasks.getEntries())
 			{
 				if(!entry.getValue().isComplete(playerID))
 				{
 					entry.getValue().detect(partInfo, dbe);
-					
+
 					if(entry.getValue().isComplete(playerID))
 					{
 						done++;
@@ -169,12 +169,12 @@ public class QuestInstance implements IQuest
 			}
 		}
 	}
-	
+
 	@Override
 	public boolean hasClaimed(UUID uuid)
 	{
 		if(rewards.size() <= 0) return true;
-  
+
 		synchronized(completeUsers)
         {
             if(qInfo.getProperty(NativeProps.GLOBAL) && !qInfo.getProperty(NativeProps.GLOBAL_SHARE))
@@ -186,21 +186,21 @@ public class QuestInstance implements IQuest
                         return true;
                     }
                 }
-        
+
                 return false;
             }
-    
+
             NBTTagCompound entry = getCompletionInfo(uuid);
             return entry != null && entry.getBoolean("claimed");
         }
 	}
-	
+
 	@Override
 	public boolean canClaim(EntityPlayer player)
 	{
 	    UUID pID = QuestingAPI.getQuestingUUID(player);
 		NBTTagCompound entry = getCompletionInfo(pID);
-		
+
 		if(entry == null || hasClaimed(pID) || canSubmit(player))
 		{
 			return false;
@@ -215,10 +215,10 @@ public class QuestInstance implements IQuest
 				}
 			}
 		}
-		
+
 		return true;
 	}
-	
+
 	@Override
 	public void claimReward(EntityPlayer player)
 	{
@@ -228,10 +228,10 @@ public class QuestInstance implements IQuest
 		{
 			rew.getValue().claimReward(player, dbe);
 		}
-		
+
 		UUID pID = QuestingAPI.getQuestingUUID(player);
         QuestCache qc = (QuestCache)player.getExtendedProperties(QuestCache.LOC_QUEST_CACHE.toString());
-		
+
         synchronized(completeUsers)
         {
             NBTTagCompound entry = getCompletionInfo(pID);
@@ -245,28 +245,28 @@ public class QuestInstance implements IQuest
             entry.setBoolean("claimed", true);
             entry.setLong("timestamp", System.currentTimeMillis());
         }
-		
+
 		if(qc != null) qc.markQuestDirty(QuestDatabase.INSTANCE.getID(this));
 	}
-	
+
 	@Override
 	public boolean canSubmit(EntityPlayer player)
 	{
 		if(player == null) return false;
-		
+
 		UUID playerID = QuestingAPI.getQuestingUUID(player);
-		
+
 		synchronized(completeUsers)
         {
             NBTTagCompound entry = this.getCompletionInfo(playerID);
             if(entry == null) return true;
-            
+
             if(!entry.getBoolean("claimed") && getProperty(NativeProps.REPEAT_TIME) >= 0) // Complete but repeatable
             {
                 if(tasks.size() <= 0) return true;
-        
+
                 int done = 0;
-        
+
                 for(DBEntry<ITask> tsk : tasks.getEntries())
                 {
                     if(tsk.getValue().isComplete(playerID))
@@ -274,7 +274,7 @@ public class QuestInstance implements IQuest
                         done += 1;
                     }
                 }
-        
+
                 return !qInfo.getProperty(NativeProps.LOGIC_TASK).getResult(done, tasks.size());
             } else
             {
@@ -282,15 +282,15 @@ public class QuestInstance implements IQuest
             }
         }
 	}
-	
+
 	@Override
 	public boolean isUnlocked(UUID uuid)
 	{
 		if(preRequisites.length <= 0) return true;
-		
+
 		int A = 0;
 		int B = preRequisites.length;
-		
+
 		for(DBEntry<IQuest> quest : QuestDatabase.INSTANCE.bulkLookup(getRequirements()))
 		{
 			if(quest.getValue().isComplete(uuid))
@@ -298,30 +298,30 @@ public class QuestInstance implements IQuest
 				A++;
 			}
 		}
-		
+
 		return qInfo.getProperty(NativeProps.LOGIC_QUEST).getResult(A, B);
 	}
-	
+
 	@Override
 	public void setComplete(UUID uuid, long timestamp)
     {
         if(uuid == null) return;
-        
+
         synchronized(completeUsers)
         {
             NBTTagCompound entry = this.getCompletionInfo(uuid);
-    
+
             if(entry == null)
             {
                 entry = new NBTTagCompound();
                 completeUsers.put(uuid, entry);
             }
-    
+
             entry.setBoolean("claimed", false);
             entry.setLong("timestamp", timestamp);
         }
     }
-    
+
 	/**
 	 * Returns true if the quest has been completed at least once
 	 */
@@ -336,27 +336,26 @@ public class QuestInstance implements IQuest
 			return getCompletionInfo(uuid) != null;
 		}
 	}
-	
+
 	@Override
-	public EnumQuestState getState(UUID uuid)
+	public EnumQuestState getState(EntityPlayer player)
 	{
-		if(this.isComplete(uuid))
-		{
-			if(this.hasClaimed(uuid))
-			{
-				return EnumQuestState.COMPLETED;
-			} else
-			{
-				return EnumQuestState.UNCLAIMED;
-			}
-		} else if(this.isUnlocked(uuid))
-		{
-			return EnumQuestState.UNLOCKED;
-		}
-		
-		return EnumQuestState.LOCKED;
+        UUID uuid = QuestingAPI.getQuestingUUID(player);
+        if (this.isComplete(uuid)) {
+            if (this.hasClaimed(uuid)) {
+                return EnumQuestState.COMPLETED;
+            } else if (this.canClaim(player)) {
+                return EnumQuestState.UNCLAIMED;
+            } else {
+				return EnumQuestState.REPEATABLE;
+            }
+        } else if (this.isUnlocked(uuid)) {
+            return EnumQuestState.UNLOCKED;
+        }
+
+        return EnumQuestState.LOCKED;
 	}
-	
+
 	@Override
 	public NBTTagCompound getCompletionInfo(UUID uuid)
 	{
@@ -365,12 +364,12 @@ public class QuestInstance implements IQuest
             return completeUsers.get(uuid);
         }
 	}
-	
+
 	@Override
     public void setCompletionInfo(UUID uuid, NBTTagCompound nbt)
     {
         if(uuid == null) return;
-        
+
         synchronized(completeUsers)
         {
             if(nbt == null)
@@ -382,7 +381,7 @@ public class QuestInstance implements IQuest
             }
         }
     }
-	
+
 	/**
 	 * Resets task progress and claim status. If performing a full reset, completion status will also be erased
 	 */
@@ -418,35 +417,35 @@ public class QuestInstance implements IQuest
                     }
                 }
             }
-    
+
             tasks.getEntries().forEach((value) -> value.getValue().resetUser(uuid));
         }
 	}
-	
+
 	@Override
 	public IDatabaseNBT<ITask, NBTTagList, NBTTagList> getTasks()
 	{
 		return tasks;
 	}
-	
+
 	@Override
 	public IDatabaseNBT<IReward, NBTTagList, NBTTagList> getRewards()
 	{
 		return rewards;
 	}
-	
+
 	@Nonnull
 	@Override
     public int[] getRequirements()
     {
         return this.preRequisites;
     }
-    
+
     public void setRequirements(@Nonnull int[] req)
     {
         this.preRequisites = req;
     }
-	
+
 	@Override
 	public NBTTagCompound writeToNBT(NBTTagCompound jObj)
 	{
@@ -454,17 +453,17 @@ public class QuestInstance implements IQuest
 		jObj.setTag("tasks", tasks.writeToNBT(new NBTTagList(), null));
 		jObj.setTag("rewards", rewards.writeToNBT(new NBTTagList(), null));
 		jObj.setTag("preRequisites", new NBTTagIntArray(getRequirements()));
-		
+
 		return jObj;
 	}
-	
+
 	@Override
 	public void readFromNBT(NBTTagCompound jObj)
 	{
 		this.qInfo.readFromNBT(jObj.getCompoundTag("properties"));
 		this.tasks.readFromNBT(jObj.getTagList("tasks", 10), false);
 		this.rewards.readFromNBT(jObj.getTagList("rewards", 10), false);
-		
+
 		if(jObj.func_150299_b("preRequisites") == 11) // Native NBT
 		{
 		    setRequirements(jObj.getIntArray("preRequisites"));
@@ -479,10 +478,10 @@ public class QuestInstance implements IQuest
 			}
 			setRequirements(req);
 		}
-		
+
 		this.setupProps();
 	}
-	
+
 	@Override
 	public NBTTagCompound writeProgressToNBT(NBTTagCompound json, @Nullable List<UUID> users)
 	{
@@ -497,14 +496,14 @@ public class QuestInstance implements IQuest
                 comJson.appendTag(tags);
             }
             json.setTag("completed", comJson);
-    
+
             NBTTagList tskJson = tasks.writeProgressToNBT(new NBTTagList(), users);
             json.setTag("tasks", tskJson);
-    
+
             return json;
         }
 	}
-	
+
 	@Override
 	public void readProgressFromNBT(NBTTagCompound json, boolean merge)
 	{
@@ -515,7 +514,7 @@ public class QuestInstance implements IQuest
             for(int i = 0; i < comList.tagCount(); i++)
             {
                 NBTTagCompound entry = (NBTTagCompound)comList.getCompoundTagAt(i).copy();
-                
+
                 try
                 {
                     UUID uuid = UUID.fromString(entry.getString("uuid"));
@@ -525,18 +524,18 @@ public class QuestInstance implements IQuest
                     BetterQuesting.logger.log(Level.ERROR, "Unable to load UUID for quest", e);
                 }
             }
-    
+
             tasks.readProgressFromNBT(json.getTagList("tasks", 10), merge);
         }
 	}
-	
+
     @Override
 	public void setClaimed(UUID uuid, long timestamp)
 	{
 		synchronized(completeUsers)
         {
             NBTTagCompound entry = this.getCompletionInfo(uuid);
-    
+
             if(entry != null)
             {
                 entry.setBoolean("claimed", true);
@@ -550,37 +549,37 @@ public class QuestInstance implements IQuest
             }
         }
 	}
-    
+
     @Override
     public <T> T getProperty(IPropertyType<T> prop)
     {
         return qInfo.getProperty(prop);
     }
-    
+
     @Override
     public <T> T getProperty(IPropertyType<T> prop, T def)
     {
         return qInfo.getProperty(prop, def);
     }
-    
+
     @Override
     public boolean hasProperty(IPropertyType<?> prop)
     {
         return qInfo.hasProperty(prop);
     }
-    
+
     @Override
     public <T> void setProperty(IPropertyType<T> prop, T value)
     {
         qInfo.setProperty(prop, value);
     }
-    
+
     @Override
     public void removeProperty(IPropertyType<?> prop)
     {
         qInfo.removeProperty(prop);
     }
-    
+
     @Override
     public void removeAllProps()
     {

--- a/src/main/resources/assets/betterquesting/bq_themes.json
+++ b/src/main/resources/assets/betterquesting/bq_themes.json
@@ -313,6 +313,22 @@
       {
         "colorType": "betterquesting:color_static",
         "color": "FF00FF00"
+      },
+      "betterquesting:quest_icon_repeatable":
+      {
+        "colorType": "betterquesting:color_pulse",
+        "period": 1.0,
+        "phase": 0.0,
+        "color1":
+        {
+          "colorType": "betterquesting:color_static",
+          "color": "ff4500ff"
+        },
+        "color2":
+        {
+          "colorType": "betterquesting:color_static",
+          "color": "ff6000ff"
+        }
       }
     },
     "lines":

--- a/src/main/resources/assets/betterquesting/lang/en_US.lang
+++ b/src/main/resources/assets/betterquesting/lang/en_US.lang
@@ -91,7 +91,7 @@ betterquesting.tooltip.quest_logic=Quest Logic: %s
 betterquesting.tooltip.simultaneous=Simultaneous Tasks: %s
 betterquesting.tooltip.auto_claim=Auto Claim: %s
 betterquesting.tooltip.repeat=Cooldown: %s
-betterquesting.tooltip.repeat_with_edit_mode=Edit mode enabled, repeatable quests won't resets
+betterquesting.tooltip.repeat_with_edit_mode=Edit mode enabled, repeatable quests won't reset
 betterquesting.tooltip.update_quests=Update Available!%n§7A new quest line version is available.%nClick to install and migrate progress.
 
 betterquesting.notice.complete=Quest Complete
@@ -150,7 +150,6 @@ betterquesting.toolbox.tool.copy.name=Copy
 betterquesting.toolbox.tool.copy.desc=Copies the given quest including prerequisites, tasks and rewards but not progression data
 betterquesting.toolbox.tool.new.name=New Quest
 betterquesting.toolbox.tool.new.desc=Creates a new empty quest
-betterquesting.toolbox.tool.delete.name=Delete Quest
 betterquesting.toolbox.tool.delete.desc=Deletes the given quest from the quest line and database
 betterquesting.toolbox.tool.remove.name=Remove Quest
 betterquesting.toolbox.tool.remove.desc=Removes the given quest only from the quest line. The quest will still be accessible through the database

--- a/src/main/resources/assets/betterquesting/lang/en_US.lang
+++ b/src/main/resources/assets/betterquesting/lang/en_US.lang
@@ -79,6 +79,7 @@ betterquesting.tooltip.tasks_complete=%s/%s Tasks Complete
 betterquesting.tooltip.complete=COMPLETE
 betterquesting.tooltip.incomplete=INCOMPLETE
 betterquesting.tooltip.rewards_pending=Unclaimed rewards
+betterquesting.tooltip.repeatable=Can be repeated
 betterquesting.tooltip.requires=Requires:
 betterquesting.tooltip.shift_advanced=Hold SHIFT for advanced info
 betterquesting.tooltip.reset_time=Cooldown: %s

--- a/src/main/resources/assets/betterquesting/lang/en_US.lang
+++ b/src/main/resources/assets/betterquesting/lang/en_US.lang
@@ -90,6 +90,7 @@ betterquesting.tooltip.quest_logic=Quest Logic: %s
 betterquesting.tooltip.simultaneous=Simultaneous Tasks: %s
 betterquesting.tooltip.auto_claim=Auto Claim: %s
 betterquesting.tooltip.repeat=Cooldown: %s
+betterquesting.tooltip.repeat_with_edit_mode=Edit mode enabled, repeatable quests won't resets
 betterquesting.tooltip.update_quests=Update Available!%n§7A new quest line version is available.%nClick to install and migrate progress.
 
 betterquesting.notice.complete=Quest Complete

--- a/src/main/resources/assets/betterquesting/lang/ru_RU.lang
+++ b/src/main/resources/assets/betterquesting/lang/ru_RU.lang
@@ -86,6 +86,7 @@ betterquesting.tooltip.task_logic=Логика задания: %s
 betterquesting.tooltip.simultaneous=Одновременные задания: %s
 betterquesting.tooltip.auto_claim=Авто-запрос: %s
 betterquesting.tooltip.repeat=Повторяется: %s
+betterquesting.tooltip.repeat_with_edit_mode=Включен режим редактирования, повторающиеся квесты не будут сбрасываться
 betterquesting.tooltip.update_quests=Update Available!%n§7A new quest line version is available.%nClick to install and migrate progress.
 
 betterquesting.notice.complete=Квест завершён

--- a/src/main/resources/assets/betterquesting/lang/ru_RU.lang
+++ b/src/main/resources/assets/betterquesting/lang/ru_RU.lang
@@ -76,6 +76,7 @@ betterquesting.tooltip.tasks_complete=%s/%s заданий завершено
 betterquesting.tooltip.complete=ЗАВЕРШЕНО
 betterquesting.tooltip.incomplete=ОТКРЫТО
 betterquesting.tooltip.rewards_pending=Незапрошенные награды
+betterquesting.tooltip.repeatable=Можно повторить
 betterquesting.tooltip.requires=Условия:
 betterquesting.tooltip.shift_advanced=Удерживать SHIFT для получения доп.информации
 betterquesting.tooltip.reset_time=Откат: %s

--- a/src/main/resources/assets/betterquesting/lang/zh_CN.lang
+++ b/src/main/resources/assets/betterquesting/lang/zh_CN.lang
@@ -90,6 +90,7 @@ betterquesting.tooltip.quest_logic=任务逻辑: %s
 betterquesting.tooltip.simultaneous=同步任务: %s
 betterquesting.tooltip.auto_claim=自动领取: %s
 betterquesting.tooltip.repeat=重置任务: %s
+betterquesting.tooltip.repeat_with_edit_mode=启用编辑模式，可重复的任务不会重置
 betterquesting.tooltip.update_quests=更新可用!%n§7新任务线版本可用.%n单击此处可安装并迁移进度.
 
 betterquesting.notice.complete=任务完成

--- a/src/main/resources/assets/betterquesting/lang/zh_CN.lang
+++ b/src/main/resources/assets/betterquesting/lang/zh_CN.lang
@@ -79,6 +79,7 @@ betterquesting.tooltip.tasks_complete=%s/%s 已达成
 betterquesting.tooltip.complete=已达成
 betterquesting.tooltip.incomplete=未达成
 betterquesting.tooltip.rewards_pending=未领取奖励
+betterquesting.tooltip.repeatable=可以重复
 betterquesting.tooltip.requires=前置任务:
 betterquesting.tooltip.shift_advanced=按住shift显示信息
 betterquesting.tooltip.reset_time=重置冷却: %s

--- a/src/main/resources/bq_themes.json
+++ b/src/main/resources/bq_themes.json
@@ -313,6 +313,22 @@
       {
         "colorType": "betterquesting:color_static",
         "color": "FF00FF00"
+      },
+      "betterquesting:quest_icon_repeatable":
+      {
+        "colorType": "betterquesting:color_pulse",
+        "period": 1.0,
+        "phase": 0.0,
+        "color1":
+        {
+          "colorType": "betterquesting:color_static",
+          "color": "FF7F50FF"
+        },
+        "color2":
+        {
+          "colorType": "betterquesting:color_static",
+          "color": "FF008080"
+        }
       }
     },
     "lines":


### PR DESCRIPTION
* Possible fix for non-resetting repeatable quests
* Add warning about `edit mode` enabled to repeatable quests tooltip
* Fix negative time display in tooltip
* Replaced pending rewards in tooltip when quest can be repeated
* Add new visual for quest what can be repeated INSTEAD of marking them as quests with non-claimed reward
![image](https://user-images.githubusercontent.com/29896317/102503424-c5077280-4090-11eb-848f-063b580008a3.png)