### PR TITLE
add gui to select image on local disk

### DIFF
--- a/src/main/java/betterquesting/api2/client/gui/GuiScreenCanvas.java
+++ b/src/main/java/betterquesting/api2/client/gui/GuiScreenCanvas.java
@@ -52,13 +52,24 @@ public class GuiScreenCanvas extends GuiScreen implements IScene
 	private GuiScreen previousScreen;
 	
 	private IGuiPanel popup = null;
+	private boolean noEscape;
 	//private IGuiPanel focused = null;
 	
 	public GuiScreenCanvas(GuiScreen parent)
 	{
 		this.parent = parent;
 	}
-    
+
+	public boolean isNoEscape()
+	{
+		return noEscape;
+	}
+
+	public void setNoEscape(boolean noEscape)
+	{
+		this.noEscape = noEscape;
+	}
+
     @Override
     public void openPopup(@Nonnull IGuiPanel panel)
     {
@@ -244,7 +255,7 @@ public class GuiScreenCanvas extends GuiScreen implements IScene
 	@Override
     public void keyTyped(char c, int keyCode)
     {
-		if (keyCode == 1) // ESCAPE
+		if (keyCode == 1 && !this.noEscape) // ESCAPE
 		{
 			if(this.isVolatile || this instanceof IVolatileScreen)
 			{

--- a/src/main/java/betterquesting/api2/client/gui/popups/PopWaitExternalEvent.java
+++ b/src/main/java/betterquesting/api2/client/gui/popups/PopWaitExternalEvent.java
@@ -69,8 +69,8 @@ public class PopWaitExternalEvent<T> extends CanvasEmpty
         // there isn't an otherwise good place to poll for this..
         if (future.isDone())
         {
-            handleComplete();
             if(SceneController.getActiveScene() != null) SceneController.getActiveScene().closePopup();
+            handleComplete();
         }
     }
 

--- a/src/main/java/betterquesting/api2/client/gui/popups/PopWaitExternalEvent.java
+++ b/src/main/java/betterquesting/api2/client/gui/popups/PopWaitExternalEvent.java
@@ -1,0 +1,176 @@
+package betterquesting.api2.client.gui.popups;
+
+import betterquesting.api2.client.gui.SceneController;
+import betterquesting.api2.client.gui.misc.GuiAlign;
+import betterquesting.api2.client.gui.misc.GuiPadding;
+import betterquesting.api2.client.gui.misc.GuiTransform;
+import betterquesting.api2.client.gui.panels.CanvasEmpty;
+import betterquesting.api2.client.gui.panels.CanvasTextured;
+import betterquesting.api2.client.gui.panels.content.PanelGeneric;
+import betterquesting.api2.client.gui.panels.content.PanelTextBox;
+import betterquesting.api2.client.gui.resources.colors.GuiColorStatic;
+import betterquesting.api2.client.gui.resources.textures.ColorTexture;
+import betterquesting.api2.client.gui.resources.textures.IGuiTexture;
+import betterquesting.api2.client.gui.themes.presets.PresetTexture;
+import betterquesting.core.BetterQuesting;
+import org.lwjgl.util.vector.Vector4f;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+public class PopWaitExternalEvent<T> extends CanvasEmpty
+{
+    private String message;
+    private final IGuiTexture icon;
+    private final CompletableFuture<T> future;
+    private PanelTextBox label;
+
+    public PopWaitExternalEvent(@Nonnull String message)
+    {
+        this(message, null);
+    }
+
+    public PopWaitExternalEvent(@Nonnull String message, @Nullable IGuiTexture icon)
+    {
+        super(new GuiTransform(GuiAlign.FULL_BOX));
+        this.message = message;
+        this.icon = icon;
+        this.future = new CompletableFuture<>();
+    }
+    
+    @Override
+    public void initPanel()
+    {
+        super.initPanel();
+        
+        this.addPanel(new PanelGeneric(new GuiTransform(GuiAlign.FULL_BOX, new GuiPadding(0, 0, 0, 0), 1), new ColorTexture(new GuiColorStatic(0x80000000))));
+    
+        CanvasTextured cvBox = new CanvasTextured(new GuiTransform(new Vector4f(0.2F, 0.3F, 0.8F, 0.6F)), PresetTexture.PANEL_MAIN.getTexture());
+        this.addPanel(cvBox);
+        
+        if(icon != null)
+        {
+            CanvasTextured icoFrame = new CanvasTextured(new GuiTransform(new Vector4f(0.5F, 0.3F, 0.5F, 0.3F), -16, -40, 32, 32, 0), PresetTexture.PANEL_MAIN.getTexture());
+            this.addPanel(icoFrame);
+            
+            icoFrame.addPanel(new PanelGeneric(new GuiTransform(GuiAlign.FULL_BOX, new GuiPadding(8, 8, 8, 8), 0), icon));
+        }
+
+        label = new PanelTextBox(new GuiTransform(GuiAlign.FULL_BOX, new GuiPadding(8, 8, 8, 8), 0), message).setAlignment(1);
+        cvBox.addPanel(label);
+    }
+
+    @Override
+    public void drawPanel(int mx, int my, float partialTick)
+    {
+        super.drawPanel(mx, my, partialTick);
+        // there isn't an otherwise good place to poll for this..
+        if (future.isDone())
+        {
+            handleComplete();
+            if(SceneController.getActiveScene() != null) SceneController.getActiveScene().closePopup();
+        }
+    }
+
+    protected void handleComplete()
+    {
+
+        if (future.isCancelled())
+        {
+            onCancel();
+            return;
+        }
+	    T v;
+	    try {
+	        v = future.get();
+	    } catch(InterruptedException e) {
+	        throw new AssertionError(e);
+	    } catch(ExecutionException e) {
+	        onError(e);
+            return;
+	    }
+	    onComplete(v);
+    }
+
+    public String getMessage()
+    {
+        return message;
+    }
+
+    public void setMessage(String message)
+    {
+        this.message = message;
+        label.setText(message);
+    }
+
+    public void complete(T val) {
+        future.complete(val);
+    }
+
+    public void fail(Throwable ex) {
+        future.completeExceptionally(ex);
+    }
+
+    public void cancel() {
+        future.cancel(true);
+    }
+
+    public void ensureDone() {
+        if (!future.isDone())
+        {
+            future.cancel(true);
+        }
+    }
+
+    // impl note: these are callbacks for subclass to override
+    // it's worth mentioning that completable future and its friends does not allow stuff in pipeline to be
+    // suspended, then resumed later, or on another thread. This makes callbacks like this mandatory
+	protected void onComplete(T future)
+	{
+	}
+
+    protected void onCancel()
+    {
+    }
+
+    protected void onError(ExecutionException e)
+    {
+        BetterQuesting.logger.error("External Event Error", e);
+    }
+
+	// == TRAP ALL UI USAGE UNTIL CLOSED ===
+    
+    @Override
+    public boolean onMouseClick(int mx, int my, int click)
+    {
+        super.onMouseClick(mx, my, click);
+        
+        return true;
+    }
+    
+    @Override
+    public boolean onMouseRelease(int mx, int my, int click)
+    {
+        super.onMouseRelease(mx, my, click);
+        
+        return true;
+    }
+    
+    @Override
+    public boolean onMouseScroll(int mx, int my, int scroll)
+    {
+        super.onMouseScroll(mx, my, scroll);
+        
+        return true;
+    }
+    
+    @Override
+    public boolean onKeyTyped(char c, int keycode)
+    {
+        super.onKeyTyped(c, keycode);
+        
+        return true;
+    }
+}

--- a/src/main/java/betterquesting/client/gui2/editors/GuiQuestEditor.java
+++ b/src/main/java/betterquesting/client/gui2/editors/GuiQuestEditor.java
@@ -234,7 +234,7 @@ public class GuiQuestEditor extends GuiScreenCanvas implements IPEventListener, 
             }
             case 7: // Description Editor
             {
-                mc.displayGuiScreen(new GuiTextEditor(this, quest.getProperty(NativeProps.DESC), value -> {
+                mc.displayGuiScreen(new GuiTextEditor(this, quest.getProperty(NativeProps.DESC), true, value -> {
                     quest.setProperty(NativeProps.DESC, value);
                     SendChanges();
                 }));

--- a/src/main/java/betterquesting/client/gui2/editors/GuiTextEditor.java
+++ b/src/main/java/betterquesting/client/gui2/editors/GuiTextEditor.java
@@ -26,6 +26,7 @@ import betterquesting.api2.client.gui.themes.presets.PresetTexture;
 import betterquesting.api2.utils.QuestTranslation;
 import betterquesting.core.BetterQuesting;
 import betterquesting.misc.QuestResourcesFile;
+import betterquesting.misc.QuestResourcesFolder;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.server.MinecraftServer;
@@ -162,6 +163,11 @@ public class GuiTextEditor extends GuiScreenCanvas implements IPEventListener, I
                 @Override
                 protected void onComplete(String resourceLoc)
                 {
+                    String domain = resourceLoc.substring(0, resourceLoc.lastIndexOf(':'));
+                    if (!QuestResourcesFolder.lastResourceDomains.contains(domain))
+                    {
+                        mc.refreshResources();
+                    }
                     writeImageTag(resourceLoc);
                 }
             };

--- a/src/main/java/betterquesting/client/gui2/editors/GuiTextEditor.java
+++ b/src/main/java/betterquesting/client/gui2/editors/GuiTextEditor.java
@@ -20,26 +20,48 @@ import betterquesting.api2.client.gui.panels.CanvasTextured;
 import betterquesting.api2.client.gui.panels.bars.PanelVScrollBar;
 import betterquesting.api2.client.gui.panels.content.PanelTextBox;
 import betterquesting.api2.client.gui.panels.lists.CanvasScrolling;
+import betterquesting.api2.client.gui.popups.PopWaitExternalEvent;
 import betterquesting.api2.client.gui.themes.presets.PresetColor;
 import betterquesting.api2.client.gui.themes.presets.PresetTexture;
 import betterquesting.api2.utils.QuestTranslation;
+import betterquesting.core.BetterQuesting;
+import betterquesting.misc.QuestResourcesFile;
 import net.minecraft.client.gui.GuiScreen;
+import net.minecraft.client.resources.I18n;
+import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.EnumChatFormatting;
 import org.lwjgl.input.Keyboard;
+
+import javax.swing.JFileChooser;
+import javax.swing.JOptionPane;
+import javax.swing.SwingUtilities;
+import javax.swing.filechooser.FileNameExtensionFilter;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 
 public class GuiTextEditor extends GuiScreenCanvas implements IPEventListener, IVolatileScreen
 {
     private final ICallback<String> callback;
+    private final boolean imageSupport;
     private final String textIn;
     
     private PanelTextField<String> flText;
     
     public GuiTextEditor(GuiScreen parent, String text, ICallback<String> callback)
     {
+        this(parent, text, false, callback);
+    }
+
+    public GuiTextEditor(GuiScreen parent, String text, boolean imageSupport, ICallback<String> callback)
+    {
         super(parent);
         
         textIn = text;
         this.callback = callback;
+        this.imageSupport = imageSupport;
     }
     
     @Override
@@ -71,12 +93,17 @@ public class GuiTextEditor extends GuiScreenCanvas implements IPEventListener, I
         
         EnumChatFormatting[] tfValues = EnumChatFormatting.values();
         // Specify how many macro buttons are manually added, before the buttons for the default colors and formatting
-        int macroCount = 4;
+        int macroCount = 0;
 
-        cvFormatList.addPanel(new PanelButtonStorage<>(new GuiRectangle(0, 16 * 0, 100, 16), 2, "§9§nHyperlink§r", "[url] [/url]"));
-        cvFormatList.addPanel(new PanelButtonStorage<>(new GuiRectangle(0, 16 * 1, 100, 16), 2, "§4§lWarning§r", "[warn] [/warn]"));
-        cvFormatList.addPanel(new PanelButtonStorage<>(new GuiRectangle(0, 16 * 2, 100, 16), 2, "§3Note§r", "[note] [/note]"));
-        cvFormatList.addPanel(new PanelButtonStorage<>(new GuiRectangle(0, 16 * 3, 100, 16), 2, "§2§nQuest Title§r", "[quest] [/quest]"));
+        if (imageSupport)
+        {
+            cvFormatList.addPanel(new PanelButton(new GuiRectangle(0, 16 * macroCount++, 100, 16), 3, "§2§nSelect Image§r"));
+            cvFormatList.addPanel(new PanelButtonStorage<>(new GuiRectangle(0, 16 * macroCount++, 100, 16), 2, "§2§n Image§r", "[img height=100] [/img]"));
+        }
+        cvFormatList.addPanel(new PanelButtonStorage<>(new GuiRectangle(0, 16 * macroCount++, 100, 16), 2, "§9§nHyperlink§r", "[url] [/url]"));
+        cvFormatList.addPanel(new PanelButtonStorage<>(new GuiRectangle(0, 16 * macroCount++, 100, 16), 2, "§4§lWarning§r", "[warn] [/warn]"));
+        cvFormatList.addPanel(new PanelButtonStorage<>(new GuiRectangle(0, 16 * macroCount++, 100, 16), 2, "§3Note§r", "[note] [/note]"));
+        cvFormatList.addPanel(new PanelButtonStorage<>(new GuiRectangle(0, 16 * macroCount++, 100, 16), 2, "§2§nQuest Title§r", "[quest] [/quest]"));
 
         for(int i = 0; i < tfValues.length; i++)
         {
@@ -116,9 +143,135 @@ public class GuiTextEditor extends GuiScreenCanvas implements IPEventListener, I
             String[] tagPair = ((PanelButtonStorage<String>)btn).getStoredValue().split(" ");
             String format = tagPair[0] + flText.getSelectedText() + tagPair[1];
             flText.writeText(format);
+        } else if(btn.getButtonID() == 3)
+        {
+            PopWaitExternalEvent<String> popup = new PopWaitExternalEvent<String>(I18n.format("betterquesting.title.choose_image_swing"))
+            {
+                @Override
+                protected void handleComplete()
+                {
+                    try
+                    {
+                        super.handleComplete();
+                    } finally
+                    {
+                        setNoEscape(false);
+                    }
+                }
+
+                @Override
+                protected void onComplete(String resourceLoc)
+                {
+                    writeImageTag(resourceLoc);
+                }
+            };
+            this.setNoEscape(true);
+            this.openPopup(popup);
+            SwingUtilities.invokeLater(() ->
+            {
+                try
+                {
+                    selectImage(popup);
+                } finally
+                {
+                    popup.ensureDone();
+                }
+            });
         }
     }
-    
+
+    private void writeImageTag(String resourceLoc)
+    {
+        final String prefix = "[img height=";
+        String tag = prefix + "]" + resourceLoc + "[/img]";
+        flText.writeText(tag);
+        flText.moveCursorBy(prefix.length() - tag.length());
+    }
+
+    // This method is run on swing loop thread!
+    private static void selectImage(PopWaitExternalEvent<String> popup)
+    {
+        JFileChooser chooser = new JFileChooser();
+        chooser.setFileSelectionMode(JFileChooser.FILES_ONLY);
+        chooser.setAcceptAllFileFilterUsed(false);
+        chooser.setFileFilter(new FileNameExtensionFilter(I18n.format("betterquesting.tooltip.image_file_type"), "png"));
+
+        File src = null, dst = null;
+        File targetRoot = QuestResourcesFile.rootFolder.getAbsoluteFile();
+
+        chooser.setCurrentDirectory(targetRoot);
+        while(true)
+        {
+            if(src == null)
+            {
+                chooser.setDialogTitle(I18n.format("betterquesting.title.choose_image.src"));
+                int r = chooser.showOpenDialog(null);
+                if(r != JFileChooser.APPROVE_OPTION)
+                {
+                    popup.cancel();
+                    return;
+                }
+                src = chooser.getSelectedFile().getAbsoluteFile();
+                if (isParent(targetRoot, src) && !src.getParentFile().equals(targetRoot))
+                {
+                    popup.complete(getResourceLocation(targetRoot, src));
+                    return;
+                }
+            }
+            chooser.setDialogTitle(I18n.format("betterquesting.title.choose_image.dst"));
+            chooser.setCurrentDirectory(QuestResourcesFile.rootFolder);
+            chooser.setSelectedFile(new File(targetRoot, src.getName()).getAbsoluteFile());
+            int r = chooser.showSaveDialog(null);
+            if(r != JFileChooser.APPROVE_OPTION)
+            {
+                popup.cancel();
+                return;
+            }
+            dst = chooser.getSelectedFile().getAbsoluteFile();
+            if(!isParent(targetRoot, dst) || dst.getParentFile().equals(targetRoot))
+            {
+                JOptionPane.showMessageDialog(null, I18n.format("betterquesting.gui.not_correct_dir", QuestResourcesFile.rootFolder.getAbsolutePath()), "Error", JOptionPane.ERROR_MESSAGE);
+                continue;
+            }
+            if(dst.exists() && JOptionPane.showConfirmDialog(null, I18n.format("betterquesting.gui.overwrite_file"), "Confirm", JOptionPane.YES_NO_OPTION, JOptionPane.QUESTION_MESSAGE) != JOptionPane.YES_OPTION)
+            {
+                continue;
+            }
+            popup.setMessage("Copying image file...");
+            try
+            {
+                Path target = dst.toPath();
+                Files.createDirectories(target.getParent());
+                Files.copy(src.toPath(), target, StandardCopyOption.REPLACE_EXISTING);
+            } catch(IOException e)
+            {
+                JOptionPane.showMessageDialog(null, e.getLocalizedMessage(), "IO Error", JOptionPane.ERROR_MESSAGE);
+                BetterQuesting.logger.error("Copying image file failed", e);
+                return;
+            }
+	        popup.complete(getResourceLocation(targetRoot, dst));
+            return;
+        }
+    }
+
+    private static String getResourceLocation(File targetRoot, File dst)
+    {
+        Path relative = targetRoot.toPath().relativize(dst.toPath());
+	    return relative.toString().replace('\\', '/').replaceFirst("/", ":");
+    }
+
+    private static boolean isParent(File parent, File child)
+    {
+        while(!parent.equals(child))
+        {
+            File curParent = child.getParentFile();
+            if(curParent == null || curParent.equals(child))
+                return false;
+            child = curParent;
+        }
+        return true;
+    }
+
     @Override
     public void onGuiClosed()
     {

--- a/src/main/java/betterquesting/misc/QuestResourcesFile.java
+++ b/src/main/java/betterquesting/misc/QuestResourcesFile.java
@@ -26,7 +26,7 @@ import java.util.zip.ZipFile;
 
 public class QuestResourcesFile implements IResourcePack, Closeable
 {
-	private static final File rootFolder = new File("config/betterquesting/resources/");
+	public static final File rootFolder = new File("config/betterquesting/resources/");
     public static final Splitter entryNameSplitter = Splitter.on('/').omitEmptyStrings().limit(3);
     ArrayList<ZipFile> zipList = null;
     

--- a/src/main/java/betterquesting/misc/QuestResourcesFolder.java
+++ b/src/main/java/betterquesting/misc/QuestResourcesFolder.java
@@ -1,6 +1,7 @@
 package betterquesting.misc;
 
 import betterquesting.core.BetterQuesting;
+import com.google.common.collect.ImmutableSet;
 import net.minecraft.client.resources.IResourcePack;
 import net.minecraft.client.resources.data.IMetadataSection;
 import net.minecraft.client.resources.data.IMetadataSerializer;
@@ -18,6 +19,7 @@ import java.util.Set;
 public class QuestResourcesFolder implements IResourcePack
 {
 	private static final File rootFolder = new File("config/betterquesting/resources/");
+	public static Set<String> lastResourceDomains;
 	
 	@Override
 	public InputStream getInputStream(ResourceLocation location) throws IOException
@@ -63,7 +65,7 @@ public class QuestResourcesFolder implements IResourcePack
 				}
 			}
 		}
-		
+		lastResourceDomains = ImmutableSet.copyOf(folders);
 		return folders;
 	}
 	

--- a/src/main/resources/assets/betterquesting/lang/en_US.lang
+++ b/src/main/resources/assets/betterquesting/lang/en_US.lang
@@ -19,6 +19,9 @@ betterquesting.title.select_theme=Select Theme
 betterquesting.title.importers=Importers
 betterquesting.title.submit_station=Submit Station
 betterquesting.title.completion=Completion: %d/%d
+betterquesting.title.choose_image.src=Select Image to Add
+betterquesting.title.choose_image.dst=Select destination
+betterquesting.title.choose_image_swing=Please select an image in the opened file chooser
 
 betterquesting.btn.rewards=Rewards
 betterquesting.btn.tasks=Tasks
@@ -85,6 +88,9 @@ betterquesting.gui.key=Key Name
 betterquesting.gui.no_key=No Key
 betterquesting.gui.duplicate_key=Duplicate Key
 betterquesting.gui.yes_always=Yes, always
+betterquesting.gui.sp_only=This feature does not work when playing on dedicated server
+betterquesting.gui.not_correct_dir=Target location must be under %s, and must not be an immediate child of it
+betterquesting.gui.overwrite_file=Target file already exists. Confirm overwrite?
 
 betterquesting.tooltip.tasks_complete=%s/%s Tasks Complete
 betterquesting.tooltip.complete=COMPLETE
@@ -106,6 +112,7 @@ betterquesting.tooltip.repeat_with_edit_mode=Edit mode enabled, repeatable quest
 betterquesting.tooltip.update_quests=Update Available!%n§7A new quest line version is available.%nClick to install and migrate progress.
 betterquesting.tooltip.cycle.true=Click to disable
 betterquesting.tooltip.cycle.false=Click to enable
+betterquesting.tooltip.image_file_type=Images
 
 betterquesting.notice.complete=Quest Complete
 betterquesting.notice.update=Quest Updated


### PR DESCRIPTION
Adds 2 buttons to quest description editor.

1. Select image
  * If editor selected a file under config/betterquesting/resources/, then it will be used. A proper mage tag WITHOUT height specified pointing towards that image will be written into the main textbox.
  * if editor selected a file outside aforementioned directory, then editor will be prompted to select a location under that directory. The image will be then copied to that selected location. Afterwards, a proper mage tag WITHOUT height specified pointing towards that image will be written into the main textbox. 
  In either case, only PNG is allowed to be selected.
2. Image. This button is pretty much the same as any other style tag button. Just wraps whatever that is already under your cursor in a pair of `[img][/img]` tag, with a default height of 100.