### PR TITLE
Fix quest completion notification causing black screen

### DIFF
--- a/src/main/java/betterquesting/client/QuestNotification.java
+++ b/src/main/java/betterquesting/client/QuestNotification.java
@@ -64,6 +64,12 @@ public class QuestNotification {
             return;
         }
 
+        float alpha = notice.getTime() <= 4F ? Math.min(1F, notice.getTime()) : Math.max(0F, 5F - notice.getTime());
+        alpha = MathHelper.clamp_float(alpha, 0.02F, 1F);
+        final int color = new Color(1F, 1F, 1F, alpha).getRGB();
+
+        if (alpha < 0.2F) return;
+
         GL11.glPushMatrix();
         {
             final float scale = width > 600 ? 1.5F : 1F;
@@ -72,11 +78,7 @@ public class QuestNotification {
             width = MathHelper.ceiling_float_int(width / scale);
             height = MathHelper.ceiling_float_int(height / scale);
 
-            float alpha = notice.getTime() <= 4F ? Math.min(1F, notice.getTime()) : Math.max(0F, 5F - notice.getTime());
-            alpha = MathHelper.clamp_float(alpha, 0.02F, 1F);
-            final int color = new Color(1F, 1F, 1F, alpha).getRGB();
-
-            if (notice.icon != null && alpha > 0.2F) {
+            if (notice.icon != null) {
                 RenderUtils.RenderItemStack(mc, notice.icon, width / 2 - 8, height / 4 - 20, "", color);
             }
 

--- a/src/main/java/betterquesting/client/QuestNotification.java
+++ b/src/main/java/betterquesting/client/QuestNotification.java
@@ -80,14 +80,14 @@ public class QuestNotification {
                 RenderUtils.RenderItemStack(mc, notice.icon, width / 2 - 8, height / 4 - 20, "", color);
             }
 
+            GL11.glEnable(GL11.GL_BLEND);
+            GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
             String tmp = EnumChatFormatting.UNDERLINE + "" + EnumChatFormatting.BOLD + QuestTranslation.translate(notice.mainTxt);
             int txtW = RenderUtils.getStringWidth(tmp, mc.fontRenderer);
             mc.fontRenderer.drawString(tmp, width / 2 - txtW / 2, height / 4, color, true);
-
             tmp = QuestTranslation.translate(notice.subTxt);
             txtW = RenderUtils.getStringWidth(tmp, mc.fontRenderer);
             mc.fontRenderer.drawString(tmp, width / 2 - txtW / 2, height / 4 + 12, color, true);
-
             GL11.glColor4f(1F, 1F, 1F, 1F);
         }
         GL11.glPopMatrix();


### PR DESCRIPTION
Partial revert of: https://github.com/GTNewHorizons/BetterQuesting/pull/124

Reported 7 years ago here: https://github.com/Funwayguy/BetterQuesting/issues/75
Fixed by original maintainer here: https://github.com/Funwayguy/BetterQuesting/commit/9cda540a5e7779f6561c44a734fd3006cde63eea

Not blending causes black screen and disabling blend at the end causes black screen... I don't get it but I can no longer reproduce.

Also makes the notification text disappear at the same time as the icon.

Closes: https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/15193