### PR TITLE
embed images

### DIFF
--- a/src/main/java/betterquesting/api2/client/gui/misc/TextureSizeHelper.java
+++ b/src/main/java/betterquesting/api2/client/gui/misc/TextureSizeHelper.java
@@ -1,0 +1,89 @@
+package betterquesting.api2.client.gui.misc;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.resources.IReloadableResourceManager;
+import net.minecraft.client.resources.IResource;
+import net.minecraft.client.resources.IResourceManager;
+import net.minecraft.client.resources.IResourceManagerReloadListener;
+import net.minecraft.util.ResourceLocation;
+
+import javax.imageio.ImageIO;
+import javax.imageio.ImageReader;
+import javax.imageio.stream.ImageInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+public class TextureSizeHelper
+{
+	private static final Map<ResourceLocation, GuiRectangle> dimensions = new HashMap<>();
+
+	static
+	{
+		//noinspection Convert2Lambda
+		((IReloadableResourceManager) Minecraft.getMinecraft().getResourceManager()).registerReloadListener(new IResourceManagerReloadListener()
+		{
+			@Override
+			public void onResourceManagerReload(IResourceManager p_110549_1_)
+			{
+				dimensions.clear();
+			}
+		});
+	}
+
+	public static IGuiRect getDimension(ResourceLocation texture)
+	{
+		if(!dimensions.containsKey(texture))
+		{
+			try
+			{
+				dimensions.put(texture, loadDimension(texture));
+			} catch(Exception e)
+			{
+				// ignore
+			}
+		}
+		GuiRectangle dimension = dimensions.get(texture);
+		if(dimension == null)
+		{
+			return new GuiRectangle(0, 0, 1, 1);  // will default to err texture, which is 1:1
+		}
+		return dimension;
+	}
+
+	private static GuiRectangle loadDimension(ResourceLocation texture) throws IOException
+	{
+		IResource resource = Minecraft.getMinecraft().getResourceManager().getResource(texture);
+		try(
+				InputStream is = resource.getInputStream();
+				ImageInputStream iis = ImageIO.createImageInputStream(is);
+		)
+		{
+			Iterator<ImageReader> readers = ImageIO.getImageReaders(iis);
+			if(!readers.hasNext())
+				return null;
+			ImageReader reader = readers.next();
+			reader.setInput(iis);
+			try
+			{
+				return new GuiRectangle(0, 0, reader.getWidth(0), reader.getHeight(0));
+			} finally
+			{
+				reader.dispose();
+			}
+		}
+	}
+
+	public static final class ResourceDimension
+	{
+		public final int height, width;
+
+		public ResourceDimension(int height, int width)
+		{
+			this.height = height;
+			this.width = width;
+		}
+	}
+}

--- a/src/main/java/betterquesting/api2/client/gui/misc/URIHandlers.java
+++ b/src/main/java/betterquesting/api2/client/gui/misc/URIHandlers.java
@@ -1,0 +1,86 @@
+package betterquesting.api2.client.gui.misc;
+
+import betterquesting.core.BetterQuesting;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiConfirmOpenLink;
+import net.minecraft.client.gui.GuiScreen;
+import net.minecraft.client.gui.GuiYesNoCallback;
+import net.minecraftforge.event.terraingen.OreGenEvent.Pre;
+
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Predicate;
+
+public class URIHandlers
+{
+	private URIHandlers()
+	{
+	}
+
+	private static final Map<String, Predicate<URI>> handlers = new ConcurrentHashMap<>();
+
+	static
+	{
+		register("http", new HTTPHandler());
+		register("https", new HTTPHandler());
+	}
+
+	public static synchronized void register(String scheme, Predicate<URI> handler)
+	{
+		if(handlers.containsKey(scheme))
+			throw new IllegalArgumentException("duplicate handler");
+		handlers.put(scheme, handler);
+	}
+
+	public static Predicate<URI> get(String scheme)
+	{
+		return handlers.get(scheme);
+	}
+
+	private static class HTTPHandler implements Predicate<URI>
+	{
+
+		@Override
+		public boolean test(URI uri)
+		{
+			if(Minecraft.getMinecraft().gameSettings.chatLinksPrompt)
+			{
+				GuiScreen oldScreen = Minecraft.getMinecraft().currentScreen;
+				// must be anonymous class. lambda doesn't work with reobf
+				//noinspection Convert2Lambda
+				Minecraft.getMinecraft().displayGuiScreen(new GuiConfirmOpenLink(new GuiYesNoCallback()
+				{
+					@Override
+					public void confirmClicked(boolean result, int id)
+					{
+						if(result)
+						{
+							openURL(uri);
+						}
+
+						Minecraft.getMinecraft().displayGuiScreen(oldScreen);
+					}
+				}, uri.toString(), 0, false));
+			} else
+			{
+				openURL(uri);
+			}
+			return true;
+		}
+
+		private static void openURL(URI p_146407_1_)
+		{
+			try
+			{
+				Class<?> oclass = Class.forName("java.awt.Desktop");
+				Object object = oclass.getMethod("getDesktop").invoke(null);
+				oclass.getMethod("browse", URI.class).invoke(object, p_146407_1_);
+			} catch(Throwable throwable)
+			{
+				BetterQuesting.logger.error("Couldn't open link", throwable);
+			}
+		}
+	}
+}

--- a/src/main/java/betterquesting/api2/client/gui/panels/content/PanelTextBox.java
+++ b/src/main/java/betterquesting/api2/client/gui/panels/content/PanelTextBox.java
@@ -5,6 +5,7 @@ import betterquesting.api.utils.RenderUtils;
 import betterquesting.api2.client.gui.misc.GuiAlign;
 import betterquesting.api2.client.gui.misc.GuiTransform;
 import betterquesting.api2.client.gui.misc.IGuiRect;
+import betterquesting.api2.client.gui.misc.URIHandlers;
 import betterquesting.api2.client.gui.panels.IGuiPanel;
 import betterquesting.api2.client.gui.resources.colors.GuiColorStatic;
 import betterquesting.api2.client.gui.resources.colors.IGuiColor;
@@ -25,6 +26,7 @@ import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -334,36 +336,15 @@ public class PanelTextBox implements IGuiPanel
 				} catch(URISyntaxException ex) {
 					return false;
 				}
-				if (!supportedUrlProtocol.contains(uri.getScheme()))
-					return false;
-				if (Minecraft.getMinecraft().gameSettings.chatLinksPrompt) {
-					// must be anonymous class. lambda doesn't work with reobf
-					GuiScreen oldScreen = Minecraft.getMinecraft().currentScreen;
-					//noinspection Convert2Lambda
-					Minecraft.getMinecraft().displayGuiScreen(new GuiConfirmOpenLink(new GuiYesNoCallback()
-					{
-						@Override
-						public void confirmClicked(boolean result, int id)
-						{
-							if (result)
-							{
-								openURL(uri);
-							}
-
-							Minecraft.getMinecraft().displayGuiScreen(oldScreen);
-						}
-					}, hotZone.url, 0, false));
-				} else {
-					openURL(uri);
-				}
-
-				return true;
+				Predicate<URI> handler = URIHandlers.get(uri.getScheme());
+				if (handler == null) return false;
+				return handler.test(uri);
 			}
 		}
 		return false;
 	}
 
-	private void openURL(URI p_146407_1_)
+	private static void openURL(URI p_146407_1_)
 	{
 		try
 		{

--- a/src/main/java/betterquesting/api2/client/gui/resources/textures/SimpleNoUVTexture.java
+++ b/src/main/java/betterquesting/api2/client/gui/resources/textures/SimpleNoUVTexture.java
@@ -1,0 +1,93 @@
+package betterquesting.api2.client.gui.resources.textures;
+
+import betterquesting.api2.client.gui.misc.IGuiRect;
+import betterquesting.api2.client.gui.resources.colors.GuiColorStatic;
+import betterquesting.api2.client.gui.resources.colors.IGuiColor;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.OpenGlHelper;
+import net.minecraft.client.renderer.Tessellator;
+import net.minecraft.util.ResourceLocation;
+import org.lwjgl.opengl.GL11;
+
+/**
+ * Like SimpleTexture, but blindly draws the entire texture without consideration over u/v
+ */
+public class SimpleNoUVTexture implements IGuiTexture
+{
+	private static final IGuiColor defColor = new GuiColorStatic(255, 255, 255, 255);
+
+	private final ResourceLocation texture;
+	private final IGuiRect texBounds;
+	private boolean maintainAspect = false;
+
+	public SimpleNoUVTexture(ResourceLocation texture, IGuiRect bounds)
+	{
+		this.texture = texture;
+		this.texBounds = bounds;
+	}
+	
+	public SimpleNoUVTexture maintainAspect(boolean enable)
+	{
+		this.maintainAspect = enable;
+		return this;
+	}
+	
+	@Override
+	public void drawTexture(int x, int y, int width, int height, float zLevel, float partialTick)
+	{
+		drawTexture(x, y, width, height, zLevel, partialTick, defColor);
+	}
+	
+	@Override
+	public void drawTexture(int x, int y, int width, int height, float zLevel, float partialTick, IGuiColor color)
+	{
+	    if(width <= 0 || height <= 0) return;
+	    
+		GL11.glPushMatrix();
+		
+		float sx = (float)width / (float)texBounds.getWidth();
+		float sy = (float)height / (float)texBounds.getHeight();
+		
+		if(maintainAspect)
+		{
+			float sa = Math.min(sx, sy);
+			float dx = (sx - sa) * texBounds.getWidth() / 2F;
+			float dy = (sy - sa) * texBounds.getHeight() / 2F;
+			sx = sa;
+			sy = sa;
+			GL11.glTranslatef(x + dx, y + dy, 0F);
+		} else
+		{
+			GL11.glTranslatef(x, y, 0F);
+		}
+
+		color.applyGlColor();
+		
+        GL11.glEnable(GL11.GL_BLEND);
+        OpenGlHelper.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA, GL11.GL_ONE, GL11.GL_ZERO);
+		
+		Minecraft.getMinecraft().renderEngine.bindTexture(texture);
+
+		Tessellator tessellator = Tessellator.instance;
+		tessellator.startDrawingQuads();
+		tessellator.addVertexWithUV(0, texBounds.getHeight() * sy, zLevel, 0, 1);
+		tessellator.addVertexWithUV(texBounds.getWidth() * sx, texBounds.getHeight() * sy, zLevel, 1, 1);
+		tessellator.addVertexWithUV(texBounds.getWidth() * sx, 0, zLevel, 1, 0);
+		tessellator.addVertexWithUV(0, 0, zLevel, 0, 0);
+		tessellator.draw();
+
+		GL11.glPopMatrix();
+	}
+	
+	@Override
+	public ResourceLocation getTexture()
+	{
+		return this.texture;
+	}
+	
+	@Override
+	public IGuiRect getBounds()
+	{
+		return this.texBounds;
+	}
+}


### PR DESCRIPTION
## Goals
- [x] render images embedded
- [x] work under other gui scale
- [ ] more image layout options, though it's not a goal to support layout options without an immediate use case. those can be added when they are needed.
- [ ] verify that it does not crash no matter what invalid quest description is given

## Non-goals
* image transforms
* responsive layout/image sizing beyond what I currently implemented
* custom quest background
* render image inline like emojis
* clickable image (as in click to zoom)
* image as hyperlink

## Misc changes
- [x] stable API to register custom URI handler. The built in http/https handler cannot be overriden.
- [x] allow specifying anchor text for urls

## syntax
current syntax is simple: `[img height=<height_in_pixels>] <resource_location>[/img]`
`height_in_pixels`: the suggested height of image. width of the image will be auto determined based on actual height and aspect ratio of image drawn. note the actual height might be smaller than this if resizing will leave some blank on vertical axis.
`resource_location`: stuff like `quest:example.png`. if you don't quite understand how resource packs works, a simple way of utilizing this feature is to put your images into `config/betterquesting/resources/gtnhquests/`. In that case, if the image to display is called `illust.png` in file explorer, then you should use `gtnhquests:illust.png` in quest description. server owners decided to add their own tasks can send the image via server resource pack.

## example
![peculiar_screenshot](https://github.com/GTNewHorizons/BetterQuesting/assets/4586901/f227401d-51bc-4ffb-8703-05e4ad748048)

