### PR TITLE
Wisp final solution

### DIFF
--- a/src/main/java/betterquesting/api/utils/RenderUtils.java
+++ b/src/main/java/betterquesting/api/utils/RenderUtils.java
@@ -145,13 +145,9 @@ public class RenderUtils
 	        GL11.glRotatef(180.0F, 0.0F, 0.0F, 1.0F);
 	        GL11.glRotatef(pitch, 1F, 0F, 0F);
 	        GL11.glRotatef(rotation, 0F, 1F, 0F);
-	        float f3 = entity.rotationYaw;
-	        float f4 = entity.rotationPitch;
 	        RenderHelper.enableStandardItemLighting();
 	        RenderManager.instance.playerViewY = 180.0F;
 	        RenderManager.instance.renderEntityWithPosYaw(entity, 0.0D, 0.0D, 0.0D, 0.0F, 1.0F);
-	        entity.rotationYaw = f3;
-	        entity.rotationPitch = f4;
 	        GL11.glDisable(GL11.GL_DEPTH_TEST);
 	        GL11.glPopMatrix();
 	        RenderHelper.disableStandardItemLighting();

--- a/src/main/java/betterquesting/api2/client/gui/GuiScreenCanvas.java
+++ b/src/main/java/betterquesting/api2/client/gui/GuiScreenCanvas.java
@@ -34,7 +34,6 @@ public class GuiScreenCanvas extends GuiScreen implements IScene
 	private boolean useMargins = true;
 	private boolean useDefaultBG = false;
 	private boolean isVolatile = false;
-	private float thePlayerPitch;
 	
 	public final GuiScreen parent;
 	
@@ -100,8 +99,6 @@ public class GuiScreenCanvas extends GuiScreen implements IScene
 	public final void initGui()
 	{
 		super.initGui();
-		// remember player's pitch for mob previews that depends on its value (Wisp mob)
-		thePlayerPitch = Minecraft.getMinecraft().thePlayer.rotationPitch;
 
 		initPanel();
 	}
@@ -110,8 +107,6 @@ public class GuiScreenCanvas extends GuiScreen implements IScene
 	public void onGuiClosed()
 	{
 		super.onGuiClosed();
-		// restore player's pitch if changed (Wisp mob)
-		Minecraft.getMinecraft().thePlayer.rotationPitch = thePlayerPitch;
 
 		Keyboard.enableRepeatEvents(false);
 	}

--- a/src/main/java/betterquesting/api2/client/gui/GuiScreenCanvas.java
+++ b/src/main/java/betterquesting/api2/client/gui/GuiScreenCanvas.java
@@ -10,6 +10,7 @@ import betterquesting.api2.client.gui.themes.presets.PresetIcon;
 import betterquesting.api2.utils.QuestTranslation;
 import betterquesting.client.BQ_Keybindings;
 import com.mojang.realmsclient.gui.ChatFormatting;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.gui.GuiButton;
 import net.minecraft.client.gui.GuiScreen;
@@ -33,6 +34,7 @@ public class GuiScreenCanvas extends GuiScreen implements IScene
 	private boolean useMargins = true;
 	private boolean useDefaultBG = false;
 	private boolean isVolatile = false;
+	private float thePlayerPitch;
 	
 	public final GuiScreen parent;
 	
@@ -98,17 +100,21 @@ public class GuiScreenCanvas extends GuiScreen implements IScene
 	public final void initGui()
 	{
 		super.initGui();
-		
+		// remember player's pitch for mob previews that depends on its value (Wisp mob)
+		thePlayerPitch = Minecraft.getMinecraft().thePlayer.rotationPitch;
+
 		initPanel();
 	}
-	
+
 	@Override
-    public void onGuiClosed()
-    {
-    	super.onGuiClosed();
-		
+	public void onGuiClosed()
+	{
+		super.onGuiClosed();
+		// restore player's pitch if changed (Wisp mob)
+		Minecraft.getMinecraft().thePlayer.rotationPitch = thePlayerPitch;
+
 		Keyboard.enableRepeatEvents(false);
-    }
+	}
 	
 	@Override
 	public void initPanel()

--- a/src/main/java/betterquesting/api2/client/gui/panels/content/PanelEntityPreview.java
+++ b/src/main/java/betterquesting/api2/client/gui/panels/content/PanelEntityPreview.java
@@ -7,6 +7,7 @@ import betterquesting.api2.client.gui.misc.GuiRectangle;
 import betterquesting.api2.client.gui.misc.IGuiRect;
 import betterquesting.api2.client.gui.panels.IGuiPanel;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.ActiveRenderInfo;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityList;
 import net.minecraft.util.MathHelper;
@@ -105,18 +106,26 @@ public class PanelEntityPreview implements IGuiPanel
 		int sizeX = bounds.getWidth();
 		int sizeY = bounds.getHeight();
 		float scale = Math.min((sizeY/2F)/entity.height, (sizeX/2F)/entity.width);
+		float thePlayerPitch = Minecraft.getMinecraft().thePlayer.rotationPitch;
 		float pitch;
 		if (EntityList.getEntityString(entity).contains("Wisp")) {
-			Minecraft.getMinecraft().thePlayer.rotationPitch = 90F;
+			changeTheCameraPitch(90F);
 			pitch = 90F;
 		} else
 			pitch = pitchDriver.readValue();
 
 		RenderUtils.RenderEntity(bounds.getX() + sizeX/2, bounds.getY() + sizeY/2 + MathHelper.ceiling_float_int(entity.height * scale / 2F), (int)scale, yawDriver.readValue(), pitch, entity);
-
 		RenderUtils.endScissor();
 		GL11.glPopMatrix();
+
+		changeTheCameraPitch(thePlayerPitch);
     }
+
+	private void changeTheCameraPitch(float pitch) {
+		Minecraft.getMinecraft().thePlayer.rotationPitch = pitch;
+		ActiveRenderInfo.updateRenderInfo(Minecraft.getMinecraft().thePlayer,
+				Minecraft.getMinecraft().gameSettings.thirdPersonView == 2);
+	}
 	
 	@Override
 	public boolean onMouseClick(int mx, int my, int click)

--- a/src/main/java/betterquesting/api2/client/gui/panels/content/PanelEntityPreview.java
+++ b/src/main/java/betterquesting/api2/client/gui/panels/content/PanelEntityPreview.java
@@ -118,7 +118,8 @@ public class PanelEntityPreview implements IGuiPanel
 		RenderUtils.endScissor();
 		GL11.glPopMatrix();
 
-		changeTheCameraPitch(thePlayerPitch);
+		if (thePlayerPitch != Minecraft.getMinecraft().thePlayer.rotationPitch)
+			changeTheCameraPitch(thePlayerPitch);
     }
 
 	private void changeTheCameraPitch(float pitch) {

--- a/src/main/java/betterquesting/api2/client/gui/panels/content/PanelEntityPreview.java
+++ b/src/main/java/betterquesting/api2/client/gui/panels/content/PanelEntityPreview.java
@@ -6,6 +6,7 @@ import betterquesting.api2.client.gui.controls.io.ValueFuncIO;
 import betterquesting.api2.client.gui.misc.GuiRectangle;
 import betterquesting.api2.client.gui.misc.IGuiRect;
 import betterquesting.api2.client.gui.panels.IGuiPanel;
+import net.minecraft.client.Minecraft;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityList;
 import net.minecraft.util.MathHelper;
@@ -93,25 +94,28 @@ public class PanelEntityPreview implements IGuiPanel
 	public void drawPanel(int mx, int my, float partialTick)
     {
         if(entity == null)
-        {
             return;
-        }
-        
-        IGuiRect bounds = this.getTransform();
-        GL11.glPushMatrix();
-        RenderUtils.startScissor(new GuiRectangle(bounds));
-		
+
+		IGuiRect bounds = this.getTransform();
+		GL11.glPushMatrix();
+		RenderUtils.startScissor(new GuiRectangle(bounds));
+
 		GL11.glColor4f(1F, 1F, 1F, 1F);
-		
+
 		int sizeX = bounds.getWidth();
 		int sizeY = bounds.getHeight();
 		float scale = Math.min((sizeY/2F)/entity.height, (sizeX/2F)/entity.width);
-		float pitch = EntityList.getEntityString(entity).contains("Wisp") ? 90F : pitchDriver.readValue();
+		float pitch;
+		if (EntityList.getEntityString(entity).contains("Wisp")) {
+			Minecraft.getMinecraft().thePlayer.rotationPitch = 90F;
+			pitch = 90F;
+		} else
+			pitch = pitchDriver.readValue();
 
 		RenderUtils.RenderEntity(bounds.getX() + sizeX/2, bounds.getY() + sizeY/2 + MathHelper.ceiling_float_int(entity.height * scale / 2F), (int)scale, yawDriver.readValue(), pitch, entity);
 
 		RenderUtils.endScissor();
-        GL11.glPopMatrix();
+		GL11.glPopMatrix();
     }
 	
 	@Override


### PR DESCRIPTION
I tried to export quests with NESQL Exporter in 2.3.6 just to check if everything was ok and the Wisp's model was empty. Then I checked the questbook, and it was missing there too. So after some WTF moments and some digging around, I realized that the Wisp's model rendering respects the player's pitch. You can confirm this in earlier versions by looking at the Wisp's model with a different vertical angle.

When I made the last two changes, I used a map that I use for NESQL Exporter where the player always looks at its feet.
To get Wisp's model preview to rotate around the Y axis, it needs to be positioned horizontally (pitch 90 degrees), but its preview also depends on the player's pitch, so it also needs to be 90 degrees. So for a preview to be fully visible like it is in the game, the player needs to look at its feet too.

The consequence of this is that opening the Wisp's preview will change the player's pitch. So to be able to restore the player's pitch to its initial state, we need to remember its value when the questbook GUI opens and restore it after the GUI closes.

There might be another solution that I do not know of, but for me, this is the easiest one.