### PR TITLE
fix no such element on empty database

### DIFF
--- a/src/main/java/betterquesting/api2/storage/EmptyLookupLogic.java
+++ b/src/main/java/betterquesting/api2/storage/EmptyLookupLogic.java
@@ -1,0 +1,16 @@
+package betterquesting.api2.storage;
+
+import java.util.Collections;
+import java.util.List;
+
+public class EmptyLookupLogic<T> extends LookupLogic<T> {
+    public EmptyLookupLogic(SimpleDatabase<T> simpleDatabase)
+    {
+        super(simpleDatabase);
+    }
+
+    @Override
+    public List<DBEntry<T>> bulkLookup(int[] keys) {
+        return Collections.emptyList();
+    }
+}

--- a/src/main/java/betterquesting/api2/storage/LookupLogicType.java
+++ b/src/main/java/betterquesting/api2/storage/LookupLogicType.java
@@ -7,6 +7,7 @@ import static betterquesting.api2.storage.SimpleDatabase.*;
 
 enum LookupLogicType
 {
+	Empty(db -> db.mapDB.isEmpty(), EmptyLookupLogic::new),
 	ArrayCache(db -> db.mapDB.size() < CACHE_MAX_SIZE && db.mapDB.size() > SPARSE_RATIO * (db.mapDB.lastKey() - db.mapDB.firstKey()), ArrayCacheLookupLogic::new),
 	Naive(db -> true, NaiveLookupLogic::new);
 	private final Predicate<SimpleDatabase<?>> shouldUse;


### PR DESCRIPTION
https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/7599

```
java.util.NoSuchElementException
	at java.util.TreeMap.key(Unknown Source)
	at java.util.TreeMap.lastKey(Unknown Source)
	at betterquesting.api2.storage.LookupLogicType.lambda$static$0(LookupLogicType.java:10)
	at betterquesting.api2.storage.LookupLogicType.determine(LookupLogicType.java:26)
	at betterquesting.api2.storage.SimpleDatabase.updateLookupLogic(SimpleDatabase.java:44)
```


did not test, but should work?