### PR TITLE
Add saving lock tray state

### DIFF
--- a/src/main/java/betterquesting/api/storage/BQ_Settings.java
+++ b/src/main/java/betterquesting/api/storage/BQ_Settings.java
@@ -28,4 +28,6 @@ public class BQ_Settings
 	public static boolean zoomOutToCursor = false;
 
 	public static boolean claimAllConfirmation = true;
+
+	public static boolean lockTray = true;
 }

--- a/src/main/java/betterquesting/client/gui2/GuiQuestLines.java
+++ b/src/main/java/betterquesting/client/gui2/GuiQuestLines.java
@@ -79,13 +79,14 @@ public class GuiQuestLines extends GuiScreenCanvas implements IPEventListener, I
     
     private PanelButton claimAll;
     
-    private static boolean trayLock = false;
+    private static boolean trayLock;
     
     private final List<PanelButtonStorage<DBEntry<IQuestLine>>> btnListRef = new ArrayList<>();
 
     public GuiQuestLines(GuiScreen parent)
     {
         super(parent);
+        trayLock = BQ_Settings.lockTray;
     }
     
     @Override
@@ -111,6 +112,8 @@ public class GuiQuestLines extends GuiScreenCanvas implements IPEventListener, I
         
         boolean canEdit = QuestingAPI.getAPI(ApiReference.SETTINGS).canUserEdit(mc.thePlayer);
         boolean preOpen = false;
+        // First time load, if tray locked - let the tray open
+        if(trayLock && cvChapterTray == null && cvDescTray == null) preOpen = true;
         if(trayLock && cvChapterTray != null && cvChapterTray.isTrayOpen()) preOpen = true;
         if(trayLock && cvDescTray != null && cvDescTray.isTrayOpen()) preOpen = true;
         
@@ -160,10 +163,16 @@ public class GuiQuestLines extends GuiScreenCanvas implements IPEventListener, I
         // These would probably be more annoying than useful if you just wanted to check a tray but not lose your position
         //cvFrame.setOpenAction(() -> cvQuest.fitToWindow());
         //cvFrame.setCloseAction(() -> cvQuest.fitToWindow());
-        
+
+        // === TRAY STATE ===
+
+        boolean chapterTrayOpened = trayLock && cvChapterTray != null && cvChapterTray.isTrayOpen();
+        boolean descTrayOpened = trayLock && cvDescTray != null && cvDescTray.isTrayOpen();
+        if (preOpen && !chapterTrayOpened && !descTrayOpened)
+            chapterTrayOpened = true;
+
         // === CHAPTER TRAY ===
-        
-        boolean oldState1 = trayLock && cvChapterTray != null && cvChapterTray.isTrayOpen();
+
         cvChapterTray = new CanvasHoverTray(new GuiTransform(GuiAlign.LEFT_EDGE, new GuiPadding(40, 24, -24, 8), -1), new GuiTransform(GuiAlign.LEFT_EDGE, new GuiPadding(40, 24, -40 - 150 - 24, 8), -1), PresetTexture.PANEL_INNER.getTexture());
         cvChapterTray.setManualOpen(true);
         cvChapterTray.setOpenAction(() -> {
@@ -172,17 +181,16 @@ public class GuiQuestLines extends GuiScreenCanvas implements IPEventListener, I
             buildChapterList();
         });
         cvBackground.addPanel(cvChapterTray);
-        
+
         cvLines = new CanvasScrolling(new GuiTransform(GuiAlign.FULL_BOX, new GuiPadding(8, 8, 16, 8), 0));
         cvChapterTray.getCanvasOpen().addPanel(cvLines);
-        
+
         scLines = new PanelVScrollBar(new GuiTransform(GuiAlign.RIGHT_EDGE, new GuiPadding(-16, 8, 8, 8), 0));
         cvLines.setScrollDriverY(scLines);
         cvChapterTray.getCanvasOpen().addPanel(scLines);
-        
+
         // === DESCRIPTION TRAY ===
-        
-        boolean oldState2 = trayLock && cvDescTray != null && cvDescTray.isTrayOpen();
+
         cvDescTray = new CanvasHoverTray(new GuiTransform(GuiAlign.LEFT_EDGE, new GuiPadding(40, 24, -24, 8), -1), new GuiTransform(GuiAlign.LEFT_EDGE, new GuiPadding(40, 24, -40 - 150 - 24, 8), -1), PresetTexture.PANEL_INNER.getTexture());
         cvDescTray.setManualOpen(true);
         cvDescTray.setOpenAction(() -> {
@@ -213,7 +221,7 @@ public class GuiQuestLines extends GuiScreenCanvas implements IPEventListener, I
         // === LEFT SIDEBAR ===
         
         PanelButton btnTrayToggle = new PanelButton(new GuiTransform(GuiAlign.TOP_LEFT, 8, 24, 32, 16, 0), -1, "");
-        btnTrayToggle.setIcon(PresetIcon.ICON_BOOKMARK.getTexture(), selectedLineId < 0 ? new GuiColorPulse(0xFFFFFFFF, 0xFF444444, 2F, 0F) : new GuiColorStatic(0xFFFFFFFF), 0);
+        btnTrayToggle.setIcon(PresetIcon.ICON_BOOKMARK.getTexture(), selectedLineId < 0 && !chapterTrayOpened ? new GuiColorPulse(0xFFFFFFFF, 0xFF444444, 2F, 0F) : new GuiColorStatic(0xFFFFFFFF), 0);
         btnTrayToggle.setClickAction((b) -> {
             cvFrame.setTrayState(cvChapterTray.isTrayOpen(), 200);
             cvChapterTray.setTrayState(!cvChapterTray.isTrayOpen(), 200);
@@ -264,6 +272,9 @@ public class GuiQuestLines extends GuiScreenCanvas implements IPEventListener, I
         btnTrayLock.setClickAction((b) -> {
             trayLock = !trayLock;
             b.setIcon(trayLock ? PresetIcon.ICON_LOCKED.getTexture() : PresetIcon.ICON_UNLOCKED.getTexture());
+            ConfigHandler.config.get(Configuration.CATEGORY_GENERAL, "Lock tray", false).set(trayLock);
+            ConfigHandler.config.save();
+            ConfigHandler.initConfigs();
         });
         btnTrayLock.setTooltip(Collections.singletonList(QuestTranslation.translate("betterquesting.btn.lock_tray")));
         cvBackground.addPanel(btnTrayLock);
@@ -293,8 +304,8 @@ public class GuiQuestLines extends GuiScreenCanvas implements IPEventListener, I
         
         // === MISC ===
         
-        cvChapterTray.setTrayState(oldState1, 1);
-        cvDescTray.setTrayState(oldState2, 1);
+        cvChapterTray.setTrayState(chapterTrayOpened, 1);
+        cvDescTray.setTrayState(descTrayOpened, 1);
         
         refreshChapterVisibility();
         refreshClaimAll();

--- a/src/main/java/betterquesting/handlers/ConfigHandler.java
+++ b/src/main/java/betterquesting/handlers/ConfigHandler.java
@@ -35,6 +35,8 @@ public class ConfigHandler
 		BQ_Settings.zoomOutToCursor = config.getBoolean("Zoom out on cursor", Configuration.CATEGORY_GENERAL, true, "Zoom out on cursor. If false, zooms out on center of screen.");
 
 		BQ_Settings.claimAllConfirmation = config.getBoolean("Claim all requires confirmation", Configuration.CATEGORY_GENERAL, true, "If true, then when you click on Claim all, a warning dialog will be displayed");
+
+		BQ_Settings.lockTray = config.getBoolean("Lock tray", Configuration.CATEGORY_GENERAL, false, "Is quest chapters list locked and opened on start");
 		config.save();
 	}
 }


### PR DESCRIPTION
[Suggestion in discord:](https://discord.com/channels/181078474394566657/181078474394566657/794253459913572352)
> `several people is typing` 31.12.2020
> @ShadowKillerPro can it be somehow configured so that betterquesting would not hide the sidebar by default every time a client is started? Not that its all that annoying but in fact it is annoying that it always starts in auto-hide mode


