### PR TITLE
fix depth test GL state leak

### DIFF
--- a/src/main/java/betterquesting/client/QuestNotification.java
+++ b/src/main/java/betterquesting/client/QuestNotification.java
@@ -83,6 +83,7 @@ public class QuestNotification {
 
             if (notice.icon != null) {
                 RenderUtils.RenderItemStack(mc, notice.icon, width / 2 - 8, height / 4 - 20, "", color);
+                GL11.glEnable(GL11.GL_DEPTH_TEST);
             }
 
             GL11.glEnable(GL11.GL_BLEND);


### PR DESCRIPTION
The item rendering enables depth testing and disables it again after its done. 
This leaks the disabled depth test into normal rendering where its expected to be enabled, because RenderItemStack is used for displaying the quest completion overlay notification, most noticeably causing weird player and tile entity rendering in the inventory.