### PR TITLE
Fix party gui rendering & npe

### DIFF
--- a/src/main/java/betterquesting/api/utils/RenderUtils.java
+++ b/src/main/java/betterquesting/api/utils/RenderUtils.java
@@ -147,27 +147,7 @@ public class RenderUtils
 			RenderHelper.enableStandardItemLighting();
 			RenderManager.instance.playerViewY = 180F;
 			RenderManager.instance.renderEntityWithPosYaw(entity, 0D, 0D, 0D, 0F, 1F);
-			if (EntityList.getEntityString(entity).equals("TwilightForest.Naga")) {
-				OpenGlHelper.setLightmapTextureCoords(OpenGlHelper.lightmapTexUnit, 240, 240);
-				int bodySize = 11;    // 0 to 12
-				Entity part = entity.getParts()[0];
-				float [][] xyzYaw = getNagaXyzYaw();
-				for (int i = 0; i < bodySize; i++)
-					RenderManager.instance.renderEntityWithPosYaw(part, xyzYaw[i][0], xyzYaw[i][1], xyzYaw[i][2], xyzYaw[i][3], 1F);
-			} else if (EntityList.getEntityString(entity).equals("TwilightForest.Hydra")) {
-				OpenGlHelper.setLightmapTextureCoords(OpenGlHelper.lightmapTexUnit, 240, 240);
-				int headsNumber = 7;    // 0 to 7, optimal 3, 5, 7
-				Entity part = EntityList.createEntityByName("TwilightForest.HydraHead", Minecraft.getMinecraft().theWorld);
-				part.rotationYaw = 0;
-				part.rotationPitch = 0;
-				float [][] xyz = getHydraHeadXyz();
-				for (int i = 0; i < headsNumber; i++)
-					RenderManager.instance.renderEntityWithPosYaw(part, xyz[i][0], xyz[i][1], xyz[i][2], 0F, 1F);
-				part = entity.getParts()[4];
-				xyz = getHydraNeckXyz();
-				for (int i = 0; i < 5 * headsNumber; i++)
-					RenderManager.instance.renderEntityWithPosYaw(part, xyz[i][0], xyz[i][1], xyz[i][2], 0F, 1F);
-			}
+			doSpecialRenders(entity);
 			GL11.glDisable(GL11.GL_DEPTH_TEST);
 			GL11.glPopMatrix();
 			RenderHelper.disableStandardItemLighting();
@@ -178,6 +158,31 @@ public class RenderUtils
 			GL11.glEnable(GL11.GL_TEXTURE_2D); // Breaks subsequent text rendering if not included
 		} catch (Exception e) {
 			// Hides rendering errors with entities which are common for invalid/technical entities
+		}
+	}
+
+	private static void doSpecialRenders(Entity entity){
+		String entityString = entity.getClass().getSimpleName();
+		if (entityString.equals("EntityTFNaga")) {
+			OpenGlHelper.setLightmapTextureCoords(OpenGlHelper.lightmapTexUnit, 240, 240);
+			int bodySize = 11;    // 0 to 12
+			Entity part = entity.getParts()[0];
+			float [][] xyzYaw = getNagaXyzYaw();
+			for (int i = 0; i < bodySize; i++)
+				RenderManager.instance.renderEntityWithPosYaw(part, xyzYaw[i][0], xyzYaw[i][1], xyzYaw[i][2], xyzYaw[i][3], 1F);
+		} else if (entityString.equals("EntityTFHydra")) {
+			OpenGlHelper.setLightmapTextureCoords(OpenGlHelper.lightmapTexUnit, 240, 240);
+			int headsNumber = 7;    // 0 to 7, optimal 3, 5, 7
+			Entity part = EntityList.createEntityByName("TwilightForest.HydraHead", Minecraft.getMinecraft().theWorld);
+			part.rotationYaw = 0;
+			part.rotationPitch = 0;
+			float [][] xyz = getHydraHeadXyz();
+			for (int i = 0; i < headsNumber; i++)
+				RenderManager.instance.renderEntityWithPosYaw(part, xyz[i][0], xyz[i][1], xyz[i][2], 0F, 1F);
+			part = entity.getParts()[4];
+			xyz = getHydraNeckXyz();
+			for (int i = 0; i < 5 * headsNumber; i++)
+				RenderManager.instance.renderEntityWithPosYaw(part, xyz[i][0], xyz[i][1], xyz[i][2], 0F, 1F);
 		}
 	}
 

--- a/src/main/java/betterquesting/api2/utils/EntityPlayerPreview.java
+++ b/src/main/java/betterquesting/api2/utils/EntityPlayerPreview.java
@@ -47,4 +47,10 @@ public class EntityPlayerPreview extends EntityOtherPlayerMP
 	{
 		return "";
 	}
+
+	@Override
+	public boolean getHideCape()
+	{
+		return true;
+	}
 }


### PR DESCRIPTION
I decided to do some testing after noticing that the party screen was insanely dark at night and started by commenting out the naga & hydra renders to better focus on the standard rendering. This however turned out to fix the problem entirely. The reason it only affected the party gui is because `EntityList.getEntityString(entity)`  returns null for players.
I also switched it to use the class name which is a less expensive operation than looking up the entity name in a list populated with every registered entity each time it draws.

Closes: https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/15228
Closes: https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/16496