### PR TITLE
Fix warning tag name: `warning` -> `warn`

### DIFF
--- a/src/main/java/betterquesting/api2/client/gui/panels/content/FormattingTag.java
+++ b/src/main/java/betterquesting/api2/client/gui/panels/content/FormattingTag.java
@@ -14,7 +14,7 @@ import java.util.stream.Collectors;
 
 public enum FormattingTag {
     NOTE("note"),
-    WARNING("warning"),
+    WARNING("warn"),
     QUEST("quest"),
 
     BOLD("bold"),


### PR DESCRIPTION
Fix warning tag name: `warning` -> `warn`
`warn` is the original name, which was changed accidentally.