### PR TITLE
Fix backspace going back while typing

### DIFF
--- a/src/main/java/betterquesting/api2/client/gui/GuiScreenCanvas.java
+++ b/src/main/java/betterquesting/api2/client/gui/GuiScreenCanvas.java
@@ -236,9 +236,17 @@ public class GuiScreenCanvas extends GuiScreen implements IScene
         if (keyCode == 14) { // BACKSPACE
             if (this.mc.currentScreen instanceof GuiScreenCanvas) {
                 GuiScreenCanvas canvas = (GuiScreenCanvas) mc.currentScreen;
-                if (canvas.parent != null) {
-                    mc.displayGuiScreen(canvas.parent);
-                }
+				boolean hasKeyAction = false;
+				for (IGuiPanel panel : canvas.getChildren()) {
+					if (panel.isEnabled() && panel.onKeyTyped(c, keyCode)) {
+						hasKeyAction = true;
+						break;
+					}
+				}
+				if (!hasKeyAction && canvas.parent != null) {
+					mc.displayGuiScreen(canvas.parent);
+				}
+				return;
             }
             return;
         }

--- a/src/main/java/betterquesting/api2/client/gui/GuiScreenCanvas.java
+++ b/src/main/java/betterquesting/api2/client/gui/GuiScreenCanvas.java
@@ -220,38 +220,28 @@ public class GuiScreenCanvas extends GuiScreen implements IScene
 	@Override
     public void keyTyped(char c, int keyCode)
     {
-        if (keyCode == 1) // ESCAPE
-        {
-        	if(this.isVolatile || this instanceof IVolatileScreen)
-        	{
-        	    openPopup(new PopChoice(QuestTranslation.translate("betterquesting.gui.closing_warning") + "\n\n" + QuestTranslation.translate("betterquesting.gui.closing_confirm"), PresetIcon.ICON_NOTICE.getTexture(), this::confirmClose, QuestTranslation.translate("gui.yes"), QuestTranslation.translate("gui.no")));
-        	} else
+		if (keyCode == 1) // ESCAPE
+		{
+			if(this.isVolatile || this instanceof IVolatileScreen)
+			{
+				openPopup(new PopChoice(QuestTranslation.translate("betterquesting.gui.closing_warning") + "\n\n" + QuestTranslation.translate("betterquesting.gui.closing_confirm"), PresetIcon.ICON_NOTICE.getTexture(), this::confirmClose, QuestTranslation.translate("gui.yes"), QuestTranslation.translate("gui.no")));
+			} else
 			{
 				this.mc.displayGuiScreen(null);
 				if(this.mc.currentScreen == null) this.mc.setIngameFocus();
 			}
-			
+
 			return;
-        }
-        if (keyCode == 14) { // BACKSPACE
-            if (this.mc.currentScreen instanceof GuiScreenCanvas) {
-                GuiScreenCanvas canvas = (GuiScreenCanvas) mc.currentScreen;
-				boolean hasKeyAction = false;
-				for (IGuiPanel panel : canvas.getChildren()) {
-					if (panel.isEnabled() && panel.onKeyTyped(c, keyCode)) {
-						hasKeyAction = true;
-						break;
-					}
-				}
-				if (!hasKeyAction && canvas.parent != null) {
+		}
+		if (this.onKeyTyped(c, keyCode)) return;
+		if (keyCode == 14) { // BACKSPACE
+			if (this.mc.currentScreen instanceof GuiScreenCanvas) {
+				GuiScreenCanvas canvas = (GuiScreenCanvas) mc.currentScreen;
+				if (canvas.parent != null) {
 					mc.displayGuiScreen(canvas.parent);
 				}
-				return;
-            }
-            return;
-        }
-        
-        this.onKeyTyped(c, keyCode);
+			}
+		}
     }
 	
 	@Override


### PR DESCRIPTION
Fixes the Backspace action introduced in #72 by ensuring that the previous screen change does not happen when the backspace key actually performs an action on the current panel.

There were changes to the backspace action introduced in the Cleanroom fork later on that fixed the backspace action, but where missed in that PR.