### PR TITLE
Adapted Wisp entity preview but by respecting DRY principle this time.

### DIFF
--- a/src/main/java/betterquesting/api2/client/gui/panels/content/PanelEntityPreview.java
+++ b/src/main/java/betterquesting/api2/client/gui/panels/content/PanelEntityPreview.java
@@ -7,6 +7,7 @@ import betterquesting.api2.client.gui.misc.GuiRectangle;
 import betterquesting.api2.client.gui.misc.IGuiRect;
 import betterquesting.api2.client.gui.panels.IGuiPanel;
 import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityList;
 import net.minecraft.util.MathHelper;
 import org.lwjgl.opengl.GL11;
 
@@ -105,9 +106,10 @@ public class PanelEntityPreview implements IGuiPanel
 		int sizeX = bounds.getWidth();
 		int sizeY = bounds.getHeight();
 		float scale = Math.min((sizeY/2F)/entity.height, (sizeX/2F)/entity.width);
-		
-		RenderUtils.RenderEntity(bounds.getX() + sizeX/2, bounds.getY() + sizeY/2 + MathHelper.ceiling_float_int(entity.height * scale / 2F), (int)scale, yawDriver.readValue(), pitchDriver.readValue(), entity);
-		
+		float pitch = EntityList.getEntityString(entity).contains("Wisp") ? 90F : pitchDriver.readValue();
+
+		RenderUtils.RenderEntity(bounds.getX() + sizeX/2, bounds.getY() + sizeY/2 + MathHelper.ceiling_float_int(entity.height * scale / 2F), (int)scale, yawDriver.readValue(), pitch, entity);
+
 		RenderUtils.endScissor();
         GL11.glPopMatrix();
     }

--- a/src/main/java/bq_standard/client/gui/tasks/PanelTaskHunt.java
+++ b/src/main/java/bq_standard/client/gui/tasks/PanelTaskHunt.java
@@ -48,16 +48,10 @@ public class PanelTaskHunt extends CanvasMinimum {
                 .setAlignment(1)
                 .setColor(PresetColor.TEXT_MAIN.getColor()));
 
-        if (target != null) {
-            ValueFuncIO<Float> pitch;
-            if (task.idName.contains("Wisp")) {
-                pitch = new ValueFuncIO<>(() -> 90F);
-            } else {
-                pitch = new ValueFuncIO<>(() -> 15F);
-            }
+        if (target != null)
             this.addPanel(new PanelEntityPreview(new GuiTransform(GuiAlign.TOP_LEFT, 0, 16, width, 64, 0), target)
-                    .setRotationDriven(pitch, new ValueFuncIO<>(() -> (float) (Minecraft.getSystemTime() % 30000L / 30000D * 360D))));
-        }
+                    .setRotationDriven(new ValueFuncIO<>(() -> 15F), new ValueFuncIO<>(() -> (float) (Minecraft.getSystemTime() % 30000L / 30000D * 360D))));
+
         recalcSizes();
     }
 }


### PR DESCRIPTION
Trying to resolve this [#14085](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/14085) problem I have realized that this [PanelTaskHunt.java#L52](https://github.com/GTNewHorizons/BetterQuesting/blob/master/src/main/java/bq_standard/client/gui/tasks/PanelTaskHunt.java#L52) code should also be at [PanelTaskMeeting.java#L49](https://github.com/GTNewHorizons/BetterQuesting/blob/master/src/main/java/bq_standard/client/gui/tasks/PanelTaskMeeting.java#L49) and [PanelTaskInteractEntity.java#L81](https://github.com/GTNewHorizons/BetterQuesting/blob/master/src/main/java/bq_standard/client/gui/tasks/PanelTaskInteractEntity.java#L81), so by respecting DRY principle I have moved it to [PanelEntityPreview.java#L109](https://github.com/FindMeSomeFun/BetterQuesting/blob/master/src/main/java/betterquesting/api2/client/gui/panels/content/PanelEntityPreview.java#L109).