### PR TITLE
Sort the JSON keys alphabetically before saving to ensure consistent order

### DIFF
--- a/src/main/java/betterquesting/api/utils/NBTConverter.java
+++ b/src/main/java/betterquesting/api/utils/NBTConverter.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -263,7 +264,8 @@ public class NBTConverter {
             return jObj;
         }
 
-        for (String key : (Set<String>) parent.func_150296_c()) {
+        final TreeSet<String> sortedKeys = new TreeSet<>(parent.func_150296_c());
+        for (String key : sortedKeys) {
             NBTBase tag = parent.getTag(key);
 
             if (format) {


### PR DESCRIPTION
Previously they were based off the HashMap key iteration order, which cannot be guaranteed to stay the same across systems and Java versions.

Tested in dev, and it seems to sort the keys alphabetically with no errors in the BQ dev instance.