### PR TITLE
Fix bug that would cause the questing API's getPlayer to be null

### DIFF
--- a/src/main/java/betterquesting/api/api/QuestingAPI.java
+++ b/src/main/java/betterquesting/api/api/QuestingAPI.java
@@ -78,7 +78,7 @@ public class QuestingAPI
 
 	public static EntityPlayerMP getPlayer(UUID uuid){
 		Optional onlinePlayer = MinecraftServer.getServer().getConfigurationManager().playerEntityList.stream().filter(i -> i instanceof EntityPlayerMP)
-				.filter(o -> getQuestingUUID((EntityPlayer) o) == uuid).findFirst();
+				.filter(o -> getQuestingUUID((EntityPlayer) o).equals(uuid)).findFirst();
 		return onlinePlayer.isPresent() ? (EntityPlayerMP) onlinePlayer.get() : null;
 	}
 }


### PR DESCRIPTION
previous code used incorrect equality checking for UUIDs.

Fixes various issues with player syncing where this function (QuestingAPI.getPlayer()) is being called.