### PR TITLE
fix compatibility for new log4j versions

### DIFF
--- a/src/main/java/bq_standard/client/gui/panels/content/PanelItemSlotBuilder.java
+++ b/src/main/java/bq_standard/client/gui/panels/content/PanelItemSlotBuilder.java
@@ -4,7 +4,8 @@ import betterquesting.api.utils.BigItemStack;
 import betterquesting.api2.client.gui.misc.IGuiRect;
 import betterquesting.api2.client.gui.panels.content.PanelItemSlot;
 import bq_standard.core.BQ_Standard;
-import org.apache.logging.log4j.core.helpers.Assert;
+
+import java.util.Objects;
 
 public final class PanelItemSlotBuilder {
 
@@ -22,7 +23,7 @@ public final class PanelItemSlotBuilder {
     }
 
     public static PanelItemSlotBuilder forValue(BigItemStack value, IGuiRect rectangle) {
-        Assert.isNotNull(rectangle, "PanelItemSlot rectangle");
+        Objects.requireNonNull(rectangle, "PanelItemSlot rectangle");
 
         return new PanelItemSlotBuilder(value, rectangle);
     }


### PR DESCRIPTION
on my custom servers, I prefer to update log4j to the latest versions instead of various patches

in new versions this function has changed its location, which leads to incompatibility, and in general I don’t understand why to use asserts from there