### PR TITLE
add disable reward mode :Gigachad:

### DIFF
--- a/src/main/java/betterquesting/api/questing/rewards/AbstractReward.java
+++ b/src/main/java/betterquesting/api/questing/rewards/AbstractReward.java
@@ -1,0 +1,51 @@
+package betterquesting.api.questing.rewards;
+
+import java.util.Map.Entry;
+import java.util.UUID;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.nbt.NBTTagCompound;
+
+import betterquesting.api.questing.IQuest;
+import betterquesting.api.storage.BQ_Settings;
+
+public abstract class AbstractReward implements IReward {
+
+    protected boolean ignoreDisabled = getDefaultIgnoreDisabled();
+
+    @Override
+    public final void claimReward(EntityPlayer player, Entry<UUID, IQuest> quest) {
+        if (!ignoreDisabled && BQ_Settings.noRewards) return;
+        claimReward0(player, quest);
+    }
+
+    /**
+     *
+     * @return a value independent of {@link #ignoreDisabled}. preferably a constant
+     */
+    protected boolean getDefaultIgnoreDisabled() {
+        return false;
+    }
+
+    protected abstract void claimReward0(EntityPlayer player, Entry<UUID, IQuest> quest);
+
+    @Override
+    public void readFromNBT(NBTTagCompound nbt) {
+        if (nbt.hasKey("ignoreDisabled")) ignoreDisabled = nbt.getBoolean("ignoreDisabled");
+        else ignoreDisabled = getDefaultIgnoreDisabled();
+    }
+
+    @Override
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
+        nbt.setBoolean("ignoreDisabled", ignoreDisabled);
+        return nbt;
+    }
+
+    public boolean isIgnoreDisabled() {
+        return ignoreDisabled;
+    }
+
+    public void setIgnoreDisabled(boolean ignoreDisabled) {
+        this.ignoreDisabled = ignoreDisabled;
+    }
+}

--- a/src/main/java/betterquesting/api/storage/BQ_Settings.java
+++ b/src/main/java/betterquesting/api/storage/BQ_Settings.java
@@ -40,4 +40,5 @@ public class BQ_Settings {
     public static boolean loadDefaultsOnStartup = true;
     public static boolean logNullQuests = true;
     public static boolean unrestrictAdminCommands = false;
+    public static boolean noRewards = false;
 }

--- a/src/main/java/betterquesting/handlers/ConfigHandler.java
+++ b/src/main/java/betterquesting/handlers/ConfigHandler.java
@@ -133,6 +133,11 @@ public class ConfigHandler {
             true,
             "Posts useful information in the log when encountering a null quest during loading.");
 
+        BQ_Settings.noRewards = config.getBoolean(
+            "Disable rewards",
+            Configuration.CATEGORY_GENERAL,
+            false,
+            "If true, rewards will be disabled. This might not be supported by reward types.");
         config.save();
     }
 }

--- a/src/main/java/bq_standard/rewards/RewardChoice.java
+++ b/src/main/java/bq_standard/rewards/RewardChoice.java
@@ -17,6 +17,7 @@ import org.apache.logging.log4j.Level;
 
 import betterquesting.api.api.QuestingAPI;
 import betterquesting.api.questing.IQuest;
+import betterquesting.api.questing.rewards.AbstractReward;
 import betterquesting.api.questing.rewards.IReward;
 import betterquesting.api.utils.BigItemStack;
 import betterquesting.api.utils.JsonHelper;
@@ -29,7 +30,7 @@ import bq_standard.rewards.factory.FactoryRewardChoice;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 
-public class RewardChoice implements IReward, IRewardItemOutput {
+public class RewardChoice extends AbstractReward implements IReward, IRewardItemOutput {
 
     /**
      * The selected reward index to be claimed.<br>
@@ -70,7 +71,7 @@ public class RewardChoice implements IReward, IRewardItemOutput {
     }
 
     @Override
-    public void claimReward(EntityPlayer player, Map.Entry<UUID, IQuest> quest) {
+    protected void claimReward0(EntityPlayer player, Map.Entry<UUID, IQuest> quest) {
         UUID playerID = QuestingAPI.getQuestingUUID(player);
 
         if (choices.size() <= 0) {
@@ -117,6 +118,7 @@ public class RewardChoice implements IReward, IRewardItemOutput {
 
     @Override
     public void readFromNBT(NBTTagCompound nbt) {
+        super.readFromNBT(nbt);
         choices.clear();
         NBTTagList cList = nbt.getTagList("choices", 10);
         for (int i = 0; i < cList.tagCount(); i++) {
@@ -126,6 +128,7 @@ public class RewardChoice implements IReward, IRewardItemOutput {
 
     @Override
     public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
+        super.writeToNBT(nbt);
         NBTTagList rJson = new NBTTagList();
         for (BigItemStack stack : choices) {
             rJson.appendTag(JsonHelper.ItemStackToJson(stack, new NBTTagCompound()));

--- a/src/main/java/bq_standard/rewards/RewardCommand.java
+++ b/src/main/java/bq_standard/rewards/RewardCommand.java
@@ -14,6 +14,7 @@ import net.minecraft.world.World;
 
 import betterquesting.api.api.QuestingAPI;
 import betterquesting.api.questing.IQuest;
+import betterquesting.api.questing.rewards.AbstractReward;
 import betterquesting.api.questing.rewards.IReward;
 import betterquesting.api2.client.gui.misc.IGuiRect;
 import betterquesting.api2.client.gui.panels.IGuiPanel;
@@ -23,7 +24,7 @@ import bq_standard.handlers.EventHandler;
 import bq_standard.rewards.factory.FactoryRewardCommand;
 import io.netty.buffer.ByteBuf;
 
-public class RewardCommand implements IReward {
+public class RewardCommand extends AbstractReward implements IReward {
 
     public String command = "/say VAR_NAME Claimed a reward";
     public boolean hideCmd = false;
@@ -45,7 +46,12 @@ public class RewardCommand implements IReward {
     }
 
     @Override
-    public void claimReward(final EntityPlayer player, Map.Entry<UUID, IQuest> quest) {
+    protected boolean getDefaultIgnoreDisabled() {
+        return true;
+    }
+
+    @Override
+    protected void claimReward0(final EntityPlayer player, Map.Entry<UUID, IQuest> quest) {
         if (player.worldObj.isRemote) return;
 
         String tmp = command.replaceAll("VAR_NAME", player.getCommandSenderName());
@@ -74,6 +80,7 @@ public class RewardCommand implements IReward {
 
     @Override
     public void readFromNBT(NBTTagCompound nbt) {
+        super.readFromNBT(nbt);
         command = nbt.getString("command");
         hideCmd = nbt.getBoolean("hideCommand");
         viaPlayer = nbt.getBoolean("viaPlayer");
@@ -81,6 +88,7 @@ public class RewardCommand implements IReward {
 
     @Override
     public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
+        super.writeToNBT(nbt);
         nbt.setString("command", command);
         nbt.setBoolean("hideCommand", hideCmd);
         nbt.setBoolean("viaPlayer", viaPlayer);

--- a/src/main/java/bq_standard/rewards/RewardItem.java
+++ b/src/main/java/bq_standard/rewards/RewardItem.java
@@ -16,6 +16,7 @@ import org.apache.logging.log4j.Level;
 
 import betterquesting.api.api.QuestingAPI;
 import betterquesting.api.questing.IQuest;
+import betterquesting.api.questing.rewards.AbstractReward;
 import betterquesting.api.questing.rewards.IReward;
 import betterquesting.api.utils.BigItemStack;
 import betterquesting.api.utils.JsonHelper;
@@ -26,7 +27,7 @@ import bq_standard.client.gui.rewards.PanelRewardItem;
 import bq_standard.core.BQ_Standard;
 import bq_standard.rewards.factory.FactoryRewardItem;
 
-public class RewardItem implements IReward, IRewardItemOutput {
+public class RewardItem extends AbstractReward implements IReward, IRewardItemOutput {
 
     public final List<BigItemStack> items = new ArrayList<>();
 
@@ -46,7 +47,7 @@ public class RewardItem implements IReward, IRewardItemOutput {
     }
 
     @Override
-    public void claimReward(EntityPlayer player, Map.Entry<UUID, IQuest> quest) {
+    protected void claimReward0(EntityPlayer player, Map.Entry<UUID, IQuest> quest) {
         for (BigItemStack r : items) {
             BigItemStack stack = r.copy();
 
@@ -71,6 +72,7 @@ public class RewardItem implements IReward, IRewardItemOutput {
 
     @Override
     public void readFromNBT(NBTTagCompound nbt) {
+        super.readFromNBT(nbt);
         items.clear();
         NBTTagList rList = nbt.getTagList("rewards", 10);
         for (int i = 0; i < rList.tagCount(); i++) {
@@ -85,6 +87,7 @@ public class RewardItem implements IReward, IRewardItemOutput {
 
     @Override
     public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
+        super.writeToNBT(nbt);
         NBTTagList rJson = new NBTTagList();
         for (BigItemStack stack : items) {
             rJson.appendTag(JsonHelper.ItemStackToJson(stack, new NBTTagCompound()));

--- a/src/main/java/bq_standard/rewards/RewardQuestCompletion.java
+++ b/src/main/java/bq_standard/rewards/RewardQuestCompletion.java
@@ -12,6 +12,7 @@ import net.minecraft.util.ResourceLocation;
 import betterquesting.api.api.ApiReference;
 import betterquesting.api.api.QuestingAPI;
 import betterquesting.api.questing.IQuest;
+import betterquesting.api.questing.rewards.AbstractReward;
 import betterquesting.api.questing.rewards.IReward;
 import betterquesting.api.utils.NBTConverter;
 import betterquesting.api.utils.UuidConverter;
@@ -22,7 +23,7 @@ import betterquesting.questing.QuestDatabase;
 import bq_standard.client.gui.rewards.PanelRewardQuestCompletion;
 import bq_standard.rewards.factory.FactoryRewardQuestCompletion;
 
-public class RewardQuestCompletion implements IReward {
+public class RewardQuestCompletion extends AbstractReward implements IReward {
 
     public UUID questNum = null;
 
@@ -42,7 +43,12 @@ public class RewardQuestCompletion implements IReward {
     }
 
     @Override
-    public void claimReward(EntityPlayer player, Map.Entry<UUID, IQuest> quest) {
+    protected boolean getDefaultIgnoreDisabled() {
+        return true;
+    }
+
+    @Override
+    protected void claimReward0(EntityPlayer player, Map.Entry<UUID, IQuest> quest) {
         if (questNum == null) {
             return;
         }
@@ -72,6 +78,7 @@ public class RewardQuestCompletion implements IReward {
 
     @Override
     public void readFromNBT(NBTTagCompound nbt) {
+        super.readFromNBT(nbt);
         Optional<UUID> uuid = NBTConverter.UuidValueType.QUEST.tryReadIdString(nbt);
         if (uuid.isPresent()) {
             questNum = uuid.get();
@@ -85,6 +92,7 @@ public class RewardQuestCompletion implements IReward {
 
     @Override
     public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
+        super.writeToNBT(nbt);
         NBTConverter.UuidValueType.QUEST.writeIdString(questNum, nbt);
         return nbt;
     }

--- a/src/main/java/bq_standard/rewards/RewardScoreboard.java
+++ b/src/main/java/bq_standard/rewards/RewardScoreboard.java
@@ -16,6 +16,7 @@ import net.minecraft.util.ResourceLocation;
 import org.apache.logging.log4j.Level;
 
 import betterquesting.api.questing.IQuest;
+import betterquesting.api.questing.rewards.AbstractReward;
 import betterquesting.api.questing.rewards.IReward;
 import betterquesting.api2.client.gui.misc.IGuiRect;
 import betterquesting.api2.client.gui.panels.IGuiPanel;
@@ -25,7 +26,7 @@ import bq_standard.rewards.factory.FactoryRewardScoreboard;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 
-public class RewardScoreboard implements IReward {
+public class RewardScoreboard extends AbstractReward implements IReward {
 
     public String score = "Reputation";
     public String type = "dummy";
@@ -48,7 +49,12 @@ public class RewardScoreboard implements IReward {
     }
 
     @Override
-    public void claimReward(EntityPlayer player, Map.Entry<UUID, IQuest> quest) {
+    protected boolean getDefaultIgnoreDisabled() {
+        return true;
+    }
+
+    @Override
+    protected void claimReward0(EntityPlayer player, Map.Entry<UUID, IQuest> quest) {
         Scoreboard board = player.getWorldScoreboard();
         if (board == null) return;
 
@@ -82,6 +88,7 @@ public class RewardScoreboard implements IReward {
 
     @Override
     public void readFromNBT(NBTTagCompound json) {
+        super.readFromNBT(json);
         score = json.getString("score");
         type = json.getString("type");
         value = json.getInteger("value");
@@ -90,6 +97,7 @@ public class RewardScoreboard implements IReward {
 
     @Override
     public NBTTagCompound writeToNBT(NBTTagCompound json) {
+        super.writeToNBT(json);
         json.setString("score", score);
         json.setString("type", "dummy");
         json.setInteger("value", value);

--- a/src/main/java/bq_standard/rewards/RewardXP.java
+++ b/src/main/java/bq_standard/rewards/RewardXP.java
@@ -9,6 +9,7 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.ResourceLocation;
 
 import betterquesting.api.questing.IQuest;
+import betterquesting.api.questing.rewards.AbstractReward;
 import betterquesting.api.questing.rewards.IReward;
 import betterquesting.api2.client.gui.misc.IGuiRect;
 import betterquesting.api2.client.gui.panels.IGuiPanel;
@@ -18,7 +19,7 @@ import bq_standard.rewards.factory.FactoryRewardXP;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 
-public class RewardXP implements IReward {
+public class RewardXP extends AbstractReward implements IReward {
 
     public int amount = 1;
     public boolean levels = true;
@@ -39,18 +40,20 @@ public class RewardXP implements IReward {
     }
 
     @Override
-    public void claimReward(EntityPlayer player, Map.Entry<UUID, IQuest> quest) {
+    protected void claimReward0(EntityPlayer player, Map.Entry<UUID, IQuest> quest) {
         XPHelper.addXP(player, !levels ? amount : XPHelper.getLevelXP(amount));
     }
 
     @Override
     public void readFromNBT(NBTTagCompound nbt) {
+        super.readFromNBT(nbt);
         amount = nbt.getInteger("amount");
         levels = nbt.getBoolean("isLevels");
     }
 
     @Override
     public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
+        super.writeToNBT(nbt);
         nbt.setInteger("amount", amount);
         nbt.setBoolean("isLevels", levels);
         return nbt;


### PR DESCRIPTION
fix https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/18306

This sounds like a easy task, but there are certain rewards that are not meant to be real rewards (such as RewardQuestCompletion), but technical measures to allow more degree of questbook customizability. Disabling these rewards does not always make sense. There are also particular quests that work as a limited crafting bench, e.g. gtnh TF map quest. None of these should be affected by a player toggleable switch.

By default, scoreboard, command and quest completion rewards are marked as ignore no reward. Others are marked as respect no reward settings. Quest authors can override this setting via `ignoreDisabled` setting for each indiviual rewards. This override is supported by every type of reward that comes with the current release of BQ3, not just the aforementioned 3 reward types.