### PR TITLE
Make searched quests more noticeable

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,8 +1,8 @@
 // Add your dependencies here
 
 dependencies {
-    implementation 'com.github.GTNewHorizons:NotEnoughItems:2.5.24-GTNH:dev'
-    compileOnly 'com.github.GTNewHorizons:DuraDisplay:1.2.2:dev'
+    implementation 'com.github.GTNewHorizons:NotEnoughItems:2.5.26-GTNH:dev'
+    compileOnly 'com.github.GTNewHorizons:DuraDisplay:1.2.3:dev'
 
     // For testing translations
     runtimeOnly 'com.github.GTNewHorizons:TX-Loader:1.7.0'

--- a/gradle.properties
+++ b/gradle.properties
@@ -50,10 +50,10 @@ enableGenericInjection = false
 # Generate a class with a String field for the mod version named as defined below.
 # If generateGradleTokenClass is empty or not missing, no such class will be generated.
 # If gradleTokenVersion is empty or missing, the field will not be present in the class.
-generateGradleTokenClass =
+generateGradleTokenClass = betterquesting.core.Tags
 
 # Name of the token containing the project's current version to generate/replace.
-gradleTokenVersion = GRADLETOKEN_VERSION
+gradleTokenVersion = VERSION
 
 # [DEPRECATED] Mod ID replacement token.
 gradleTokenModId =
@@ -70,7 +70,7 @@ gradleTokenGroupName =
 # The string's content will be replaced with your mod's version when compiled. You should use this to specify your mod's
 # version in @Mod([...], version = VERSION, [...]).
 # Leave these properties empty to skip individual token replacements.
-replaceGradleTokenInFile = BetterQuesting.java
+replaceGradleTokenInFile =
 
 # In case your mod provides an API for other mods to implement you may declare its package here. Otherwise, you can
 # leave this property empty.
@@ -117,7 +117,7 @@ minimizeShadowedDependencies = true
 # If disabled, won't rename the shadowed classes.
 relocateShadowedDependencies = true
 
-# Adds the GTNH maven, CurseMaven, IC2/Player maven, and some more well-known 1.7.10 repositories.
+# Adds the GTNH maven, CurseMaven, Modrinth, and some more well-known 1.7.10 repositories.
 includeWellKnownRepositories = true
 
 # Change these to your Maven coordinates if you want to publish to a custom Maven repository instead of the default GTNH Maven.

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,7 +17,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.17'
+    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.21'
 }
 
 

--- a/src/main/java/betterquesting/api2/client/gui/panels/lists/CanvasQuestLine.java
+++ b/src/main/java/betterquesting/api2/client/gui/panels/lists/CanvasQuestLine.java
@@ -244,4 +244,14 @@ public class CanvasQuestLine extends CanvasScrolling
         this.setScrollY(bounds.getY() + bounds.getHeight()/2);
         this.updatePanelScroll();
     }
+
+    public void centerOn(PanelButtonQuest btn)
+    {
+        int x = btn.rect.x;
+        int y = btn.rect.y;
+        int width = btn.rect.w;
+        int height = btn.rect.h;
+        this.setScrollX(x - width + lsx);
+        this.setScrollY(y + height + lsy);
+    }
 }

--- a/src/main/java/betterquesting/client/gui2/GuiQuestLines.java
+++ b/src/main/java/betterquesting/client/gui2/GuiQuestLines.java
@@ -474,7 +474,7 @@ public class GuiQuestLines extends GuiScreenCanvas implements IPEventListener, I
                         new GuiColorPulse(
                                 new GuiColorStatic(0, 0, 0, 255),
                                 new GuiColorStatic(255, 191, 0, 255),
-                                1, 0
+                                0.7, 0
                         ));
                 panelButtonQuest.setTextures(newTexture, newTexture, newTexture);
                 cvQuest.setZoom(2f);

--- a/src/main/java/betterquesting/client/gui2/GuiQuestLines.java
+++ b/src/main/java/betterquesting/client/gui2/GuiQuestLines.java
@@ -472,11 +472,13 @@ public class GuiQuestLines extends GuiScreenCanvas implements IPEventListener, I
             targetQuestButton.ifPresent(panelButtonQuest -> {
                 GuiTextureColored newTexture = new GuiTextureColored(panelButtonQuest.txFrame,
                         new GuiColorPulse(
-                                new GuiColorStatic(255, 220, 115, 255),
+                                new GuiColorStatic(0, 0, 0, 255),
                                 new GuiColorStatic(255, 191, 0, 255),
                                 1, 0
                         ));
                 panelButtonQuest.setTextures(newTexture, newTexture, newTexture);
+                cvQuest.setZoom(2f);
+                cvQuest.centerOn(panelButtonQuest);
             });
         });
 

--- a/src/main/java/betterquesting/core/BetterQuesting.java
+++ b/src/main/java/betterquesting/core/BetterQuesting.java
@@ -54,7 +54,7 @@ public class BetterQuesting
 {
     public static final String MODID = "betterquesting";
     public static final String NAME = "BetterQuesting";
-    public static final String VERSION = "GRADLETOKEN_VERSION";
+    public static final String VERSION = Tags.VERSION;
     public static final String PROXY = "betterquesting.core.proxies";
     public static final String CHANNEL = "BQ_NET_CHAN";
     public static final String FORMAT = "3.1.0";


### PR DESCRIPTION
When searching for a quest it will now zoom in fully and center the screen on the quest.
In case that doesn't make the quest obvious enough I also changed it to more clearly flash yellow instead of the very slight color change it had before.
![bq](https://github.com/GTNewHorizons/BetterQuesting/assets/127234178/ab08b9b2-85c1-4733-ba40-bf2cfe7e0dbe)

The flashing felt too slow so I made it a bit faster:
![bq_flash](https://github.com/GTNewHorizons/BetterQuesting/assets/127234178/194c868c-cbcb-408e-9fa8-3c959e7aa94a)


Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/14757
