### PR TITLE
dont parse hunt task nbt if its ignored

### DIFF
--- a/src/main/java/bq_standard/client/gui/editors/tasks/GuiEditTaskHunt.java
+++ b/src/main/java/bq_standard/client/gui/editors/tasks/GuiEditTaskHunt.java
@@ -66,7 +66,7 @@ public class GuiEditTaskHunt extends GuiScreenCanvas {
 
         if (EntityList.stringToClassMapping.containsKey(task.idName)) {
             target = EntityList.createEntityByName(task.idName, Minecraft.getMinecraft().theWorld);
-            if (target != null) target.readFromNBT(task.targetTags);
+            if (target != null && !task.ignoreNBT) target.readFromNBT(task.targetTags);
         } else target = null;
 
         this.addPanel(

--- a/src/main/java/bq_standard/client/gui/tasks/PanelTaskHunt.java
+++ b/src/main/java/bq_standard/client/gui/tasks/PanelTaskHunt.java
@@ -34,7 +34,7 @@ public class PanelTaskHunt extends CanvasMinimum {
 
         if (EntityList.stringToClassMapping.containsKey(task.idName)) {
             target = EntityList.createEntityByName(task.idName, Minecraft.getMinecraft().theWorld);
-            if (target != null) target.readFromNBT(task.targetTags);
+            if (target != null && !task.ignoreNBT) target.readFromNBT(task.targetTags);
         } else {
             target = null;
         }


### PR DESCRIPTION
Some mobs have attributes that cause "unknown attribute" warnings to be spammed on the server even when nbt is ignored.
Example: BG2 attributes when BG2 is replaced with backhand.