### PR TITLE
Add Formatting Macros for Quest Descriptions

### DIFF
--- a/src/main/java/betterquesting/api2/client/gui/panels/content/PanelTextBox.java
+++ b/src/main/java/betterquesting/api2/client/gui/panels/content/PanelTextBox.java
@@ -56,9 +56,9 @@ public class PanelTextBox implements IGuiPanel
 			"betterquesting:overworld", "§b");
 
 	private static final ImmutableMap<String, String> questReferenceColors = ImmutableMap.of(
-			"betterquesting:dark", "§a§n",
-			"betterquesting:stronghold", "§a§n",
-			"betterquesting:overworld", "§a§n");
+			"betterquesting:dark", "§a§l",
+			"betterquesting:stronghold", "§a§l",
+			"betterquesting:overworld", "§a§l");
 
 	private static final Pattern urlTagStart = Pattern.compile("\\[url]");
 	private static final Pattern warningTagStart = Pattern.compile("\\[warn]");
@@ -115,7 +115,7 @@ public class PanelTextBox implements IGuiPanel
 			String urlColor = urlColors.getOrDefault(currentTheme, "§1§n"); // default dark blue + underlined
 			String warningColor = warningColors.getOrDefault(currentTheme, "§4"); // default dark red
 			String noteColor = noteColors.getOrDefault(currentTheme, "§3"); // default dark aqua
-			String questRefColor = questReferenceColors.getOrDefault(currentTheme, "§2§n"); // default dark green + underlined
+			String questRefColor = questReferenceColors.getOrDefault(currentTheme, "§2§l"); // default dark green + bold
 
 			this.rawText = text;
 			coloredText = warningTagStart.matcher(text).replaceAll(warningColor);

--- a/src/main/java/betterquesting/api2/client/gui/panels/content/PanelTextBox.java
+++ b/src/main/java/betterquesting/api2/client/gui/panels/content/PanelTextBox.java
@@ -9,6 +9,7 @@ import betterquesting.api2.client.gui.panels.IGuiPanel;
 import betterquesting.api2.client.gui.resources.colors.GuiColorStatic;
 import betterquesting.api2.client.gui.resources.colors.IGuiColor;
 import betterquesting.core.BetterQuesting;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.FontRenderer;
@@ -37,6 +38,33 @@ public class PanelTextBox implements IGuiPanel
 	private final GuiRectText transform;
 	private final List<HotZone> hotZones = new ArrayList<>();
 	private boolean enabled = true;
+
+	// List of colors set for specific themes, usually dark ones, to improve readability
+	private static final ImmutableMap<String, String> urlColors = ImmutableMap.of(
+			"betterquesting:dark", "§9§n",
+			"betterquesting:stronghold", "§9§n",
+			"betterquesting:overworld", "§9§n");
+
+	private static final ImmutableMap<String, String> warningColors = ImmutableMap.of(
+			"betterquesting:dark", "§c",
+			"betterquesting:stronghold", "§c",
+			"betterquesting:overworld", "§c");
+
+	private static final ImmutableMap<String, String> noteColors = ImmutableMap.of(
+			"betterquesting:stronghold", "§b",
+			"betterquesting:ender", "§b",
+			"betterquesting:overworld", "§b");
+
+	private static final ImmutableMap<String, String> questReferenceColors = ImmutableMap.of(
+			"betterquesting:dark", "§a§n",
+			"betterquesting:stronghold", "§a§n",
+			"betterquesting:overworld", "§a§n");
+
+	private static final Pattern urlTagStart = Pattern.compile("\\[url]");
+	private static final Pattern warningTagStart = Pattern.compile("\\[warn]");
+	private static final Pattern noteTagStart = Pattern.compile("\\[note]");
+	private static final Pattern questRefTagStart = Pattern.compile("\\[quest]");
+	private static final Pattern allTagEnds = Pattern.compile("\\[/url]|\\[/warn]|\\[/note]|\\[/quest]");
 
 	private String text = "", rawText = "";
 	private boolean shadow = false;
@@ -82,8 +110,19 @@ public class PanelTextBox implements IGuiPanel
 	{
 		if(hyperlinkAware)
 		{
+			String coloredText = "";
+			String currentTheme = BQ_Settings.curTheme;
+			String urlColor = urlColors.getOrDefault(currentTheme, "§1§n"); // default dark blue + underlined
+			String warningColor = warningColors.getOrDefault(currentTheme, "§4"); // default dark red
+			String noteColor = noteColors.getOrDefault(currentTheme, "§3"); // default dark aqua
+			String questRefColor = questReferenceColors.getOrDefault(currentTheme, "§2§n"); // default dark green + underlined
+
 			this.rawText = text;
-			this.text = url.matcher(text).replaceAll("$1");
+			coloredText = warningTagStart.matcher(text).replaceAll(warningColor);
+			coloredText = noteTagStart.matcher(coloredText).replaceAll(noteColor);
+			coloredText = questRefTagStart.matcher(coloredText).replaceAll(questRefColor);
+			coloredText = urlTagStart.matcher(coloredText).replaceAll(urlColor);
+			this.text = allTagEnds.matcher(coloredText).replaceAll("§r");
 		} else
 		{
 			this.text = text;

--- a/src/main/java/betterquesting/api2/client/gui/panels/content/PanelTextBox.java
+++ b/src/main/java/betterquesting/api2/client/gui/panels/content/PanelTextBox.java
@@ -56,9 +56,9 @@ public class PanelTextBox implements IGuiPanel
 			"betterquesting:overworld", "§b");
 
 	private static final ImmutableMap<String, String> questReferenceColors = ImmutableMap.of(
-			"betterquesting:dark", "§a§l",
-			"betterquesting:stronghold", "§a§l",
-			"betterquesting:overworld", "§a§l");
+			"betterquesting:dark", "§a§n",
+			"betterquesting:stronghold", "§a§n",
+			"betterquesting:overworld", "§a§n");
 
 	private static final Pattern urlTagStart = Pattern.compile("\\[url]");
 	private static final Pattern warningTagStart = Pattern.compile("\\[warn]");
@@ -115,7 +115,7 @@ public class PanelTextBox implements IGuiPanel
 			String urlColor = urlColors.getOrDefault(currentTheme, "§1§n"); // default dark blue + underlined
 			String warningColor = warningColors.getOrDefault(currentTheme, "§4"); // default dark red
 			String noteColor = noteColors.getOrDefault(currentTheme, "§3"); // default dark aqua
-			String questRefColor = questReferenceColors.getOrDefault(currentTheme, "§2§l"); // default dark green + bold
+			String questRefColor = questReferenceColors.getOrDefault(currentTheme, "§2§n"); // default dark green + bold
 
 			this.rawText = text;
 			coloredText = warningTagStart.matcher(text).replaceAll(warningColor);

--- a/src/main/java/betterquesting/client/gui2/editors/GuiTextEditor.java
+++ b/src/main/java/betterquesting/client/gui2/editors/GuiTextEditor.java
@@ -70,9 +70,22 @@ public class GuiTextEditor extends GuiScreenCanvas implements IPEventListener, I
         cvBackground.addPanel(cvFormatList);
         
         EnumChatFormatting[] tfValues = EnumChatFormatting.values();
+        // Specify how many macro buttons are manually added, before the buttons for the default colors and formatting
+        int macroCount = 10;
+
+        cvFormatList.addPanel(new PanelButtonStorage<>(new GuiRectangle(0, 16 * 0, 100, 16), 1, "§9§nHyperlink§r", "§9§n[url][/url]§r"));
+        cvFormatList.addPanel(new PanelButtonStorage<>(new GuiRectangle(0, 16 * 1, 100, 16), 1, "§3PS:§r", "§3PS: text§r"));
+        cvFormatList.addPanel(new PanelButtonStorage<>(new GuiRectangle(0, 16 * 2, 100, 16), 1, "§cNote§r", "§cNote: text§r"));
+        cvFormatList.addPanel(new PanelButtonStorage<>(new GuiRectangle(0, 16 * 3, 100, 16), 1, "§4§lWarning§r", "§4§lWARNING:§r§4 text§r"));
+        cvFormatList.addPanel(new PanelButtonStorage<>(new GuiRectangle(0, 16 * 4, 100, 16), 1, "§6§oKeyword§r", "§6§otext§r"));
+        cvFormatList.addPanel(new PanelButtonStorage<>(new GuiRectangle(0, 16 * 5, 100, 16), 1, "§2Positive Focus§r", "§2text§r"));
+        cvFormatList.addPanel(new PanelButtonStorage<>(new GuiRectangle(0, 16 * 6, 100, 16), 1, "§5Neutral Focus§r", "§5text§r"));
+        cvFormatList.addPanel(new PanelButtonStorage<>(new GuiRectangle(0, 16 * 7, 100, 16), 1, "§2§nEU Gained§r", "§2§n100 EU§r"));
+        cvFormatList.addPanel(new PanelButtonStorage<>(new GuiRectangle(0, 16 * 8, 100, 16), 1, "§c§nEU Spent§r", "§c§n100 EU§r"));
+        cvFormatList.addPanel(new PanelButtonStorage<>(new GuiRectangle(0, 16 * 9, 100, 16), 1, "§d§oRecipe Time§r", "§d§o100s§r"));
         for(int i = 0; i < tfValues.length; i++)
         {
-            cvFormatList.addPanel(new PanelButtonStorage<>(new GuiRectangle(0, i * 16, 100, 16), 1, tfValues[i].getFriendlyName(), tfValues[i].toString()));
+            cvFormatList.addPanel(new PanelButtonStorage<>(new GuiRectangle(0, (i + macroCount) * 16, 100, 16), 1, tfValues[i].getFriendlyName(), tfValues[i].toString()));
         }
     
         PanelVScrollBar scFormatScroll = new PanelVScrollBar(new GuiTransform(GuiAlign.RIGHT_EDGE, new GuiPadding(0, 0, -8, 0), 0));

--- a/src/main/java/betterquesting/client/gui2/editors/GuiTextEditor.java
+++ b/src/main/java/betterquesting/client/gui2/editors/GuiTextEditor.java
@@ -71,18 +71,13 @@ public class GuiTextEditor extends GuiScreenCanvas implements IPEventListener, I
         
         EnumChatFormatting[] tfValues = EnumChatFormatting.values();
         // Specify how many macro buttons are manually added, before the buttons for the default colors and formatting
-        int macroCount = 10;
+        int macroCount = 4;
 
-        cvFormatList.addPanel(new PanelButtonStorage<>(new GuiRectangle(0, 16 * 0, 100, 16), 1, "§9§nHyperlink§r", "§9§n[url][/url]§r"));
-        cvFormatList.addPanel(new PanelButtonStorage<>(new GuiRectangle(0, 16 * 1, 100, 16), 1, "§3PS:§r", "§3PS: text§r"));
-        cvFormatList.addPanel(new PanelButtonStorage<>(new GuiRectangle(0, 16 * 2, 100, 16), 1, "§cNote§r", "§cNote: text§r"));
-        cvFormatList.addPanel(new PanelButtonStorage<>(new GuiRectangle(0, 16 * 3, 100, 16), 1, "§4§lWarning§r", "§4§lWARNING:§r§4 text§r"));
-        cvFormatList.addPanel(new PanelButtonStorage<>(new GuiRectangle(0, 16 * 4, 100, 16), 1, "§6§oKeyword§r", "§6§otext§r"));
-        cvFormatList.addPanel(new PanelButtonStorage<>(new GuiRectangle(0, 16 * 5, 100, 16), 1, "§2Positive Focus§r", "§2text§r"));
-        cvFormatList.addPanel(new PanelButtonStorage<>(new GuiRectangle(0, 16 * 6, 100, 16), 1, "§5Neutral Focus§r", "§5text§r"));
-        cvFormatList.addPanel(new PanelButtonStorage<>(new GuiRectangle(0, 16 * 7, 100, 16), 1, "§2§nEU Gained§r", "§2§n100 EU§r"));
-        cvFormatList.addPanel(new PanelButtonStorage<>(new GuiRectangle(0, 16 * 8, 100, 16), 1, "§c§nEU Spent§r", "§c§n100 EU§r"));
-        cvFormatList.addPanel(new PanelButtonStorage<>(new GuiRectangle(0, 16 * 9, 100, 16), 1, "§d§oRecipe Time§r", "§d§o100s§r"));
+        cvFormatList.addPanel(new PanelButtonStorage<>(new GuiRectangle(0, 16 * 0, 100, 16), 2, "§9§nHyperlink§r", "[url] [/url]"));
+        cvFormatList.addPanel(new PanelButtonStorage<>(new GuiRectangle(0, 16 * 1, 100, 16), 2, "§4§lWarning§r", "[warn] [/warn]"));
+        cvFormatList.addPanel(new PanelButtonStorage<>(new GuiRectangle(0, 16 * 2, 100, 16), 2, "§3Note§r", "[note] [/note]"));
+        cvFormatList.addPanel(new PanelButtonStorage<>(new GuiRectangle(0, 16 * 3, 100, 16), 2, "§2§nQuest Title§r", "[quest] [/quest]"));
+
         for(int i = 0; i < tfValues.length; i++)
         {
             cvFormatList.addPanel(new PanelButtonStorage<>(new GuiRectangle(0, (i + macroCount) * 16, 100, 16), 1, tfValues[i].getFriendlyName(), tfValues[i].toString()));
@@ -115,6 +110,11 @@ public class GuiTextEditor extends GuiScreenCanvas implements IPEventListener, I
         } else if(btn.getButtonID() == 1 && btn instanceof PanelButtonStorage)
         {
             String format = ((PanelButtonStorage<String>)btn).getStoredValue();
+            flText.writeText(format);
+        }else if(btn.getButtonID() == 2 && btn instanceof PanelButtonStorage)
+        {
+            String[] tagPair = ((PanelButtonStorage<String>)btn).getStoredValue().split(" ");
+            String format = tagPair[0] + flText.getSelectedText() + tagPair[1];
             flText.writeText(format);
         }
     }

--- a/src/main/resources/assets/betterquesting/bq_themes.json
+++ b/src/main/resources/assets/betterquesting/bq_themes.json
@@ -1485,6 +1485,16 @@
         "padding": [11, 11, 11, 11],
         "sliceMode": 2
       }
+    },
+    "colors": {
+      "betterquesting:text_header": {
+        "colorType": "betterquesting:color_static",
+        "color": "FF000000"
+      },
+      "betterquesting:text_main": {
+        "colorType": "betterquesting:color_static",
+        "color": "FF000000"
+      }
     }
   },
   {


### PR DESCRIPTION
![GIF 01-12-2023 15-21-51](https://github.com/Funwayguy/BetterQuesting/assets/70096037/2aa356e7-7ad6-4591-be94-64c2b36793f7)

This PR adds new options in the text formatting of quest descriptions. Instead of using the previously added buttons to [format text with color and some extra options, as done by vanilla Minecraft text formatting rules](https://minecraft.fandom.com/wiki/Formatting_codes), these new buttons add a block of text with specific formatting, so that devs can follow a standard of formatting. [In the developer's guide for making quests](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/tree/master/config/betterquesting), there are only three colors mentioned, all of which are included here: dark red for warnings, dark aqua for "PS:" entries and default for the rest of the text. On top of that, hyperlinks are supposed to be underlined and colored dark-blue, although I set the color here to blue because it's easier to read in dark themes.

<details>
  <summary>Example of formatted text in various BQ themes</summary>
  
![2023-12-01_15 18 49](https://github.com/Funwayguy/BetterQuesting/assets/70096037/324c3b77-2f81-4b12-87df-ed1fb5e7261c)
![2023-12-01_15 18 50](https://github.com/Funwayguy/BetterQuesting/assets/70096037/5f61e6be-1e7e-45d5-a31d-25d0dc90f50a)
![2023-12-01_15 18 57](https://github.com/Funwayguy/BetterQuesting/assets/70096037/14c90491-0cc1-48c6-91ef-0f7306e9962d)
![2023-12-01_15 18 58](https://github.com/Funwayguy/BetterQuesting/assets/70096037/c0497a59-2f2a-413d-b7b6-e87b6271689e)
![2023-12-01_15 19 06](https://github.com/Funwayguy/BetterQuesting/assets/70096037/daaf7257-04da-4f98-8c51-0c9c96a60d3d)
![2023-12-01_15 19 07](https://github.com/Funwayguy/BetterQuesting/assets/70096037/dee4d19e-bb54-45e5-ba92-53bdf433c1fb)
![2023-12-01_15 19 14](https://github.com/Funwayguy/BetterQuesting/assets/70096037/fa49af26-ede9-486d-a968-3a699b4237a8)
![2023-12-01_15 19 15](https://github.com/Funwayguy/BetterQuesting/assets/70096037/4fc89d0e-51f6-43a4-8012-b757a4635c4f)

</details>

Note: the formatting decisions in this example are something I came up in the moment. We don't have any rules for how to format descriptions aside from the three colors. Standardizing quest formatting is a topic that can be discussed.