### PR TITLE
Make custom quest sounds decent volume

### DIFF
--- a/src/main/java/betterquesting/client/QuestNotification.java
+++ b/src/main/java/betterquesting/client/QuestNotification.java
@@ -60,7 +60,7 @@ public class QuestNotification {
             notice.init = true;
             notice.startTime = Minecraft.getSystemTime();
             // lower volume for default xp jingle, standard volume for custom sounds
-            float volume = notice.sound.equals(NativeProps.SOUND_COMPLETE.getDefault()) ? 0.4f : 1f;
+            float volume = notice.sound.equals(NativeProps.SOUND_COMPLETE.getDefault()) ? 0.25f : 1f;
             mc.getSoundHandler()
                 .playSound(new QuestCompleteSound(new ResourceLocation(notice.sound), volume));
         }

--- a/src/main/java/betterquesting/client/QuestNotification.java
+++ b/src/main/java/betterquesting/client/QuestNotification.java
@@ -5,7 +5,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.audio.PositionedSoundRecord;
+import net.minecraft.client.audio.PositionedSound;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.MathHelper;
@@ -14,6 +14,7 @@ import net.minecraftforge.client.event.RenderGameOverlayEvent;
 
 import org.lwjgl.opengl.GL11;
 
+import betterquesting.api.properties.NativeProps;
 import betterquesting.api.storage.BQ_Settings;
 import betterquesting.api.utils.RenderUtils;
 import betterquesting.api2.utils.QuestTranslation;
@@ -58,8 +59,10 @@ public class QuestNotification {
             }
             notice.init = true;
             notice.startTime = Minecraft.getSystemTime();
+            // lower volume for default xp jingle, standard volume for custom sounds
+            float volume = notice.sound.equals(NativeProps.SOUND_COMPLETE.getDefault()) ? 0.4f : 1f;
             mc.getSoundHandler()
-                .playSound(PositionedSoundRecord.func_147674_a(new ResourceLocation(notice.sound), 1.0F));
+                .playSound(new QuestCompleteSound(new ResourceLocation(notice.sound), volume));
         }
 
         if (notice.getTime() >= 6F) {
@@ -123,4 +126,18 @@ public class QuestNotification {
         }
     }
 
+    public static class QuestCompleteSound extends PositionedSound {
+
+        public QuestCompleteSound(ResourceLocation resource, float volume) {
+            super(resource);
+            this.volume = volume;
+            this.field_147663_c = 1; // Pitch
+            this.xPosF = 0;
+            this.yPosF = 0;
+            this.zPosF = 0;
+            this.repeat = false;
+            this.field_147665_h = 0; // Repeat time
+            this.field_147666_i = AttenuationType.NONE;
+        }
+    }
 }


### PR DESCRIPTION
Currently the quest complete sound (xp jingle noise) plays at 25% volume due to the `PositionedSoundRecord` constructor method used. This is ok for this sound effect, but when adding [new quest sounds](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/pull/19991), they are very quiet due to this reduced volume. This PR makes it that the default quest sound will continue to play at 25% volume, but custom added sounds will play at full volume (still respecting in game volume menu sliders).