### PR TITLE
add clickable URI to quest description

### DIFF
--- a/src/main/java/betterquesting/client/gui2/GuiQuest.java
+++ b/src/main/java/betterquesting/client/gui2/GuiQuest.java
@@ -405,7 +405,7 @@ public class GuiQuest extends GuiScreenCanvas implements IPEventListener, INeeds
             csDesc = new CanvasScrolling(new GuiTransform(GuiAlign.HALF_LEFT, new GuiPadding(0, 0, 16, 0), 0));
         }
         cvInner.addPanel(csDesc);
-        PanelTextBox paDesc = new PanelTextBox(new GuiRectangle(0, 0, csDesc.getTransform().getWidth(), 0), QuestTranslation.translateQuestDescription(questID, quest), true);
+        PanelTextBox paDesc = new PanelTextBox(new GuiRectangle(0, 0, csDesc.getTransform().getWidth(), 0), QuestTranslation.translateQuestDescription(questID, quest), true, true);
         paDesc.setColor(PresetColor.TEXT_MAIN.getColor());//.setFontSize(10);
         csDesc.addCulledPanel(paDesc, false);
 


### PR DESCRIPTION
Fix https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/7926

The URL is not detected automatically for clarity (but can be made to, with some minor code edit). You have to wrap the link between `[url]....[/url]`. When rendering, only stuff within the bracket will be visible. There is no implicit style change, e.g. add underline and make it blue. If you want it, you will have to do it yourself via traditional minecraft formatting codes.

While the infrasturcture is there, such "url awareness" is only enabled for quest description in quest gui. if needed, it can be easily enabled for most other places where a text is displayed.