### PR TITLE
Add shorter string encoding for UUIDs, and make saved quest data more stable

### DIFF
--- a/src/main/java/betterquesting/api/utils/NBTConverter.java
+++ b/src/main/java/betterquesting/api/utils/NBTConverter.java
@@ -60,7 +60,7 @@ public class NBTConverter
         /** Use this method in cases where the player needs to edit the NBT manually. */
         public void writeIdString(@Nullable UUID uuid, NBTTagCompound tag)
         {
-            tag.setString(idFieldName, uuid == null ? "" : uuid.toString());
+            tag.setString(idFieldName, uuid == null ? "" : UuidConverter.encodeUuid(uuid));
         }
 
         public NBTTagList writeIds(Collection<UUID> uuids)
@@ -99,7 +99,12 @@ public class NBTConverter
                 return Optional.empty();
             }
 
-            return Optional.of(UUID.fromString(questId));
+            if (questId.length() > 24) {
+                // Handle old data, from before we started encoding UUIDs.
+                return Optional.of(UUID.fromString(questId));
+            }
+
+            return Optional.of(UuidConverter.decodeUuid(questId));
         }
 
         public List<UUID> readIds(NBTTagCompound tag, String key)

--- a/src/main/java/betterquesting/api/utils/UuidConverter.java
+++ b/src/main/java/betterquesting/api/utils/UuidConverter.java
@@ -1,0 +1,35 @@
+package betterquesting.api.utils;
+
+import com.google.common.base.Preconditions;
+import com.google.common.primitives.Bytes;
+import com.google.common.primitives.Longs;
+
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.UUID;
+
+public class UuidConverter {
+    /** Converts a legacy integer ID to a UUID. */
+    public static UUID convertLegacyId(int legacyId) {
+        // Negative legacy IDs are invalid, and are used to indicate an unset ID.
+        Preconditions.checkArgument(legacyId >= 0);
+        return new UUID(0L, legacyId);
+    }
+
+    /** Returns a compact string representation of a UUID. */
+    public static String encodeUuid(UUID uuid) {
+        byte[] upper = Longs.toByteArray(uuid.getMostSignificantBits());
+        byte[] lower = Longs.toByteArray(uuid.getLeastSignificantBits());
+
+        return Base64.getUrlEncoder().encodeToString(Bytes.concat(upper, lower));
+    }
+
+    /** Decodes a compact string representation of a UUID. */
+    public static UUID decodeUuid(String string) {
+        byte[] bytes = Base64.getUrlDecoder().decode(string);
+        byte[] upper = Arrays.copyOfRange(bytes, 0, 8);
+        byte[] lower = Arrays.copyOfRange(bytes, 8, 16);
+
+        return new UUID(Longs.fromByteArray(upper), Longs.fromByteArray(lower));
+    }
+}

--- a/src/main/java/betterquesting/api2/cache/QuestCache.java
+++ b/src/main/java/betterquesting/api2/cache/QuestCache.java
@@ -7,7 +7,6 @@ import betterquesting.api.properties.NativeProps;
 import betterquesting.api.questing.IQuest;
 import betterquesting.api.storage.BQ_Settings;
 import betterquesting.api.utils.NBTConverter;
-import betterquesting.api2.storage.IUuidDatabase;
 import betterquesting.network.handlers.NetCacheSync;
 import betterquesting.questing.QuestDatabase;
 import net.minecraft.entity.Entity;
@@ -22,14 +21,12 @@ import net.minecraftforge.common.util.Constants;
 
 import javax.annotation.Nonnull;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.UUID;
-import java.util.function.BiConsumer;
 
 public class QuestCache implements IExtendedEntityProperties
 {
@@ -187,25 +184,10 @@ public class QuestCache implements IExtendedEntityProperties
         autoClaims.clear();
         markedDirty.clear();
 
-        BiConsumer<String, Set<UUID>> handleTag =
-                (tagName, map) -> {
-                    if (nbt.func_150299_b(tagName) == Constants.NBT.TAG_LIST)
-                    {
-                        map.addAll(NBTConverter.UuidValueType.QUEST.readIds(nbt, tagName));
-                    }
-                    else
-                    {
-                        // TODO is this NBT ever persisted? We only need this block if it is.
-                        Arrays.stream(nbt.getIntArray(tagName))
-                                .mapToObj(IUuidDatabase::convertLegacyId)
-                                .forEach(map::add);
-                    }
-                };
-
-        handleTag.accept("visibleQuests", visibleQuests);
-        handleTag.accept("activeQuests", activeQuests);
-        handleTag.accept("autoClaims", autoClaims);
-        handleTag.accept("markedDirty", markedDirty);
+        visibleQuests.addAll(NBTConverter.UuidValueType.QUEST.readIds(nbt, "visibleQuests"));
+        activeQuests.addAll(NBTConverter.UuidValueType.QUEST.readIds(nbt, "activeQuests"));
+        autoClaims.addAll(NBTConverter.UuidValueType.QUEST.readIds(nbt, "autoClaims"));
+        markedDirty.addAll(NBTConverter.UuidValueType.QUEST.readIds(nbt, "markedDirty"));
 
         NBTTagList tagList = nbt.getTagList("resetSchedule", Constants.NBT.TAG_COMPOUND);
         for (int i = 0; i < tagList.tagCount(); i++)

--- a/src/main/java/betterquesting/api2/cache/QuestCache.java
+++ b/src/main/java/betterquesting/api2/cache/QuestCache.java
@@ -86,10 +86,15 @@ public class QuestCache implements IExtendedEntityProperties
     {
         markedDirty.clear();
     }
-    
+
+    /**
+     * This method must return a copy of {@code markedDirty}, because {@code markedDirty} gets
+     * cleared every tick. Returning it directly means introducing a potential race condition where
+     * any callers that run code on separate threads may run after {@code markedDirty} gets cleared.
+     */
     public synchronized Set<UUID> getDirtyQuests()
     {
-        return markedDirty;
+        return new HashSet<>(markedDirty);
     }
     
     // TODO: Ensure this is thread safe because we're likely going to run this in the background

--- a/src/main/java/betterquesting/api2/cache/QuestCache.java
+++ b/src/main/java/betterquesting/api2/cache/QuestCache.java
@@ -9,6 +9,7 @@ import betterquesting.api.storage.BQ_Settings;
 import betterquesting.api.utils.NBTConverter;
 import betterquesting.network.handlers.NetCacheSync;
 import betterquesting.questing.QuestDatabase;
+import com.google.common.collect.ImmutableSet;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
@@ -51,20 +52,32 @@ public class QuestCache implements IExtendedEntityProperties
     public void init(Entity entity, World world)
     {
     }
-    
-    public synchronized Set<UUID> getActiveQuests()
+
+    /**
+     * I don't think that it's currently necessary for this method to return a copy, but let's do so
+     * anyway in case of future concurrency changes.
+     */
+    public synchronized ImmutableSet<UUID> getActiveQuests()
     {
-        return activeQuests;
+        return ImmutableSet.copyOf(activeQuests);
     }
-    
-    public synchronized Set<UUID> getVisibleQuests()
+
+    /**
+     * I don't think that it's currently necessary for this method to return a copy, but let's do so
+     * anyway in case of future concurrency changes.
+     */
+    public synchronized ImmutableSet<UUID> getVisibleQuests()
     {
-        return visibleQuests;
+        return ImmutableSet.copyOf(visibleQuests);
     }
-    
-    public synchronized Set<UUID> getPendingAutoClaims()
+
+    /**
+     * I don't think that it's currently necessary for this method to return a copy, but let's do so
+     * anyway in case of future concurrency changes.
+     */
+    public synchronized ImmutableSet<UUID> getPendingAutoClaims()
     {
-        return autoClaims;
+        return ImmutableSet.copyOf(autoClaims);
     }
     
     public synchronized QResetTime[] getScheduledResets() // Already sorted by time
@@ -92,9 +105,9 @@ public class QuestCache implements IExtendedEntityProperties
      * cleared every tick. Returning it directly means introducing a potential race condition where
      * any callers that run code on separate threads may run after {@code markedDirty} gets cleared.
      */
-    public synchronized Set<UUID> getDirtyQuests()
+    public synchronized ImmutableSet<UUID> getDirtyQuests()
     {
-        return new HashSet<>(markedDirty);
+        return ImmutableSet.copyOf(markedDirty);
     }
     
     // TODO: Ensure this is thread safe because we're likely going to run this in the background

--- a/src/main/java/betterquesting/api2/client/gui/controls/PanelButtonQuest.java
+++ b/src/main/java/betterquesting/api2/client/gui/controls/PanelButtonQuest.java
@@ -8,6 +8,7 @@ import betterquesting.api.questing.IQuest;
 import betterquesting.api.questing.tasks.ITask;
 import betterquesting.api.storage.BQ_Settings;
 import betterquesting.api.utils.BigItemStack;
+import betterquesting.api.utils.UuidConverter;
 import betterquesting.api2.client.gui.misc.GuiRectangle;
 import betterquesting.api2.client.gui.resources.colors.IGuiColor;
 import betterquesting.api2.client.gui.resources.textures.GuiTextureColored;
@@ -109,7 +110,7 @@ public class PanelButtonQuest extends PanelButtonStorage<Map.Entry<UUID, IQuest>
     {
 		List<String> list = new ArrayList<>();
 
-		list.add(QuestTranslation.translateQuestName(qID, quest) + (!Minecraft.getMinecraft().gameSettings.advancedItemTooltips ? "" : (" #" + qID)));
+		list.add(QuestTranslation.translateQuestName(qID, quest) + (!Minecraft.getMinecraft().gameSettings.advancedItemTooltips ? "" : (" #" + UuidConverter.encodeUuid(qID))));
 
 		UUID playerID = QuestingAPI.getQuestingUUID(player);
 

--- a/src/main/java/betterquesting/api2/client/gui/panels/lists/CanvasQuestDatabase.java
+++ b/src/main/java/betterquesting/api2/client/gui/panels/lists/CanvasQuestDatabase.java
@@ -2,6 +2,7 @@ package betterquesting.api2.client.gui.panels.lists;
 
 import betterquesting.api.properties.NativeProps;
 import betterquesting.api.questing.IQuest;
+import betterquesting.api.utils.UuidConverter;
 import betterquesting.api2.client.gui.misc.IGuiRect;
 import betterquesting.api2.utils.QuestTranslation;
 import betterquesting.questing.QuestDatabase;
@@ -28,7 +29,7 @@ public abstract class CanvasQuestDatabase extends CanvasSearch<Map.Entry<UUID, I
     @Override
     protected void queryMatches(Map.Entry<UUID, IQuest> entry, String query, final ArrayDeque<Map.Entry<UUID, IQuest>> results)
     {
-        if ((entry.getKey().toString()).contains(query) || entry.getValue().getProperty(NativeProps.NAME).toLowerCase().contains(query) || QuestTranslation.translateQuestName(entry).toLowerCase().contains(query))
+        if (UuidConverter.encodeUuid(entry.getKey()).toLowerCase().contains(query) || entry.getValue().getProperty(NativeProps.NAME).toLowerCase().contains(query) || QuestTranslation.translateQuestName(entry).toLowerCase().contains(query))
         {
             results.add(entry);
         }

--- a/src/main/java/betterquesting/api2/client/gui/panels/lists/CanvasQuestSearch.java
+++ b/src/main/java/betterquesting/api2/client/gui/panels/lists/CanvasQuestSearch.java
@@ -6,6 +6,7 @@ import betterquesting.api.questing.IQuest;
 import betterquesting.api.questing.IQuestLine;
 import betterquesting.api.questing.IQuestLineEntry;
 import betterquesting.api.questing.tasks.ITask;
+import betterquesting.api.utils.UuidConverter;
 import betterquesting.api2.cache.QuestCache;
 import betterquesting.api2.client.gui.controls.PanelButtonCustom;
 import betterquesting.api2.client.gui.controls.PanelButtonQuest;
@@ -70,7 +71,7 @@ public class CanvasQuestSearch extends CanvasSearch<QuestSearchEntry, QuestSearc
             }
         } else if (
             // quest id
-            String.valueOf(entry.getQuest().getKey()).contains(query)
+            UuidConverter.encodeUuid(entry.getQuest().getKey()).toLowerCase().contains(query)
             // quest title
             || entry.getQuest().getValue().getProperty(NativeProps.NAME).toLowerCase().contains(query)
             || QuestTranslation.translateQuestName(entry.getQuest()).toLowerCase().contains(query)

--- a/src/main/java/betterquesting/api2/storage/IUuidDatabase.java
+++ b/src/main/java/betterquesting/api2/storage/IUuidDatabase.java
@@ -1,6 +1,5 @@
 package betterquesting.api2.storage;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.BiMap;
 
 import javax.annotation.Nullable;
@@ -12,13 +11,6 @@ import java.util.stream.Stream;
 
 /** Database that uses randomly-generated UUIDs as keys. */
 public interface IUuidDatabase<T> extends BiMap<UUID, T> {
-    /** Converts a legacy integer ID to a UUID. */
-    static UUID convertLegacyId(int legacyId) {
-        // Negative legacy IDs are invalid, and are used to indicate an unset ID.
-        Preconditions.checkArgument(legacyId >= 0);
-        return new UUID(0L, legacyId);
-    }
-
     /** Returns an unused UUID. */
     UUID generateKey();
 

--- a/src/main/java/betterquesting/api2/storage/IUuidDatabase.java
+++ b/src/main/java/betterquesting/api2/storage/IUuidDatabase.java
@@ -17,6 +17,12 @@ public interface IUuidDatabase<T> extends BiMap<UUID, T> {
     @Nullable
     UUID lookupKey(T value);
 
+    /**
+     * Returns this database's entries in a stable order.
+     * Useful for ensuring that exported files change as little as possible.
+     */
+    Stream<Map.Entry<UUID, T>> orderedEntries();
+
     Stream<T> getAll(Collection<UUID> keys);
 
     Map<UUID, T> filterKeys(Collection<UUID> keys);

--- a/src/main/java/betterquesting/api2/storage/UuidDatabase.java
+++ b/src/main/java/betterquesting/api2/storage/UuidDatabase.java
@@ -34,6 +34,11 @@ public class UuidDatabase<T> implements IUuidDatabase<T> {
     }
 
     @Override
+    public Stream<Map.Entry<UUID, T>> orderedEntries() {
+        return entrySet().stream().sorted(Map.Entry.comparingByKey());
+    }
+
+    @Override
     public Stream<T> getAll(Collection<UUID> keys) {
         return keys.stream().distinct().filter(database::containsKey).map(database::get);
     }

--- a/src/main/java/betterquesting/api2/utils/QuestTranslation.java
+++ b/src/main/java/betterquesting/api2/utils/QuestTranslation.java
@@ -5,6 +5,7 @@ import betterquesting.api.properties.IPropertyType;
 import betterquesting.api.properties.NativeProps;
 import betterquesting.api.questing.IQuest;
 import betterquesting.api.questing.IQuestLine;
+import betterquesting.api.utils.UuidConverter;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.util.StatCollector;
 
@@ -30,7 +31,7 @@ public class QuestTranslation {
     }
 
     public static String buildQuestNameKey(UUID questId) {
-        return String.format(QUEST_NAME_KEY, questId);
+        return String.format(QUEST_NAME_KEY, UuidConverter.encodeUuid(questId));
     }
 
     public static String translateQuestName(UUID questId, IQuest quest) {
@@ -42,7 +43,7 @@ public class QuestTranslation {
     }
 
     public static String buildQuestDescriptionKey(UUID questId) {
-        return String.format(QUEST_DESCRIPTION_KEY, questId);
+        return String.format(QUEST_DESCRIPTION_KEY, UuidConverter.encodeUuid(questId));
     }
 
     public static String translateQuestDescription(UUID questId, IQuest quest) {
@@ -54,7 +55,7 @@ public class QuestTranslation {
     }
 
     public static String buildQuestLineNameKey(UUID questLineId) {
-        return String.format(QUEST_LINE_NAME_KEY, questLineId);
+        return String.format(QUEST_LINE_NAME_KEY, UuidConverter.encodeUuid(questLineId));
     }
 
     public static String translateQuestLineName(UUID questLineId, IQuestLine questLine) {
@@ -66,7 +67,7 @@ public class QuestTranslation {
     }
 
     public static String buildQuestLineDescriptionKey(UUID questLineId) {
-        return String.format(QUEST_LINE_DESCRIPTION_KEY, questLineId);
+        return String.format(QUEST_LINE_DESCRIPTION_KEY, UuidConverter.encodeUuid(questLineId));
     }
 
     public static String translateQuestLineDescription(UUID questLineId, IQuestLine questLine) {

--- a/src/main/java/betterquesting/api2/utils/QuestTranslation.java
+++ b/src/main/java/betterquesting/api2/utils/QuestTranslation.java
@@ -5,7 +5,8 @@ import betterquesting.api.properties.IPropertyType;
 import betterquesting.api.properties.NativeProps;
 import betterquesting.api.questing.IQuest;
 import betterquesting.api.questing.IQuestLine;
-import betterquesting.api2.storage.DBEntry;
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
 import cpw.mods.fml.relauncher.ReflectionHelper;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.client.resources.Locale;
@@ -23,17 +24,22 @@ public class QuestTranslation {
     /**
      * We'll look up translation keys directly from the map, to avoid needing to perform string
      * comparison to check if a key is missing.
+     *
+     * <p>This must be a supplier, because this class is called on the server (in order to build
+     * quest translation keys during saving). The {@link I18n} class is not available on the server,
+     * so attempting to build this map will cause a crash.
      */
-    private static final Map<String, String> translations;
-    static {
-        try {
-            Field localeField = ReflectionHelper.findField(I18n.class, "i18nLocale", "field_135054_a");
-            Field translationsField = ReflectionHelper.findField(Locale.class, "field_135032_a");
-            translations = (Map<String, String>) translationsField.get(localeField.get(null));
-        } catch (IllegalAccessException e) {
-            throw new RuntimeException(e);
-        }
-    }
+    private static final Supplier<Map<String, String>> translations =
+            Suppliers.memoize(
+                    () -> {
+                        try {
+                            Field localeField = ReflectionHelper.findField(I18n.class, "i18nLocale", "field_135054_a");
+                            Field translationsField = ReflectionHelper.findField(Locale.class, "field_135032_a");
+                            return (Map<String, String>) translationsField.get(localeField.get(null));
+                        } catch (IllegalAccessException e) {
+                            throw new RuntimeException(e);
+                        }
+                    });
 
     public static String translate(String text, Object... args) {
         String out = I18n.format(text, args);
@@ -102,7 +108,7 @@ public class QuestTranslation {
      */
     private static String translateProperty(
             String key, IPropertyContainer container, IPropertyType<String> property) {
-        String translation = translations.get(key);
+        String translation = translations.get().get(key);
         if (translation != null) {
             return String.format(translation);
         }

--- a/src/main/java/betterquesting/api2/utils/QuestTranslation.java
+++ b/src/main/java/betterquesting/api2/utils/QuestTranslation.java
@@ -27,7 +27,7 @@ public class QuestTranslation {
      *
      * <p>This must be a supplier, because this class is called on the server (in order to build
      * quest translation keys during saving). The {@link I18n} class is not available on the server,
-     * so attempting to build this map will cause a crash.
+     * so attempting to fetch this map will cause a crash.
      */
     private static final Supplier<Map<String, String>> translations =
             Suppliers.memoize(

--- a/src/main/java/betterquesting/blocks/TileSubmitStation.java
+++ b/src/main/java/betterquesting/blocks/TileSubmitStation.java
@@ -6,8 +6,8 @@ import betterquesting.api.questing.tasks.IFluidTask;
 import betterquesting.api.questing.tasks.IItemTask;
 import betterquesting.api.questing.tasks.ITask;
 import betterquesting.api.utils.NBTConverter;
+import betterquesting.api.utils.UuidConverter;
 import betterquesting.api2.cache.QuestCache;
-import betterquesting.api2.storage.IUuidDatabase;
 import betterquesting.core.BetterQuesting;
 import betterquesting.questing.QuestDatabase;
 import betterquesting.storage.QuestSettings;
@@ -424,7 +424,7 @@ public class TileSubmitStation extends TileEntity implements IFluidHandler, ISid
         else if (tags.hasKey("questID"))
         {
             // Needed for compatibility with old worlds.
-            questID = IUuidDatabase.convertLegacyId(tags.getInteger("questID"));
+            questID = UuidConverter.convertLegacyId(tags.getInteger("questID"));
         }
 
 		taskID = tags.hasKey("task") ? tags.getInteger("task") : -1;

--- a/src/main/java/betterquesting/client/gui2/GuiQuestLines.java
+++ b/src/main/java/betterquesting/client/gui2/GuiQuestLines.java
@@ -11,6 +11,7 @@ import betterquesting.api.questing.IQuestLine;
 import betterquesting.api.questing.IQuestLineEntry;
 import betterquesting.api.storage.BQ_Settings;
 import betterquesting.api.utils.RenderUtils;
+import betterquesting.api.utils.UuidConverter;
 import betterquesting.api2.cache.QuestCache;
 import betterquesting.api2.client.gui.GuiScreenCanvas;
 import betterquesting.api2.client.gui.controls.IPanelButton;
@@ -388,13 +389,13 @@ public class GuiQuestLines extends GuiScreenCanvas implements IPEventListener, I
 
                         PopContextMenu popup = new PopContextMenu(new GuiRectangle(mx, my, maxWidth + 12, questExistsUnderMouse ? 48 : 16), true);
                         Runnable questSharer = () -> {
-                            mc.thePlayer.sendChatMessage("betterquesting.msg.sharequest:" + questId);
+                            mc.thePlayer.sendChatMessage("betterquesting.msg.sharequest:" + UuidConverter.encodeUuid(questId));
                             mc.displayGuiScreen(null);
                         };
                         popup.addButton(QuestTranslation.translate("betterquesting.btn.share_quest"), null, questSharer);
 
                         Runnable copyQuestId = () -> {
-                            StringSelection stringToCopy = new StringSelection(questId.toString());
+                            StringSelection stringToCopy = new StringSelection(UuidConverter.encodeUuid(questId));
                             try {
                                 Toolkit.getDefaultToolkit().getSystemClipboard().setContents(stringToCopy, null);
                                 mc.thePlayer.addChatMessage(
@@ -402,7 +403,7 @@ public class GuiQuestLines extends GuiScreenCanvas implements IPEventListener, I
                                                 QuestTranslation.translate("betterquesting.msg.copy_quest_copied")));
                                 mc.thePlayer.addChatMessage(
                                         new ChatComponentText(
-                                                "  " + EnumChatFormatting.AQUA + questId));
+                                                "  " + EnumChatFormatting.AQUA + UuidConverter.encodeUuid(questId)));
                             } catch (IllegalStateException e) {
                                 mc.thePlayer.addChatMessage(
                                         new ChatComponentText(

--- a/src/main/java/betterquesting/commands/admin/QuestCommandCheckCompletion.java
+++ b/src/main/java/betterquesting/commands/admin/QuestCommandCheckCompletion.java
@@ -2,6 +2,7 @@ package betterquesting.commands.admin;
 
 import betterquesting.api.properties.NativeProps;
 import betterquesting.api.questing.IQuest;
+import betterquesting.api.utils.UuidConverter;
 import betterquesting.commands.QuestCommandBase;
 import betterquesting.questing.QuestDatabase;
 import betterquesting.storage.NameCache;
@@ -35,7 +36,7 @@ public class QuestCommandCheckCompletion extends QuestCommandBase {
 			return CommandBase.getListOfStringsMatchingLastWord(args, NameCache.INSTANCE.getAllNames().toArray(new String[0]));
 		} else if (args.length == 3) {
 			for (UUID id : QuestDatabase.INSTANCE.keySet()) {
-				list.add(id.toString());
+				list.add(UuidConverter.encodeUuid(id));
 			}
 		}
 
@@ -59,7 +60,7 @@ public class QuestCommandCheckCompletion extends QuestCommandBase {
 
 		String pName = NameCache.INSTANCE.getName(uuid);
 
-		UUID id = UUID.fromString(args[2].trim());
+		UUID id = UuidConverter.decodeUuid(args[2].trim());
 		IQuest quest = QuestDatabase.INSTANCE.get(id);
 		if (quest == null) throw getException(command);
 		sender.addChatMessage(new ChatComponentTranslation("betterquesting.cmd.check." + quest.isComplete(uuid), pName, new ChatComponentTranslation(quest.getProperty(NativeProps.NAME))));

--- a/src/main/java/betterquesting/commands/admin/QuestCommandComplete.java
+++ b/src/main/java/betterquesting/commands/admin/QuestCommandComplete.java
@@ -2,6 +2,7 @@ package betterquesting.commands.admin;
 
 import betterquesting.api.properties.NativeProps;
 import betterquesting.api.questing.IQuest;
+import betterquesting.api.utils.UuidConverter;
 import betterquesting.commands.QuestCommandBase;
 import betterquesting.network.handlers.NetQuestEdit;
 import betterquesting.questing.QuestDatabase;
@@ -41,7 +42,7 @@ public class QuestCommandComplete extends QuestCommandBase
 		{
 			for (UUID id : QuestDatabase.INSTANCE.keySet())
 			{
-				list.add(id.toString());
+                list.add(UuidConverter.encodeUuid(id));
 			}
 		}
         else if (args.length == 3)
@@ -79,7 +80,7 @@ public class QuestCommandComplete extends QuestCommandBase
 		
 		String pName = uuid == null? "NULL" : NameCache.INSTANCE.getName(uuid);
 		
-        UUID id = UUID.fromString(args[1].trim());
+        UUID id = UuidConverter.decodeUuid(args[1].trim());
         IQuest quest = QuestDatabase.INSTANCE.get(id);
         if (quest == null)
         {

--- a/src/main/java/betterquesting/commands/admin/QuestCommandDefaults.java
+++ b/src/main/java/betterquesting/commands/admin/QuestCommandDefaults.java
@@ -7,6 +7,7 @@ import betterquesting.api.questing.IQuestLine;
 import betterquesting.api.storage.BQ_Settings;
 import betterquesting.api.utils.JsonHelper;
 import betterquesting.api.utils.NBTConverter;
+import betterquesting.api.utils.UuidConverter;
 import betterquesting.api2.utils.QuestTranslation;
 import betterquesting.commands.QuestCommandBase;
 import betterquesting.core.BetterQuesting;
@@ -143,11 +144,17 @@ public class QuestCommandDefaults extends QuestCommandBase {
 
     public static void save(@Nullable ICommandSender sender, @Nullable String databaseName, File dataDir) {
         BiFunction<String, UUID, String> buildFileName =
-                // "\u00a7" is "§". As of the time of this writing, we MUST NOT include "§" in our
-                // string literals, because it is somehow getting turned into Japanese at runtime.
-                //
                 // Remove chat formatting, as well as simplifying names for use in file paths.
-                (name, id) -> name.replaceAll("\u00a7[0-9a-fk-or]", "").replaceAll("[^a-zA-Z0-9]", "") + "-" + id;
+                (name, id) ->
+                        String.format(
+                                "%s-%s",
+                                name
+                                        // As of the time of this writing, we MUST NOT include "§"
+                                        // in our string literals, because it is somehow getting
+                                        // turned into Japanese at runtime. "\u00a7" is "§".
+                                        .replaceAll("\u00a7[0-9a-fk-or]", "")
+                                        .replaceAll("[^a-zA-Z0-9]", ""),
+                                UuidConverter.encodeUuid(id));
 
         File settingsFile = new File(dataDir, SETTINGS_FILE);
         if (dataDir.exists()) {

--- a/src/main/java/betterquesting/commands/admin/QuestCommandDefaults.java
+++ b/src/main/java/betterquesting/commands/admin/QuestCommandDefaults.java
@@ -29,6 +29,7 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.ChatComponentTranslation;
+import net.minecraft.util.EnumChatFormatting;
 import net.minecraftforge.common.util.Constants;
 import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.Level;
@@ -143,7 +144,7 @@ public class QuestCommandDefaults extends QuestCommandBase {
 
     public static void save(@Nullable ICommandSender sender, @Nullable String databaseName, File dataDir) {
         BiFunction<String, String, String> buildFileName =
-                (name, id) -> name.replaceAll("[^a-zA-Z0-9]", "") + "-" + id;
+                (name, id) -> EnumChatFormatting.getTextWithoutFormattingCodes(name).replaceAll("[^a-zA-Z0-9]", "") + "-" + id;
 
         File settingsFile = new File(dataDir, SETTINGS_FILE);
         if (dataDir.exists()) {

--- a/src/main/java/betterquesting/commands/admin/QuestCommandDelete.java
+++ b/src/main/java/betterquesting/commands/admin/QuestCommandDelete.java
@@ -2,6 +2,7 @@ package betterquesting.commands.admin;
 
 import betterquesting.api.properties.NativeProps;
 import betterquesting.api.questing.IQuest;
+import betterquesting.api.utils.UuidConverter;
 import betterquesting.commands.QuestCommandBase;
 import betterquesting.handlers.SaveLoadHandler;
 import betterquesting.network.handlers.NetChapterSync;
@@ -44,7 +45,7 @@ public class QuestCommandDelete extends QuestCommandBase
 			
 			for (UUID id : QuestDatabase.INSTANCE.keySet())
 			{
-				list.add(id.toString());
+                list.add(UuidConverter.encodeUuid(id));
 			}
 		}
 		
@@ -74,7 +75,7 @@ public class QuestCommandDelete extends QuestCommandBase
 		{
 			try
 			{
-				UUID id = UUID.fromString(args[1].trim());
+				UUID id = UuidConverter.decodeUuid(args[1].trim());
 				IQuest quest = QuestDatabase.INSTANCE.get(id);
                 NetQuestEdit.deleteQuests(Collections.singletonList(id));
 				

--- a/src/main/java/betterquesting/commands/admin/QuestCommandReset.java
+++ b/src/main/java/betterquesting/commands/admin/QuestCommandReset.java
@@ -2,6 +2,7 @@ package betterquesting.commands.admin;
 
 import betterquesting.api.properties.NativeProps;
 import betterquesting.api.questing.IQuest;
+import betterquesting.api.utils.UuidConverter;
 import betterquesting.commands.QuestCommandBase;
 import betterquesting.handlers.SaveLoadHandler;
 import betterquesting.network.handlers.NetQuestSync;
@@ -44,7 +45,7 @@ public class QuestCommandReset extends QuestCommandBase
 			
 			for (UUID id : QuestDatabase.INSTANCE.keySet())
 			{
-				list.add(id.toString());
+                list.add(UuidConverter.encodeUuid(id));
 			}
 		}
         else if (args.length == 3)
@@ -126,7 +127,7 @@ public class QuestCommandReset extends QuestCommandBase
 		{
 			try
 			{
-				UUID id = UUID.fromString(action.trim());
+				UUID id = UuidConverter.decodeUuid(action.trim());
 				IQuest quest = QuestDatabase.INSTANCE.get(id);
 				
 				if (uuid != null)

--- a/src/main/java/betterquesting/commands/client/QuestCommandShow.java
+++ b/src/main/java/betterquesting/commands/client/QuestCommandShow.java
@@ -2,6 +2,7 @@ package betterquesting.commands.client;
 
 import betterquesting.api.api.QuestingAPI;
 import betterquesting.api.questing.IQuest;
+import betterquesting.api.utils.UuidConverter;
 import betterquesting.api2.cache.QuestCache;
 import betterquesting.client.gui2.GuiQuest;
 import betterquesting.client.gui2.GuiQuestLines;
@@ -46,7 +47,7 @@ public class QuestCommandShow extends QuestCommandBase {
     public void runCommand(MinecraftServer server, CommandBase command, ICommandSender sender, String[] args) throws CommandException {
         if (sender instanceof EntityPlayerSP && args.length == 2) {
             try {
-                questId = UUID.fromString(args[1]);
+                questId = UuidConverter.decodeUuid(args[1]);
                 if (sentViaClick) {
                     sentViaClick = false;
                     Minecraft.getMinecraft().displayGuiScreen(new GuiQuest(new GuiQuestLines(null), questId));

--- a/src/main/java/betterquesting/network/handlers/NetImport.java
+++ b/src/main/java/betterquesting/network/handlers/NetImport.java
@@ -3,6 +3,7 @@ package betterquesting.network.handlers;
 import betterquesting.api.api.QuestingAPI;
 import betterquesting.api.network.QuestingPacket;
 import betterquesting.api.questing.*;
+import betterquesting.api.utils.UuidConverter;
 import betterquesting.api2.utils.Tuple2;
 import betterquesting.client.importers.ImportedQuestLines;
 import betterquesting.client.importers.ImportedQuests;
@@ -93,7 +94,7 @@ public class NetImport
             {
                 if (!remapped.containsKey(qle.getKey()))
                 {
-                    BetterQuesting.logger.error("Failed to import quest into quest line. Unable to remap ID " + qle.getKey());
+                    BetterQuesting.logger.error("Failed to import quest into quest line. Unable to remap ID " + UuidConverter.encodeUuid(qle.getKey()));
                     continue;
                 }
                 

--- a/src/main/java/betterquesting/questing/QuestDatabase.java
+++ b/src/main/java/betterquesting/questing/QuestDatabase.java
@@ -69,17 +69,17 @@ public class QuestDatabase extends UuidDatabase<IQuest> implements IQuestDatabas
 	@Override
 	public synchronized NBTTagList writeToNBT(NBTTagList nbt, @Nullable List<UUID> subset)
 	{
-		for (Map.Entry<UUID, IQuest> entry : entrySet())
+		orderedEntries().forEach(entry ->
 		{
             if (subset != null && !subset.contains(entry.getKey()))
             {
-                continue;
+                return;
             }
 			NBTTagCompound jq = new NBTTagCompound();
 			entry.getValue().writeToNBT(jq);
             NBTConverter.UuidValueType.QUEST.writeId(entry.getKey(), jq);
 			nbt.appendTag(jq);
-		}
+		});
 		
 		return nbt;
 	}

--- a/src/main/java/betterquesting/questing/QuestDatabase.java
+++ b/src/main/java/betterquesting/questing/QuestDatabase.java
@@ -3,7 +3,7 @@ package betterquesting.questing;
 import betterquesting.api.questing.IQuest;
 import betterquesting.api.questing.IQuestDatabase;
 import betterquesting.api.utils.NBTConverter;
-import betterquesting.api2.storage.IUuidDatabase;
+import betterquesting.api.utils.UuidConverter;
 import betterquesting.api2.storage.UuidDatabase;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
@@ -105,7 +105,7 @@ public class QuestDatabase extends UuidDatabase<IQuest> implements IQuestDatabas
             else if (qTag.hasKey("questID", 99))
             {
                 // This block is needed for old questbook data.
-                questID = IUuidDatabase.convertLegacyId(qTag.getInteger("questID"));
+                questID = UuidConverter.convertLegacyId(qTag.getInteger("questID"));
             }
             else
             {
@@ -147,7 +147,7 @@ public class QuestDatabase extends UuidDatabase<IQuest> implements IQuestDatabas
             else if (qTag.hasKey("questID", 99))
             {
                 // This block is needed for old player progress data.
-                questID = IUuidDatabase.convertLegacyId(qTag.getInteger("questID"));
+                questID = UuidConverter.convertLegacyId(qTag.getInteger("questID"));
             }
 
             if (questID == null)

--- a/src/main/java/betterquesting/questing/QuestInstance.java
+++ b/src/main/java/betterquesting/questing/QuestInstance.java
@@ -11,10 +11,10 @@ import betterquesting.api.questing.rewards.IReward;
 import betterquesting.api.questing.tasks.ITask;
 import betterquesting.api.utils.BigItemStack;
 import betterquesting.api.utils.NBTConverter;
+import betterquesting.api.utils.UuidConverter;
 import betterquesting.api2.cache.QuestCache;
 import betterquesting.api2.storage.DBEntry;
 import betterquesting.api2.storage.IDatabaseNBT;
-import betterquesting.api2.storage.IUuidDatabase;
 import betterquesting.api2.utils.DirtyPlayerMarker;
 import betterquesting.api2.utils.ParticipantInfo;
 import betterquesting.core.BetterQuesting;
@@ -577,7 +577,7 @@ public class QuestInstance implements IQuest
             preRequisites = new HashSet<>();
             int[] intArray = jObj.getIntArray("preRequisites");
             for (int i = 0; i < intArray.length; i++) {
-                UUID questID = IUuidDatabase.convertLegacyId(intArray[i]);
+                UUID questID = UuidConverter.convertLegacyId(intArray[i]);
                 preRequisites.add(questID);
                 legacyPrerequisiteIndex.put(i, questID);
             }

--- a/src/main/java/betterquesting/questing/QuestLine.java
+++ b/src/main/java/betterquesting/questing/QuestLine.java
@@ -11,7 +11,7 @@ import betterquesting.api.questing.IQuestLineDatabase;
 import betterquesting.api.questing.IQuestLineEntry;
 import betterquesting.api.utils.BigItemStack;
 import betterquesting.api.utils.NBTConverter;
-import betterquesting.api2.storage.IUuidDatabase;
+import betterquesting.api.utils.UuidConverter;
 import betterquesting.api2.storage.UuidDatabase;
 import betterquesting.storage.PropertyContainer;
 import net.minecraft.init.Items;
@@ -171,7 +171,7 @@ public class QuestLine extends UuidDatabase<IQuestLineEntry> implements IQuestLi
             else if (qTag.hasKey("id", 99))
             {
                 // This block is needed for old questbook data.
-                questID = IUuidDatabase.convertLegacyId(qTag.getInteger("id"));
+                questID = UuidConverter.convertLegacyId(qTag.getInteger("id"));
             }
             else
             {

--- a/src/main/java/betterquesting/questing/QuestLine.java
+++ b/src/main/java/betterquesting/questing/QuestLine.java
@@ -135,13 +135,13 @@ public class QuestLine extends UuidDatabase<IQuestLineEntry> implements IQuestLi
 		json.setTag("properties", info.writeToNBT(new NBTTagCompound()));
 		
 		NBTTagList jArr = new NBTTagList();
-		
-		for(Map.Entry<UUID, IQuestLineEntry> entry : entrySet())
+
+        orderedEntries().forEach(entry ->
 		{
 			NBTTagCompound qle = entry.getValue().writeToNBT(new NBTTagCompound());
             NBTConverter.UuidValueType.QUEST.writeId(entry.getKey(), qle);
 			jArr.appendTag(qle);
-		}
+		});
 		
 		json.setTag("quests", jArr);
 		return json;

--- a/src/main/java/betterquesting/questing/QuestLineDatabase.java
+++ b/src/main/java/betterquesting/questing/QuestLineDatabase.java
@@ -3,7 +3,7 @@ package betterquesting.questing;
 import betterquesting.api.questing.IQuestLine;
 import betterquesting.api.questing.IQuestLineDatabase;
 import betterquesting.api.utils.NBTConverter;
-import betterquesting.api2.storage.IUuidDatabase;
+import betterquesting.api.utils.UuidConverter;
 import betterquesting.api2.storage.UuidDatabase;
 import betterquesting.api2.utils.QuestLineSorter;
 import net.minecraft.nbt.NBTTagCompound;
@@ -125,7 +125,7 @@ public class QuestLineDatabase extends UuidDatabase<IQuestLine> implements IQues
             }
             else if (jql.hasKey("lineID", 99))
             {
-                lineID = IUuidDatabase.convertLegacyId(jql.getInteger("lineID"));
+                lineID = UuidConverter.convertLegacyId(jql.getInteger("lineID"));
             }
 			int order = jql.hasKey("order", 99) ? jql.getInteger("order") : -1;
 

--- a/src/main/java/betterquesting/questing/QuestLineDatabase.java
+++ b/src/main/java/betterquesting/questing/QuestLineDatabase.java
@@ -87,17 +87,17 @@ public class QuestLineDatabase extends UuidDatabase<IQuestLine> implements IQues
 	@Override
 	public NBTTagList writeToNBT(NBTTagList json, @Nullable List<UUID> subset)
 	{
-		for (Map.Entry<UUID, IQuestLine> entry : entrySet())
-		{
+		orderedEntries().forEach(entry ->
+        {
             if (subset != null && !subset.contains(entry.getKey()))
             {
-                continue;
+                return;
             }
-			NBTTagCompound jObj = entry.getValue().writeToNBT(new NBTTagCompound(), null);
+            NBTTagCompound jObj = entry.getValue().writeToNBT(new NBTTagCompound(), null);
             NBTConverter.UuidValueType.QUEST_LINE.writeId(entry.getKey(), jObj);
-			jObj.setInteger("order", getOrderIndex(entry.getKey()));
-			json.appendTag(jObj);
-		}
+            jObj.setInteger("order", getOrderIndex(entry.getKey()));
+            json.appendTag(jObj);
+        });
 		
 		return json;
 	}

--- a/src/main/java/bq_standard/rewards/RewardQuestCompletion.java
+++ b/src/main/java/bq_standard/rewards/RewardQuestCompletion.java
@@ -5,9 +5,9 @@ import betterquesting.api.api.QuestingAPI;
 import betterquesting.api.questing.IQuest;
 import betterquesting.api.questing.rewards.IReward;
 import betterquesting.api.utils.NBTConverter;
+import betterquesting.api.utils.UuidConverter;
 import betterquesting.api2.client.gui.misc.IGuiRect;
 import betterquesting.api2.client.gui.panels.IGuiPanel;
-import betterquesting.api2.storage.IUuidDatabase;
 import bq_standard.client.gui.rewards.PanelRewardQuestCompletion;
 import bq_standard.rewards.factory.FactoryRewardQuestCompletion;
 
@@ -61,7 +61,7 @@ public class RewardQuestCompletion implements IReward {
             questNum = uuid.get();
         } else if (nbt.hasKey("quest", 99)) {
             // This block is needed for old questbook data.
-            questNum = IUuidDatabase.convertLegacyId(nbt.getInteger("quest"));
+            questNum = UuidConverter.convertLegacyId(nbt.getInteger("quest"));
         } else {
             questNum = null;
         }


### PR DESCRIPTION
This PR is a follow-up to (and should be merged after):
 * https://github.com/GTNewHorizons/BetterQuesting/pull/91

Shortens UUID string encoding, and makes saved quest data more stable (NBT lists sorted by UUID), which should reduce noise in PRs.

Fixes:
 * https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/12965