### PR TITLE
Don't crash if a taskGui or rewardGui isn't available

### DIFF
--- a/src/main/java/betterquesting/client/gui2/GuiQuest.java
+++ b/src/main/java/betterquesting/client/gui2/GuiQuest.java
@@ -331,12 +331,14 @@ public class GuiQuest extends GuiScreenCanvas implements IPEventListener, INeeds
             yOffset += 12;
 
             IGuiPanel rewardGui = rew.getRewardGui(new GuiTransform(GuiAlign.FULL_BOX, 0, 0, rectReward.getWidth(), rectReward.getHeight(), 111), new DBEntry<>(questID, quest));
-            rewardGui.initPanel();
-            // Wrapping into canvas allow avoid empty space at end
-            CanvasEmpty tempCanvas = new CanvasEmpty(new GuiTransform(GuiAlign.TOP_LEFT, 0, yOffset, rectReward.getWidth(), rewardGui.getTransform().getHeight() - rewardGui.getTransform().getY(), 1));
-            csReward.addPanel(tempCanvas);
-            tempCanvas.addPanel(rewardGui);
-            yOffset += tempCanvas.getTransform().getHeight();
+            if (rewardGui != null) {
+                rewardGui.initPanel();
+                // Wrapping into canvas allow avoid empty space at end
+                CanvasEmpty tempCanvas = new CanvasEmpty(new GuiTransform(GuiAlign.TOP_LEFT, 0, yOffset, rectReward.getWidth(), rewardGui.getTransform().getHeight() - rewardGui.getTransform().getY(), 1));
+                csReward.addPanel(tempCanvas);
+                tempCanvas.addPanel(rewardGui);
+                yOffset += tempCanvas.getTransform().getHeight();
+            }
         }
 
         csReward.setScrollY(scrollPosition.getRewardScrollY());
@@ -377,14 +379,14 @@ public class GuiQuest extends GuiScreenCanvas implements IPEventListener, INeeds
             IGuiPanel taskGui = tsk.getTaskGui(new GuiTransform(GuiAlign.FULL_BOX, 0, 0, rectTask.getWidth(), rectTask.getHeight(), 0), new DBEntry<>(questID, quest));
             if (taskGui != null) {
                 taskGui.initPanel();
-            }
-            // Wrapping into canvas allow avoid empty space at end
-            CanvasEmpty tempCanvas = new CanvasEmpty(new GuiTransform(GuiAlign.TOP_LEFT, 0, yOffset, rectTask.getWidth(), taskGui.getTransform().getHeight() - taskGui.getTransform().getY(), 1));
-            csTask.addPanel(tempCanvas);
-            tempCanvas.addPanel(taskGui);
-            int guiHeight = tempCanvas.getTransform().getHeight();
-            yOffset += guiHeight;
+                // Wrapping into canvas allow avoid empty space at end
+                CanvasEmpty tempCanvas = new CanvasEmpty(new GuiTransform(GuiAlign.TOP_LEFT, 0, yOffset, rectTask.getWidth(), taskGui.getTransform().getHeight() - taskGui.getTransform().getY(), 1));
+                csTask.addPanel(tempCanvas);
+                tempCanvas.addPanel(taskGui);
+                int guiHeight = tempCanvas.getTransform().getHeight();
+                yOffset += guiHeight;
 
+            }
             //Indent from the previous
             yOffset += 8;
         }


### PR DESCRIPTION
Fixes GTNewHorizons/GT-New-Horizons-Modpack#10617 which I has also noticed playing around in the editor.

I'm not sure this is the right fix as it only avoids the consequences of the NPE, and I'm not sure whether that situation is supposed to be possible or not.