### PR TITLE
unrestrictAdminCommands Config Option

### DIFF
--- a/src/main/java/betterquesting/api/storage/BQ_Settings.java
+++ b/src/main/java/betterquesting/api/storage/BQ_Settings.java
@@ -38,4 +38,6 @@ public class BQ_Settings
 	public static boolean alwaysDrawImplicit = false;
 	public static boolean urlDebug = false;
 	public static boolean loadDefaultsOnStartup = true;
+
+	public static boolean unrestrictAdminCommands = false;
 }

--- a/src/main/java/betterquesting/commands/BQ_CommandAdmin.java
+++ b/src/main/java/betterquesting/commands/BQ_CommandAdmin.java
@@ -11,6 +11,8 @@ import betterquesting.commands.admin.QuestCommandLives;
 import betterquesting.commands.admin.QuestCommandPurge;
 import betterquesting.commands.admin.QuestCommandReportAllProgress;
 import betterquesting.commands.admin.QuestCommandReset;
+import drethic.questbook.config.QBConfig;
+
 import cpw.mods.fml.common.FMLCommonHandler;
 import net.minecraft.command.CommandBase;
 import net.minecraft.command.ICommandSender;
@@ -103,6 +105,13 @@ public class BQ_CommandAdmin extends CommandBase
     {
         return 2;
     }
+
+	@Override
+	public boolean canCommandSenderUseCommand(ICommandSender sender)
+	{
+		if(QBConfig.unrestrictAdminCommands) return true;
+		else return super.canCommandSenderUseCommand(sender);
+	}
 
 	@Override
 	public void processCommand(ICommandSender sender, String[] args)

--- a/src/main/java/betterquesting/commands/BQ_CommandAdmin.java
+++ b/src/main/java/betterquesting/commands/BQ_CommandAdmin.java
@@ -11,12 +11,13 @@ import betterquesting.commands.admin.QuestCommandLives;
 import betterquesting.commands.admin.QuestCommandPurge;
 import betterquesting.commands.admin.QuestCommandReportAllProgress;
 import betterquesting.commands.admin.QuestCommandReset;
-import drethic.questbook.config.QBConfig;
 
+import betterquesting.handlers.ConfigHandler;
 import cpw.mods.fml.common.FMLCommonHandler;
 import net.minecraft.command.CommandBase;
 import net.minecraft.command.ICommandSender;
 import net.minecraft.command.WrongUsageException;
+import net.minecraftforge.common.config.Configuration;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -109,7 +110,7 @@ public class BQ_CommandAdmin extends CommandBase
 	@Override
 	public boolean canCommandSenderUseCommand(ICommandSender sender)
 	{
-		if(QBConfig.unrestrictAdminCommands) return true;
+		if(ConfigHandler.config.get(Configuration.CATEGORY_GENERAL,"Unrestrict Admin Commands", false).getBoolean(false)) return true;
 		else return super.canCommandSenderUseCommand(sender);
 	}
 

--- a/src/main/java/betterquesting/handlers/ConfigHandler.java
+++ b/src/main/java/betterquesting/handlers/ConfigHandler.java
@@ -47,6 +47,7 @@ public class ConfigHandler
 		BQ_Settings.alwaysDrawImplicit = config.getBoolean("Always draw implicit dependency", Configuration.CATEGORY_GENERAL, false, "If true, always draw implicit dependency. This property can be changed by the GUI");
 		BQ_Settings.urlDebug = config.getBoolean("Highlight detected clickable url hotzone.", Configuration.CATEGORY_GENERAL, false, "If true, render each hotzone using alternating color.");
 		BQ_Settings.loadDefaultsOnStartup = config.getBoolean("Load the default quest DB on world startup.", Configuration.CATEGORY_GENERAL, true, "Does an equivalent of '/bq_admin default load' on every world load");
+		BQ_Settings.unrestrictAdminCommands = config.getBoolean("Unrestrict Admin Commands", Configuration.CATEGORY_GENERAL, false, "If true, all users can use /bq_admin commands regardless of op-status. Useful for single-player without cheats.");
 
 		config.save();
 	}

--- a/src/main/java/drethic/questbook/config/QBConfig.java
+++ b/src/main/java/drethic/questbook/config/QBConfig.java
@@ -14,6 +14,7 @@ public class QBConfig {
     public static boolean spawnWithBook;
     public static boolean disablePartyNotifications;
     public static boolean disableQuestNotifications;
+    public static boolean unrestrictAdminCommands;
 
     public static final void init(FMLPreInitializationEvent e) {
         QBLogger.logger.info("Loading config file.");
@@ -29,7 +30,8 @@ public class QBConfig {
                 "[NYI]Disable party notifications.  Default: false");
         disableQuestNotifications = configBoolOption(Configuration.CATEGORY_GENERAL, "disableQuestNotifications", false,
                 "[NYI]Disable quest notifications.  Default: false");
-
+        unrestrictAdminCommands = configBoolOption(Configuration.CATEGORY_GENERAL, "unrestrictAdminCommands", false,
+                "Enable this option to let non-op players use /bq_admin commands. Useful for single-player without cheats enabled.  Default: false");
         qbconfig.save();
     }
 

--- a/src/main/java/drethic/questbook/config/QBConfig.java
+++ b/src/main/java/drethic/questbook/config/QBConfig.java
@@ -14,7 +14,6 @@ public class QBConfig {
     public static boolean spawnWithBook;
     public static boolean disablePartyNotifications;
     public static boolean disableQuestNotifications;
-    public static boolean unrestrictAdminCommands;
 
     public static final void init(FMLPreInitializationEvent e) {
         QBLogger.logger.info("Loading config file.");
@@ -30,8 +29,6 @@ public class QBConfig {
                 "[NYI]Disable party notifications.  Default: false");
         disableQuestNotifications = configBoolOption(Configuration.CATEGORY_GENERAL, "disableQuestNotifications", false,
                 "[NYI]Disable quest notifications.  Default: false");
-        unrestrictAdminCommands = configBoolOption(Configuration.CATEGORY_GENERAL, "unrestrictAdminCommands", false,
-                "Enable this option to let non-op players use /bq_admin commands. Useful for single-player without cheats enabled.  Default: false");
         qbconfig.save();
     }
 

--- a/src/main/java/drethic/questbook/config/QBConfig.java
+++ b/src/main/java/drethic/questbook/config/QBConfig.java
@@ -29,6 +29,7 @@ public class QBConfig {
                 "[NYI]Disable party notifications.  Default: false");
         disableQuestNotifications = configBoolOption(Configuration.CATEGORY_GENERAL, "disableQuestNotifications", false,
                 "[NYI]Disable quest notifications.  Default: false");
+
         qbconfig.save();
     }
 


### PR DESCRIPTION
Adds a new config option `unrestrictAdminCommands` which allows everyone to use `/bq_admin` commands when set to true without checking for permission.  
Which can be useful for single-player so you don't have to do the "_Open to LAN, enable cheats, use command, exit world, re-join world_" trick.

Uses an `@Override canCommandSenderUseCommand` similarly to how the class `BQ_CommandUser` does.
Using the ConfigHandler both client and server are handshaking nicely.