### PR TITLE
Add message about non-AND task logic

### DIFF
--- a/src/main/java/betterquesting/client/gui2/GuiQuest.java
+++ b/src/main/java/betterquesting/client/gui2/GuiQuest.java
@@ -384,12 +384,6 @@ public class GuiQuest extends GuiScreenCanvas implements IPEventListener, INeeds
 
         int yOffset = 0;
         EnumLogic taskLogic = quest.getProperty(NativeProps.LOGIC_TASK);
-        if (taskLogic != EnumLogic.AND){
-            String logicText = QuestTranslation.translate("betterquesting.gui.logic."+taskLogic.name().toLowerCase());
-            PanelTextBox panelLogic = new PanelTextBox(new GuiTransform(new Vector4f(), 0, yOffset, rectTask.getWidth(), 12, 0), logicText);
-            csTask.addPanel(panelLogic);
-            yOffset = 20;
-        }
         List<DBEntry<ITask>> entries = quest.getTasks().getEntries();
         for (int i = 0; i < entries.size(); i++) {
             ITask tsk = entries.get(i).getValue();
@@ -400,17 +394,26 @@ public class GuiQuest extends GuiScreenCanvas implements IPEventListener, INeeds
             csTask.addPanel(titleReward);
             yOffset += 10;
 
-            IGuiPanel taskGui = tsk.getTaskGui(new GuiTransform(GuiAlign.FULL_BOX, 0, 0, rectTask.getWidth(), rectTask.getHeight(), 0), Maps.immutableEntry(questID, quest));
+            IGuiPanel taskGui = tsk.getTaskGui(new GuiTransform(GuiAlign.FULL_BOX, 10, 10, rectTask.getWidth(), rectTask.getHeight(), 0), Maps.immutableEntry(questID, quest));
             if (taskGui != null) {
                 taskGui.initPanel();
                 // Wrapping into canvas allow avoid empty space at end
-                CanvasEmpty tempCanvas = new CanvasEmpty(new GuiTransform(GuiAlign.TOP_LEFT, 0, yOffset, rectTask.getWidth(), taskGui.getTransform().getHeight() - taskGui.getTransform().getY(), 1));
+                CanvasTextured tempCanvas = new CanvasTextured(new GuiTransform(GuiAlign.TOP_LEFT, 0, yOffset, rectTask.getWidth() - 15, taskGui.getTransform().getHeight() + 20 - taskGui.getTransform().getY(), 1), PresetTexture.PANEL_MAIN.getTexture());
                 csTask.addPanel(tempCanvas);
                 tempCanvas.addPanel(taskGui);
                 int guiHeight = tempCanvas.getTransform().getHeight();
-                yOffset += guiHeight;
-
+                yOffset += guiHeight + 5;
             }
+
+            if (taskLogic == EnumLogic.OR && i < entries.size() - 1) {
+                yOffset += 10;
+                String logicText = QuestTranslation.translate("betterquesting.gui.logic."+taskLogic.name().toLowerCase());
+                PanelTextBox panelLogic = new PanelTextBox(new GuiTransform(new Vector4f(), 0, yOffset, rectTask.getWidth(), 12, 0), logicText);
+                panelLogic.setColor(PresetColor.TEXT_HIGHLIGHT.getColor()).setAlignment(1);
+                csTask.addPanel(panelLogic);
+                yOffset += 10;
+            }
+
             //Indent from the previous
             yOffset += 8;
         }

--- a/src/main/java/betterquesting/client/gui2/GuiQuest.java
+++ b/src/main/java/betterquesting/client/gui2/GuiQuest.java
@@ -3,6 +3,8 @@ package betterquesting.client.gui2;
 import betterquesting.api.api.ApiReference;
 import betterquesting.api.api.QuestingAPI;
 import betterquesting.api.client.gui.misc.INeedsRefresh;
+import betterquesting.api.enums.EnumLogic;
+import betterquesting.api.properties.NativeProps;
 import betterquesting.api.questing.IQuest;
 import betterquesting.api.questing.rewards.IReward;
 import betterquesting.api.questing.tasks.ITask;
@@ -381,10 +383,16 @@ public class GuiQuest extends GuiScreenCanvas implements IPEventListener, INeeds
         csTask.setScrollDriverY(scList);
 
         int yOffset = 0;
+        EnumLogic taskLogic = quest.getProperty(NativeProps.LOGIC_TASK);
+        if (taskLogic != EnumLogic.AND){
+            String logicText = QuestTranslation.translate("betterquesting.gui.logic."+taskLogic.name().toLowerCase());
+            PanelTextBox panelLogic = new PanelTextBox(new GuiTransform(new Vector4f(), 0, yOffset, rectTask.getWidth(), 12, 0), logicText);
+            csTask.addPanel(panelLogic);
+            yOffset = 20;
+        }
         List<DBEntry<ITask>> entries = quest.getTasks().getEntries();
         for (int i = 0; i < entries.size(); i++) {
             ITask tsk = entries.get(i).getValue();
-
             String taskName = (i + 1) + ". " + QuestTranslation.translate(tsk.getUnlocalisedName());
             PanelTextBox titleReward = new PanelTextBox(new GuiTransform(new Vector4f(), 0, yOffset, rectTask.getWidth(), 12, 0), taskName);
             titleReward.setColor(PresetColor.TEXT_HEADER.getColor()).setAlignment(1);

--- a/src/main/java/betterquesting/questing/QuestInstance.java
+++ b/src/main/java/betterquesting/questing/QuestInstance.java
@@ -148,13 +148,14 @@ public class QuestInstance implements IQuest
             ParticipantInfo partInfo = new ParticipantInfo(player);
             Map.Entry<UUID, IQuest> mapEntry = Maps.immutableEntry(questID, this);
 
+            int numTasks = tasks.size();
 			for (DBEntry<ITask> entry : tasks.getEntries())
 			{
-				if (!entry.getValue().isComplete(playerID) || !entry.getValue().ignored(playerID))
+				if (!entry.getValue().isComplete(playerID))
 				{
 					entry.getValue().detect(partInfo, mapEntry);
 
-					if (entry.getValue().isComplete(playerID) || entry.getValue().ignored(playerID))
+					if (entry.getValue().isComplete(playerID))
 					{
 						done++;
 						update = true;
@@ -164,9 +165,17 @@ public class QuestInstance implements IQuest
 				{
 					done++;
 				}
+
+                if (entry.getValue().ignored(playerID)){
+                    // values are only used for logic checking
+                    numTasks--;
+                    if (entry.getValue().isComplete(playerID)){
+                        done--;
+                    }
+                }
 			}
 			// Note: Tasks can mark the quest dirty themselves if progress changed but hasn't fully completed.
-			if (tasks.size() <= 0 || qInfo.getProperty(NativeProps.LOGIC_TASK).getResult(done, tasks.size()))
+			if (numTasks <= 0 || qInfo.getProperty(NativeProps.LOGIC_TASK).getResult(done, numTasks))
 			{
 			    // State won't be auto updated in edit mode so we force change it here and mark it for re-sync
 				if (QuestSettings.INSTANCE.getProperty(NativeProps.EDIT_MODE))

--- a/src/main/resources/assets/betterquesting/lang/en_US.lang
+++ b/src/main/resources/assets/betterquesting/lang/en_US.lang
@@ -94,7 +94,7 @@ betterquesting.gui.yes_always=Yes, always
 betterquesting.gui.sp_only=This feature does not work when playing on dedicated server
 betterquesting.gui.not_correct_dir=Target location must be under %s, and must not be an immediate child of it
 betterquesting.gui.overwrite_file=Target file already exists. Confirm overwrite?
-betterquesting.gui.logic.or=Only 1 of the following non-optional tasks needs to be completed
+betterquesting.gui.logic.or=OR
 
 betterquesting.tooltip.tasks_complete=%s/%s Tasks Complete
 betterquesting.tooltip.complete=COMPLETE

--- a/src/main/resources/assets/betterquesting/lang/en_US.lang
+++ b/src/main/resources/assets/betterquesting/lang/en_US.lang
@@ -94,6 +94,7 @@ betterquesting.gui.yes_always=Yes, always
 betterquesting.gui.sp_only=This feature does not work when playing on dedicated server
 betterquesting.gui.not_correct_dir=Target location must be under %s, and must not be an immediate child of it
 betterquesting.gui.overwrite_file=Target file already exists. Confirm overwrite?
+betterquesting.gui.logic.or=Only 1 of the following non-optional tasks needs to be completed
 
 betterquesting.tooltip.tasks_complete=%s/%s Tasks Complete
 betterquesting.tooltip.complete=COMPLETE

--- a/src/main/resources/assets/betterquesting/lang/ru_RU.lang
+++ b/src/main/resources/assets/betterquesting/lang/ru_RU.lang
@@ -82,6 +82,7 @@ betterquesting.gui.key=Название ключа
 betterquesting.gui.no_key=Без ключа
 betterquesting.gui.duplicate_key=Дубль ключа
 betterquesting.gui.yes_always=Да, всегда
+betterquesting.gui.logic.or=OR
 
 betterquesting.tooltip.tasks_complete=%s/%s заданий завершено
 betterquesting.tooltip.complete=ЗАВЕРШЕНО

--- a/src/main/resources/assets/betterquesting/lang/zh_CN.lang
+++ b/src/main/resources/assets/betterquesting/lang/zh_CN.lang
@@ -87,6 +87,7 @@ betterquesting.gui.key=键位名称
 betterquesting.gui.no_key=无效键位
 betterquesting.gui.duplicate_key=键位冲突
 betterquesting.gui.yes_always=总是
+betterquesting.gui.logic.or=OR
 
 betterquesting.tooltip.tasks_complete=%s/%s 已达成
 betterquesting.tooltip.complete=已达成


### PR DESCRIPTION
Noticed that for the redstone ore quest in nightlies, its not obvious that this quest uses OR logic for its tasks, and while a note could be added to the description, a way to notify the player that you dont have to do everything would be nice.

latest layout:

![348643667-11bb3e04-d431-4ba3-8725-a5bc40d04a92](https://github.com/user-attachments/assets/bb27ff34-34ba-4785-b68e-1ff2426beb82)


TODO

- [x] Update logic to not factor in optional quests?