### PR TITLE
Add Localization

### DIFF
--- a/src/main/resources/assets/betterquesting/lang/en_US.lang
+++ b/src/main/resources/assets/betterquesting/lang/en_US.lang
@@ -140,6 +140,7 @@ itemGroup.betterquesting=Better Questing
 fluid.betterquesting.placeholder=Placeholder
 
 item.betterquesting.placeholder.name=Item Placeholder
+item.betterquesting.extra_life.name=Extra Life
 item.betterquesting.extra_life.full.name=Extra Life
 item.betterquesting.extra_life.half.name=Half Heart
 item.betterquesting.extra_life.quarter.name=Quarter Heart


### PR DESCRIPTION
This adds some missing localizations for unlocalized names returned by the ItemStack-insensitive version of `Item.getUnlocalizedName()`.
Relevant for the Item/Block stats introduced in https://github.com/GTNewHorizons/Hodgepodge/pull/398.