### PR TITLE
Fix NaiveLookupLogic not invalidating ref cache upon changes to the underlying map

### DIFF
--- a/src/main/java/betterquesting/api2/storage/NaiveLookupLogic.java
+++ b/src/main/java/betterquesting/api2/storage/NaiveLookupLogic.java
@@ -16,6 +16,7 @@ class NaiveLookupLogic<T> extends LookupLogic<T>
 
     @Override
     public void onDataChange() {
+        super.onDataChange();
         backingMap = null;
     }
 


### PR DESCRIPTION
This will address Prometheus's problem of quest not appearing in questline after being added via designer.