### PR TITLE
NEI text color customization with lang file

### DIFF
--- a/src/main/java/betterquesting/api2/utils/QuestTranslation.java
+++ b/src/main/java/betterquesting/api2/utils/QuestTranslation.java
@@ -6,6 +6,7 @@ import betterquesting.api.properties.NativeProps;
 import betterquesting.api.questing.IQuest;
 import betterquesting.api.questing.IQuestLine;
 import betterquesting.api.utils.UuidConverter;
+import betterquesting.core.BetterQuesting;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.util.StatCollector;
 
@@ -77,6 +78,20 @@ public class QuestTranslation {
 
     public static String translateQuestLineDescription(Map.Entry<UUID, IQuestLine> entry) {
         return translateQuestLineDescription(entry.getKey(), entry.getValue());
+    }
+
+    public static int getColor(String key) {
+        BetterQuesting.logger.warn("Getting Colors! for: " + key);
+        String hex = translate(key);
+        int color = 0x000000;
+        if (hex.length() <= 6) {
+            try {
+                color = Integer.parseUnsignedInt(hex, 16);
+            } catch (NumberFormatException e) {
+                BetterQuesting.logger.warn("Couldn't format color correctly for: " + key, e);
+            }
+        }
+        return color;
     }
 
     /**

--- a/src/main/java/betterquesting/api2/utils/QuestTranslation.java
+++ b/src/main/java/betterquesting/api2/utils/QuestTranslation.java
@@ -81,7 +81,6 @@ public class QuestTranslation {
     }
 
     public static int getColor(String key) {
-        BetterQuesting.logger.warn("Getting Colors! for: " + key);
         String hex = translate(key);
         int color = 0x000000;
         if (hex.length() <= 6) {

--- a/src/main/java/bq_standard/integration/nei/QuestRecipeHandler.java
+++ b/src/main/java/bq_standard/integration/nei/QuestRecipeHandler.java
@@ -65,6 +65,10 @@ public class QuestRecipeHandler extends TemplateRecipeHandler {
     private static final int GUI_WIDTH = 166;
     private static final int LINE_SPACE = GuiDraw.fontRenderer.FONT_HEIGHT + 1;
 
+    private Stopwatch stopwatch;
+    private int textColor;
+    private int textColorHovered;
+
     @Override
     public void loadTransferRects() {
         transferRects.add(new RecipeTransferRect(new Rectangle(75, 59, 16, 13), getOverlayIdentifier()));
@@ -73,7 +77,8 @@ public class QuestRecipeHandler extends TemplateRecipeHandler {
     @Override
     public void loadCraftingRecipes(String outputId, Object... results) {
         if (outputId.equals(getOverlayIdentifier())) {
-            Stopwatch stopwatch = Stopwatch.createStarted();
+            if (debug) stopwatch = Stopwatch.createStarted();
+            setTextColors();
             for (Map.Entry<UUID, IQuest> entry : getVisibleQuests().entrySet()) {
                 if (getTaskItemInputs(getTasks(entry.getValue())).isEmpty()
                         && getRewardItemOutputs(getRewards(entry.getValue())).isEmpty()) {
@@ -92,7 +97,8 @@ public class QuestRecipeHandler extends TemplateRecipeHandler {
 
     @Override
     public void loadCraftingRecipes(ItemStack result) {
-        Stopwatch stopwatch = Stopwatch.createStarted();
+        if (debug) stopwatch = Stopwatch.createStarted();
+        setTextColors();
         for (Map.Entry<UUID, IQuest> entry : getVisibleQuests().entrySet()) {
             for (BigItemStack compareTo : getRewardItemOutputs(getRewards(entry.getValue()))) {
                 if (matchStack(result, compareTo)) {
@@ -108,7 +114,8 @@ public class QuestRecipeHandler extends TemplateRecipeHandler {
 
     @Override
     public void loadUsageRecipes(ItemStack ingredient) {
-        Stopwatch stopwatch = Stopwatch.createStarted();
+        if (debug) stopwatch = Stopwatch.createStarted();
+        setTextColors();
         for (Map.Entry<UUID, IQuest> entry : getVisibleQuests().entrySet()) {
             for (BigItemStack compareTo : getTaskItemInputs(getTasks(entry.getValue()))) {
                 if (matchStack(ingredient, compareTo)) {
@@ -139,9 +146,9 @@ public class QuestRecipeHandler extends TemplateRecipeHandler {
 
         int color;
         if (isMouseOverTitle(recipeIndex)) {
-            color = 0xa87a5e;
+            color = textColorHovered;
         } else {
-            color = 0x000000;
+            color = textColor;
         }
 
         //noinspection unchecked
@@ -300,6 +307,11 @@ public class QuestRecipeHandler extends TemplateRecipeHandler {
                 titleWidth + 1 * 2,
                 titleHeight + 1);
         return titleArea.contains(relMousePos);
+    }
+
+    private void setTextColors() {
+        textColor = QuestTranslation.getColor("bq_standard.gui.neiQuestNameColor");
+        textColorHovered = QuestTranslation.getColor("bq_standard.gui.neiQuestNameHoveredColor");
     }
 
     private class CachedQuestRecipe extends CachedRecipe {

--- a/src/main/resources/assets/bq_standard/lang/en_US.lang
+++ b/src/main/resources/assets/bq_standard/lang/en_US.lang
@@ -53,6 +53,8 @@ bq_standard.gui.weight=Weight
 bq_standard.gui.experience=Experience
 bq_standard.gui.tame=Tame %s
 bq_standard.gui.questcompletion=Quest Completed
+bq_standard.gui.neiQuestNameColor=000000
+bq_standard.gui.neiQuestNameHoveredColor=A87A5E
 
 bq_standard.importer.dummy.name=Dummy Importer
 bq_standard.importer.dummy.desc=Does nothing but throw UnsupportedOperationException.


### PR DESCRIPTION
This PR adds the following:
- Text color customization for the quest names displayed in NEI by providing a hex color in bq_standard's `.lang` file.
- Make the debug stopwatch start only if the debug flag is set to `true`

This is deliberately not part of a theme, since it should provide a way to make text readable on custom gui textures for resource pack creators. Themes are placed in `config/betterquesting/resources` and thus are not changeable by a resource pack.