### PR TITLE
Add git blame ignore file

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Initial spotlessApply
+6c9fac5e9eb85dde746e37f8b3aa270a47ef12cf


### PR DESCRIPTION
Makes `git blame` more usable.

Follow-up for #152.