### PR TITLE
Allow skip home and open quests gui at start

### DIFF
--- a/src/main/java/betterquesting/api/storage/BQ_Settings.java
+++ b/src/main/java/betterquesting/api/storage/BQ_Settings.java
@@ -14,6 +14,7 @@ public class BQ_Settings
 	public static String defaultDir = "config/betterquesting/";
 	
 	public static boolean useBookmark = true;
+	public static boolean skipHome = false;
 	public static String curTheme = "betterquesting:light";
 	public static int guiWidth = -1;
 	public static int guiHeight = -1;

--- a/src/main/java/betterquesting/client/gui2/GuiHome.java
+++ b/src/main/java/betterquesting/client/gui2/GuiHome.java
@@ -74,7 +74,7 @@ public class GuiHome extends GuiScreenCanvas implements IPEventListener
 		if (BQ_Settings.skipHome){
 			ConfigHandler.config.get(Configuration.CATEGORY_GENERAL, "Skip home", false).set(false);
 			ConfigHandler.config.save();
-			ConfigHandler.initConfigs();
+			BQ_Settings.skipHome = false;
 		}
 		
 		PEventBroadcaster.INSTANCE.register(this, PEventButton.class);

--- a/src/main/java/betterquesting/client/gui2/GuiHome.java
+++ b/src/main/java/betterquesting/client/gui2/GuiHome.java
@@ -30,6 +30,7 @@ import betterquesting.api2.utils.QuestTranslation;
 import betterquesting.client.gui2.editors.nbt.GuiNbtEditor;
 import betterquesting.client.gui2.party.GuiPartyCreate;
 import betterquesting.client.gui2.party.GuiPartyManage;
+import betterquesting.handlers.ConfigHandler;
 import betterquesting.handlers.EventHandler;
 import betterquesting.handlers.SaveLoadHandler;
 import betterquesting.network.handlers.NetChapterSync;
@@ -46,6 +47,7 @@ import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
 import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.common.config.Configuration;
 import org.lwjgl.util.vector.Vector4f;
 
 import java.io.File;
@@ -66,6 +68,14 @@ public class GuiHome extends GuiScreenCanvas implements IPEventListener
 	public void initPanel()
 	{
 		super.initPanel();
+
+		GuiHome.bookmark = this;
+		// If we come to home gui - we set skip home to false
+		if (BQ_Settings.skipHome){
+			ConfigHandler.config.get(Configuration.CATEGORY_GENERAL, "Skip home", false).set(false);
+			ConfigHandler.config.save();
+			ConfigHandler.initConfigs();
+		}
 		
 		PEventBroadcaster.INSTANCE.register(this, PEventButton.class);
 		

--- a/src/main/java/betterquesting/client/gui2/GuiQuestLines.java
+++ b/src/main/java/betterquesting/client/gui2/GuiQuestLines.java
@@ -47,6 +47,7 @@ import betterquesting.network.handlers.NetQuestAction;
 import betterquesting.questing.QuestDatabase;
 import betterquesting.questing.QuestLineDatabase;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.Gui;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraftforge.common.config.Configuration;
 import org.lwjgl.input.Mouse;
@@ -99,6 +100,14 @@ public class GuiQuestLines extends GuiScreenCanvas implements IPEventListener, I
     public void initPanel()
     {
         super.initPanel();
+
+        GuiHome.bookmark = this;
+        // If we come to quests gui - we set skip home to true
+        if (!BQ_Settings.skipHome){
+            ConfigHandler.config.get(Configuration.CATEGORY_GENERAL, "Skip home", false).set(true);
+            ConfigHandler.config.save();
+            ConfigHandler.initConfigs();
+        }
         
         if(selectedLineId >= 0)
         {

--- a/src/main/java/betterquesting/client/gui2/GuiQuestLines.java
+++ b/src/main/java/betterquesting/client/gui2/GuiQuestLines.java
@@ -455,7 +455,7 @@ public class GuiQuestLines extends GuiScreenCanvas implements IPEventListener, I
         selectedLine = q.getValue();
         selectedLineId = q.getID();
         for (int i = 0; i < btnListRef.size(); i++) {
-            btnListRef.get(i).setActive((visChapters.get(i).getSecond() & 4) == 0 && q.getID() != selectedLineId);
+            btnListRef.get(i).setActive((visChapters.get(i).getSecond() & 4) == 0 && btnListRef.get(i).getStoredValue().getID() != selectedLineId);
         }
 
         cvQuest.setQuestLine(q.getValue());

--- a/src/main/java/betterquesting/client/gui2/GuiQuestLines.java
+++ b/src/main/java/betterquesting/client/gui2/GuiQuestLines.java
@@ -106,7 +106,7 @@ public class GuiQuestLines extends GuiScreenCanvas implements IPEventListener, I
         if (!BQ_Settings.skipHome){
             ConfigHandler.config.get(Configuration.CATEGORY_GENERAL, "Skip home", false).set(true);
             ConfigHandler.config.save();
-            ConfigHandler.initConfigs();
+            BQ_Settings.skipHome = true;
         }
         
         if(selectedLineId >= 0)

--- a/src/main/java/betterquesting/handlers/ConfigHandler.java
+++ b/src/main/java/betterquesting/handlers/ConfigHandler.java
@@ -35,6 +35,8 @@ public class ConfigHandler
 		BQ_Settings.zoomOutToCursor = config.getBoolean("Zoom out on cursor", Configuration.CATEGORY_GENERAL, true, "Zoom out on cursor. If false, zooms out on center of screen.");
 
 		BQ_Settings.claimAllConfirmation = config.getBoolean("Claim all requires confirmation", Configuration.CATEGORY_GENERAL, true, "If true, then when you click on Claim all, a warning dialog will be displayed");
+
+		BQ_Settings.skipHome = config.getBoolean("Skip home", Configuration.CATEGORY_GENERAL, false, "If true will skip home gui and open quests at startup. This property will be changed by the mod itself.");
 		config.save();
 	}
 }

--- a/src/main/java/betterquesting/handlers/EventHandler.java
+++ b/src/main/java/betterquesting/handlers/EventHandler.java
@@ -19,6 +19,7 @@ import betterquesting.api2.client.gui.themes.presets.PresetGUIs;
 import betterquesting.api2.storage.DBEntry;
 import betterquesting.client.BQ_Keybindings;
 import betterquesting.client.gui2.GuiHome;
+import betterquesting.client.gui2.GuiQuestLines;
 import betterquesting.client.themes.ThemeRegistry;
 import betterquesting.core.BetterQuesting;
 import betterquesting.network.handlers.NetBulkSync;
@@ -96,7 +97,10 @@ public class EventHandler
 					mc.displayGuiScreen(GuiHome.bookmark);
 				} else
 				{
-					mc.displayGuiScreen(ThemeRegistry.INSTANCE.getGui(PresetGUIs.HOME, GArgsNone.NONE));
+                    GuiScreen guiToDisplay = ThemeRegistry.INSTANCE.getGui(PresetGUIs.HOME, GArgsNone.NONE);
+                    if (BQ_Settings.useBookmark && BQ_Settings.skipHome)
+                        guiToDisplay = new GuiQuestLines(guiToDisplay);
+                    mc.displayGuiScreen(guiToDisplay);
 				}
 			}
 		}


### PR DESCRIPTION
[Suggestion from discord](https://discord.com/channels/181078474394566657/289850721988509696/794266130532925450):
> @ShadowKillerPro Я предлагаю вернуть стартовую страницу со вкладками в квестах как было раньше. Раздражает необходимость каждый раз её открывать.

or, in English (close to text):

> I suggest return the quest lines gui as start page as it was before. It is annoying to have to open it every time.

-------------
Now mod will open `home gui` only if we close BQ's gui at `home gui`, otherwise start page - `questlines gui`. However, we can always return to `home gui` from the `questline gui` with "back" button