### PR TITLE
Do not trigger task check for all inventory slots

### DIFF
--- a/src/main/java/bq_standard/handlers/PlayerContainerListener.java
+++ b/src/main/java/bq_standard/handlers/PlayerContainerListener.java
@@ -42,7 +42,10 @@ public class PlayerContainerListener implements ICrafting {
 
     @Override
     public void sendSlotContents(Container container, int i, ItemStack itemStack) {
-        updateTasks();
+        // Ignore changes outside of main inventory (e.g. crafting grid and armor)
+        if (i >= 9 && i <= 44) {
+            updateTasks();
+        }
     }
 
     @Override


### PR DESCRIPTION
Only trigger completion checks on changes to the main 36-slot inventory. Previously chargeable armors would trigger these checks on each tick they drained or were charged. This showed up in server profiling.

Before:
![image](https://user-images.githubusercontent.com/73182109/225166298-5625eb7d-aa50-4e72-98d5-9b4aeb06fa3a.png)

After (even while spamming drop to simulate potential normal inventory changes):
![image](https://user-images.githubusercontent.com/73182109/225166389-1da43c6d-7f97-4edc-8735-f91b374fc31b.png)
