### PR TITLE
Add a config to correct the width of the split text

### DIFF
--- a/src/main/java/betterquesting/api/storage/BQ_Settings.java
+++ b/src/main/java/betterquesting/api/storage/BQ_Settings.java
@@ -18,6 +18,7 @@ public class BQ_Settings
 	public static String curTheme = "betterquesting:light";
 	public static int guiWidth = -1;
 	public static int guiHeight = -1;
+	public static float textWidthCorrection = 1.0f;
 	public static boolean questNotices = true;
 	public static boolean dirtyMode = true;
 	public static float scrollMultiplier = 0.1F;

--- a/src/main/java/betterquesting/api2/client/gui/panels/content/PanelTextBox.java
+++ b/src/main/java/betterquesting/api2/client/gui/panels/content/PanelTextBox.java
@@ -12,6 +12,8 @@ import org.lwjgl.opengl.GL11;
 
 import java.util.List;
 
+import static betterquesting.api.storage.BQ_Settings.textWidthCorrection;
+
 public class PanelTextBox implements IGuiPanel
 {
 	private final GuiRectText transform;
@@ -102,7 +104,7 @@ public class PanelTextBox implements IGuiPanel
 			return;
 		}
 		
-		List<String> sl = fr.listFormattedStringToWidth(text, (int)Math.floor(bounds.getWidth() / scale));
+		List<String> sl = fr.listFormattedStringToWidth(text, (int)Math.floor(bounds.getWidth() / scale / textWidthCorrection));
 		lines = sl.size() - 1;
 		
 		this.transform.h = (int)Math.floor(fr.FONT_HEIGHT * sl.size() * scale);
@@ -128,7 +130,7 @@ public class PanelTextBox implements IGuiPanel
 		
 		float s = fontScale / 12F;
 		int w = (int)Math.ceil(RenderUtils.getStringWidth(text, fr) * s);
-		int bw = (int)Math.floor(bounds.getWidth() / s);
+		int bw = (int)Math.floor(bounds.getWidth() / s / textWidthCorrection);
 		
 		if(bw <= 0) return;
         

--- a/src/main/java/betterquesting/handlers/ConfigHandler.java
+++ b/src/main/java/betterquesting/handlers/ConfigHandler.java
@@ -24,6 +24,7 @@ public class ConfigHandler
 		BQ_Settings.useBookmark = config.getBoolean("Use Quest Bookmark", Configuration.CATEGORY_GENERAL, true, "Jumps the user to the last opened quest");
 		BQ_Settings.guiWidth = config.getInt("Max GUI Width", Configuration.CATEGORY_GENERAL, -1, -1, Integer.MAX_VALUE, "Clamps the max UI width (-1 to disable)");
 		BQ_Settings.guiHeight = config.getInt("Max GUI Height", Configuration.CATEGORY_GENERAL, -1, -1, Integer.MAX_VALUE, "Clamps the max UI height (-1 to disable)");
+		BQ_Settings.textWidthCorrection = config.getFloat("Text Width Correction", Configuration.CATEGORY_GENERAL, 1F, 0.01F, 10.0F, "Correcting the width of split text");
 		
 		BQ_Settings.scrollMultiplier = config.getFloat("Scroll multiplier", Configuration.CATEGORY_GENERAL, 1F, 0F, 10F, "Scrolling multiplier");
 


### PR DESCRIPTION
Closed https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/10354
BQ + smooth-font
Some text is blocked


<img width="1280" alt="bq-01" src="https://user-images.githubusercontent.com/49554020/168855701-60475ac9-2206-4e88-a647-d1bba419d806.png">
<img width="278" alt="image" src="https://user-images.githubusercontent.com/49554020/168862785-717c4da9-7f5f-49aa-8f84-5aaf24efd74e.png">


---
So add a config to correct the width of the split text:


<img width="1280" alt="bq-02" src="https://user-images.githubusercontent.com/49554020/168862672-751cb130-d518-4c87-85e5-dd54df69771a.png">
<img width="1569" alt="image" src="https://user-images.githubusercontent.com/49554020/168871534-fdcb2a69-36c2-4245-8fea-47b5cc9ba90c.png">

---
Effect


<img width="1280" alt="bq-03" src="https://user-images.githubusercontent.com/49554020/168862681-dfa9a89c-a18b-41de-9b78-2422e45df128.png">

