### PR TITLE
Quest line save format

### DIFF
--- a/src/main/java/betterquesting/api/questing/IQuestLine.java
+++ b/src/main/java/betterquesting/api/questing/IQuestLine.java
@@ -26,9 +26,6 @@ public interface IQuestLine extends IUuidDatabase<IQuestLineEntry>, INBTPartial<
      * we want to try to avoid merge conflicts. The fact that quests are exported to NBT in
      * sequential order (as an {@code NBTTagList}) makes this format particularly prone to merge
      * conflicts.
-     *
-     * <p>Instead of using the exported NBT to find quests belonging to a quest line, we will find
-     * them by subdirectory within the exported quests directory.
      */
     NBTTagCompound writeToNBT(NBTTagCompound json, boolean skipQuests);
 }

--- a/src/main/java/betterquesting/api/questing/IQuestLine.java
+++ b/src/main/java/betterquesting/api/questing/IQuestLine.java
@@ -3,6 +3,7 @@ package betterquesting.api.questing;
 import betterquesting.api.properties.IPropertyContainer;
 import betterquesting.api2.storage.INBTPartial;
 import betterquesting.api2.storage.IUuidDatabase;
+import net.minecraft.nbt.NBTBase;
 import net.minecraft.nbt.NBTTagCompound;
 
 import java.util.Map;
@@ -17,4 +18,17 @@ public interface IQuestLine extends IUuidDatabase<IQuestLineEntry>, INBTPartial<
 	String getUnlocalisedDescription();
 	
 	Map.Entry<UUID, IQuestLineEntry> getEntryAt(int x, int y);
+
+    /**
+     * Variant of {@link #writeToNBT(NBTBase)} which allows skipping writing quests.
+     *
+     * <p>The reason why we want to skip writing quests is that, when exporting the quest database,
+     * we want to try to avoid merge conflicts. The fact that quests are exported to NBT in
+     * sequential order (as an {@code NBTTagList}) makes this format particularly prone to merge
+     * conflicts.
+     *
+     * <p>Instead of using the exported NBT to find quests belonging to a quest line, we will find
+     * them by subdirectory within the exported quests directory.
+     */
+    NBTTagCompound writeToNBT(NBTTagCompound json, boolean skipQuests);
 }

--- a/src/main/java/betterquesting/api2/storage/UuidDatabase.java
+++ b/src/main/java/betterquesting/api2/storage/UuidDatabase.java
@@ -1,11 +1,13 @@
 package betterquesting.api2.storage;
 
+import betterquesting.api.utils.UuidConverter;
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
 import com.google.common.collect.Maps;
 
 import javax.annotation.Nullable;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
@@ -17,6 +19,10 @@ import java.util.stream.Stream;
 /** Database that uses randomly-generated UUIDs as keys. */
 public class UuidDatabase<T> implements IUuidDatabase<T> {
     private final HashBiMap<UUID, T> database = HashBiMap.create();
+
+    private int compareEntries(Map.Entry<UUID, T> e1, Map.Entry<UUID, T> e2) {
+        return UuidConverter.encodeUuid(e1.getKey()).compareTo(UuidConverter.encodeUuid(e2.getKey()));
+    }
 
     @Override
     public UUID generateKey() {
@@ -35,7 +41,7 @@ public class UuidDatabase<T> implements IUuidDatabase<T> {
 
     @Override
     public Stream<Map.Entry<UUID, T>> orderedEntries() {
-        return entrySet().stream().sorted(Map.Entry.comparingByKey());
+        return entrySet().stream().sorted(this::compareEntries);
     }
 
     @Override

--- a/src/main/java/betterquesting/commands/admin/QuestCommandDefaults.java
+++ b/src/main/java/betterquesting/commands/admin/QuestCommandDefaults.java
@@ -63,6 +63,7 @@ public class QuestCommandDefaults extends QuestCommandBase {
     public static final String LANG_FILE = "template.lang";
     public static final String SETTINGS_FILE = "QuestSettings.json";
     public static final String QUEST_LINE_DIR = "QuestLines";
+    public static final String QUEST_LINE_FILE = "QuestLine.json";
     public static final String QUEST_LINE_ORDER_FILE = "QuestLinesOrder.txt";
     public static final String QUEST_DIR = "Quests";
     public static final String MULTI_QUEST_LINE_DIRECTORY = "MultipleQuestLine";
@@ -237,7 +238,7 @@ public class QuestCommandDefaults extends QuestCommandBase {
                 return;
             }
 
-            File questLineFile = new File(questLineSubdir, "QuestLine.json");
+            File questLineFile = new File(questLineSubdir, QUEST_LINE_FILE);
             NBTTagCompound questLineTag = questLine.writeToNBT(new NBTTagCompound(), true);
             NBTConverter.UuidValueType.QUEST_LINE.writeId(questLineId, questLineTag);
             JsonHelper.WriteToFile(questLineFile, NBTConverter.NBTtoJSON_Compound(questLineTag, new JsonObject(), true));
@@ -357,7 +358,7 @@ public class QuestCommandDefaults extends QuestCommandBase {
         File questLineDir = new File(dataDir, QUEST_LINE_DIR);
         Map<UUID, IQuestLine> questLines = new HashMap<>();
         for (File questLineSubdir : questLineDir.listFiles()) {
-            File questLineFile = new File(questLineSubdir, "QuestLine.json");
+            File questLineFile = new File(questLineSubdir, QUEST_LINE_FILE);
             if (!questLineFile.exists()) {
                 QuestingAPI.getLogger().log(Level.ERROR, "Missing quest line file\n" + questLineSubdir);
                 sendChatMessage(sender, "betterquesting.cmd.error");
@@ -372,7 +373,7 @@ public class QuestCommandDefaults extends QuestCommandBase {
             questLines.put(questLineId, questLine);
 
             for (File questLineEntryFile : questLineSubdir.listFiles()) {
-                if (questLineEntryFile.getName().equals("QuestLine.json")) {
+                if (questLineEntryFile.getName().equals(QUEST_LINE_FILE)) {
                     continue;
                 }
 

--- a/src/main/java/betterquesting/commands/admin/QuestCommandDefaults.java
+++ b/src/main/java/betterquesting/commands/admin/QuestCommandDefaults.java
@@ -243,9 +243,16 @@ public class QuestCommandDefaults extends QuestCommandBase {
             JsonHelper.WriteToFile(questLineFile, NBTConverter.NBTtoJSON_Compound(questLineTag, new JsonObject(), true));
 
             for (Map.Entry<UUID, IQuestLineEntry> questLineEntry : questLine.entrySet()) {
-                File questLineEntryFile = new File(questLineSubdir, UuidConverter.encodeUuid(questLineEntry.getKey()) + ".json");
+                // Unfortunately, we must prepend the quest name to the filename.
+                // This is because Windows treats filenames which differ only in casing, as the same
+                // file. This causes problems for us as many UUIDs differ only in casing, so we must
+                // disambiguate using the quest name as a prefix.
+                UUID questId = questLineEntry.getKey();
+                String questName = QuestDatabase.INSTANCE.get(questId).getProperty(NativeProps.NAME);
+
+                File questLineEntryFile = new File(questLineSubdir, buildFileName.apply(questName, questId) + ".json");
                 NBTTagCompound questLineEntryTag = questLineEntry.getValue().writeToNBT(new NBTTagCompound());
-                NBTConverter.UuidValueType.QUEST.writeId(questLineEntry.getKey(), questLineEntryTag);
+                NBTConverter.UuidValueType.QUEST.writeId(questId, questLineEntryTag);
                 JsonHelper.WriteToFile(questLineEntryFile, NBTConverter.NBTtoJSON_Compound(questLineEntryTag, new JsonObject(), true));
             }
         }

--- a/src/main/java/betterquesting/commands/admin/QuestCommandDefaults.java
+++ b/src/main/java/betterquesting/commands/admin/QuestCommandDefaults.java
@@ -237,7 +237,7 @@ public class QuestCommandDefaults extends QuestCommandBase {
                 return;
             }
 
-            File questLineFile = new File(questLineSubdir, "questLine.json");
+            File questLineFile = new File(questLineSubdir, "QuestLine.json");
             NBTTagCompound questLineTag = questLine.writeToNBT(new NBTTagCompound(), true);
             NBTConverter.UuidValueType.QUEST_LINE.writeId(questLineId, questLineTag);
             JsonHelper.WriteToFile(questLineFile, NBTConverter.NBTtoJSON_Compound(questLineTag, new JsonObject(), true));
@@ -350,7 +350,7 @@ public class QuestCommandDefaults extends QuestCommandBase {
         File questLineDir = new File(dataDir, QUEST_LINE_DIR);
         Map<UUID, IQuestLine> questLines = new HashMap<>();
         for (File questLineSubdir : questLineDir.listFiles()) {
-            File questLineFile = new File(questLineSubdir, "questLine.json");
+            File questLineFile = new File(questLineSubdir, "QuestLine.json");
             if (!questLineFile.exists()) {
                 QuestingAPI.getLogger().log(Level.ERROR, "Missing quest line file\n" + questLineSubdir);
                 sendChatMessage(sender, "betterquesting.cmd.error");
@@ -365,7 +365,7 @@ public class QuestCommandDefaults extends QuestCommandBase {
             questLines.put(questLineId, questLine);
 
             for (File questLineEntryFile : questLineSubdir.listFiles()) {
-                if (questLineEntryFile.getName().equals("questLine.json")) {
+                if (questLineEntryFile.getName().equals("QuestLine.json")) {
                     continue;
                 }
 

--- a/src/main/java/betterquesting/questing/QuestLine.java
+++ b/src/main/java/betterquesting/questing/QuestLine.java
@@ -135,14 +135,6 @@ public class QuestLine extends UuidDatabase<IQuestLineEntry> implements IQuestLi
         return writeToNBT(json, false);
 	}
 
-    /**
-     * The reason why we want to skip writing quests is that, when exporting the quest database, we
-     * want to try to avoid merge conflicts. The fact that quests are exported in a sequential order
-     * (as an {@code NBTTagList}) makes this format particularly prone to merge conflicts.
-     *
-     * <p>Instead of using the exported NBT to find quests belonging to a quest line, we will find
-     * them by subdirectory within the exported quests directory.
-     */
     @Override
     public NBTTagCompound writeToNBT(NBTTagCompound json, boolean skipQuests)
     {


### PR DESCRIPTION
Update quest line format in saved quest data, to use separate files per entry. The current format stores all entries as a list within a single file, which has caused problems with merges in the past. As requested / discussed here:
*   https://discord.com/channels/181078474394566657/949447391587733504/1216196017742020732

The new format is, instead of a file per quest line under `QuestLines/`, we have a subdirectory for each quest line. Each subdirectory contains a file named `QuestLine.json`, which contains all of the quest line information other than quest line entries. Each quest line entry is now stored as a separate file in the subdirectory, named after the quest that the entry is for.

I also updated the sort order for UUID databases to use string comparison on the encoded strings, rather than on the UUID internal values. This is to make it easier for the i18n script to maintain the same ordering.

---

Quest book data updated in:
*   https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/pull/15749

i18n script updated in:
*   https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/pull/15750