### PR TITLE
Split up quest lines into separate files

### DIFF
--- a/src/main/java/betterquesting/api/questing/IQuestLineDatabase.java
+++ b/src/main/java/betterquesting/api/questing/IQuestLineDatabase.java
@@ -4,9 +4,11 @@ import betterquesting.api2.storage.INBTPartial;
 import betterquesting.api2.storage.IUuidDatabase;
 import net.minecraft.nbt.NBTTagList;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Stream;
 
 public interface IQuestLineDatabase extends IUuidDatabase<IQuestLine>, INBTPartial<NBTTagList, UUID>
 {
@@ -19,7 +21,29 @@ public interface IQuestLineDatabase extends IUuidDatabase<IQuestLine>, INBTParti
 	
 	int getOrderIndex(UUID lineID);
 	void setOrderIndex(UUID lineID, int index);
-	
+
+    /**
+     * Sorry for the confusing naming! This method is basically the same as
+     * {@link #orderedEntries()}, except that it returns a list instead of a stream.
+     *
+     * <p>Contents are ordered by the quest line display order.
+     */
 	List<Map.Entry<UUID, IQuestLine>> getOrderedEntries();
-	
+
+    /**
+     * Clears the database, and then sets its entries to {@code entries}.
+     * {@code entries} should be ordered, and will determine the quest line display order.
+     */
+    void setOrderedEntries(Collection<Entry<UUID, IQuestLine>> entries);
+
+    /**
+     * Sorry for the confusing naming! This method is basically the same as
+     * {@link #getOrderedEntries()}, except that it returns a stream instead of a list.
+     *
+     * <p>Contents are ordered by the quest line display order.
+     */
+    @Override
+    default Stream<Map.Entry<UUID, IQuestLine>> orderedEntries() {
+        return getOrderedEntries().stream();
+    }
 }


### PR DESCRIPTION
Split up quest lines into separate files, similar to what was done for quests. Hopefully the last format change for a while.

Note: this change is incompatible with dev quest book formats, which will still look for the `QuestLines.json` file that no longer exists. This shouldn't be a problem for anyone else, since I will update the quest book format data once this PR, and all quest book data PRs, are merged, but in case it is, you can update the format with the following steps:

1. Use old BetterQuesting version, prior to this PR
2. Copy over the latest quest book data (in old format) from HEAD into `.minecraft/config/betterquesting/DefaultQuests/`
3. `/bq_admin default load`
4. `/bq_admin default savelegacy`
5. Delete `.minecraft/config/betterquesting/DefaultQuests/` directory
6. Switch to new BetterQuesting version and restart client
7. `/bq_admin default load`
8. `/bq_admin default save`
9. Delete `.minecraft/config/betterquesting/DefaultQuests.json`
10. Latest quest book data should be saved to `.minecraft/config/betterquesting/DefaultQuests`