### PR TITLE
Guard against broken mods returning invalid itemstack

### DIFF
--- a/src/main/java/betterquesting/api2/client/gui/panels/lists/CanvasItemDatabase.java
+++ b/src/main/java/betterquesting/api2/client/gui/panels/lists/CanvasItemDatabase.java
@@ -77,7 +77,7 @@ public class CanvasItemDatabase extends CanvasSearch<ItemStack, Item>
     @Override
     public boolean addResult(ItemStack stack, int index, int cachedWidth)
     {
-        if(stack == null) return false;
+        if(stack == null || stack.getItem() == null) return false;
         
         int x = (index % (cachedWidth / 18)) * 18;
         int y = (index / (cachedWidth / 18)) * 18;


### PR DESCRIPTION
https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/8076

Probably an item stack with a null item. I don't quite know who is null, but this should prevent all crashes like this.