### PR TITLE
Go back to previous screen with right click

### DIFF
--- a/src/main/java/betterquesting/api2/client/gui/GuiScreenCanvas.java
+++ b/src/main/java/betterquesting/api2/client/gui/GuiScreenCanvas.java
@@ -323,7 +323,7 @@ public class GuiScreenCanvas extends GuiScreen implements IScene
 
 		if(!used && click == 1) {
 			if(parent != null && parent instanceof GuiScreenCanvas &&
-					!(this instanceof GuiQuestLines & parent instanceof GuiHome)) {
+					!(this instanceof GuiQuestLines && parent instanceof GuiHome)) {
 				mc.displayGuiScreen(parent);
 				return false;
 			}

--- a/src/main/java/betterquesting/api2/client/gui/GuiScreenCanvas.java
+++ b/src/main/java/betterquesting/api2/client/gui/GuiScreenCanvas.java
@@ -14,6 +14,8 @@ import betterquesting.api2.client.gui.popups.PopChoice;
 import betterquesting.api2.client.gui.themes.presets.PresetIcon;
 import betterquesting.api2.utils.QuestTranslation;
 import betterquesting.client.BQ_Keybindings;
+import betterquesting.client.gui2.GuiHome;
+import betterquesting.client.gui2.GuiQuestLines;
 import betterquesting.core.BetterQuesting;
 import com.caedis.duradisplay.render.DurabilityRenderer;
 import com.mojang.realmsclient.gui.ChatFormatting;
@@ -201,7 +203,7 @@ public class GuiScreenCanvas extends GuiScreen implements IScene
 		
 		List<String> tt = this.getTooltip(mx, my);
 		
-		if(tt != null && tt.size() > 0)
+		if(tt != null && !tt.isEmpty())
 		{
 			this.drawHoveringText(tt, mx, my, mc.fontRenderer);
 		}
@@ -316,6 +318,14 @@ public class GuiScreenCanvas extends GuiScreen implements IScene
 			{
 				used = true;
 				break;
+			}
+		}
+
+		if(!used && click == 1) {
+			if(parent != null && parent instanceof GuiScreenCanvas &&
+					!(this instanceof GuiQuestLines & parent instanceof GuiHome)) {
+				mc.displayGuiScreen(parent);
+				return false;
 			}
 		}
 		


### PR DESCRIPTION
Saves you having to hit the back button a gazillion times while browsing quests or sitting with your finger planted on backspace.

This will only trigger if clicked on empty spaces to keep it from interfering with buttons, on top of that it will also never close the gui, take you to an external gui or return to the BQ home screen when right clicking on the questline gui, 