### PR TITLE
Set entry quest to dummy quest if null

### DIFF
--- a/src/main/java/betterquesting/api2/client/gui/controls/PanelButtonQuest.java
+++ b/src/main/java/betterquesting/api2/client/gui/controls/PanelButtonQuest.java
@@ -54,8 +54,9 @@ public class PanelButtonQuest extends PanelButtonStorage<Map.Entry<UUID, IQuest>
         player = Minecraft.getMinecraft().thePlayer;
 
         if (value == null) {
-            IQuest dummyQuest = new QuestInstance();
-            value = Maps.immutableEntry(UUID.randomUUID(), dummyQuest);
+            value = Maps.immutableEntry(UUID.randomUUID(), new QuestInstance());
+        } else if (value.getValue() == null) {
+            value.setValue(new QuestInstance());
         }
 
         EnumQuestState qState = value.getValue()


### PR DESCRIPTION
If a quest fails to load (like via a missing reward metadata (gtpp manual for example)), the value is set to null.
This sets it to a dummy quest so the search button doesnt crash the client.