### PR TITLE
Wait for IO finish upon save

### DIFF
--- a/src/main/java/betterquesting/api/utils/JsonHelper.java
+++ b/src/main/java/betterquesting/api/utils/JsonHelper.java
@@ -204,13 +204,18 @@ public class JsonHelper
 			return new JsonObject();
 		}
 	}
-	
+
+	public static void WriteToFile(File file, JsonObject jObj)
+	{
+		WriteToFile2(file, jObj);
+	}
+
 	@SuppressWarnings("ResultOfMethodCallIgnored")
-    public static void WriteToFile(File file, JsonObject jObj)
+	public static Future<Void> WriteToFile2(File file, JsonObject jObj)
 	{
 	    final File tmp = new File(file.getAbsolutePath() + ".tmp");
 	    
-		BQThreadedIO.INSTANCE.enqueue(() -> {
+		return BQThreadedIO.INSTANCE.enqueue(() -> {
 			try
 			{
 	            if(tmp.exists())
@@ -225,7 +230,7 @@ public class JsonHelper
 			} catch(Exception e)
 			{
 				QuestingAPI.getLogger().error("An error occured while saving JSON to file (Directory setup):", e);
-				return;
+				return null;
 			}
 			
 			// NOTE: These are now split due to an edge case in the previous implementation where resource leaking can occur should the outer constructor fail
@@ -237,7 +242,7 @@ public class JsonHelper
 			} catch(Exception e)
 			{
 				QuestingAPI.getLogger().error("An error occured while saving JSON to file (File write):", e);
-				return;
+				return null;
 			}
 			
 			// NOTE: These are now split due to an edge case in the previous implementation where resource leaking can occur should the outer constructor fail
@@ -248,7 +253,7 @@ public class JsonHelper
             } catch(Exception e)
             {
 				QuestingAPI.getLogger().error("An error occured while saving JSON to file (Validation check):", e);
-				return;
+				return null;
             }
 			
 			try
@@ -258,6 +263,7 @@ public class JsonHelper
             {
 				QuestingAPI.getLogger().error("An error occured while saving JSON to file (Temp copy):", e);
             }
+			return null;
 		});
 	}
 	


### PR DESCRIPTION
This happens with high probability with FTBU backup.

![bug](https://media.discordapp.net/attachments/234936569360809996/832819745190314024/unknown.png)
https://discord.com/channels/181078474394566657/234936569360809996/832819747028074517

BQ3 use asynchronous IO to save its database. In this process there will be a few temporary files created then removed. If ftbu happens to be running backup while this is happening, there is a good chance of race condition, and hence stopping ftbu from properlly making a backup. This PR ensures BQ3 returns only if all the file IO has finished.