### PR TITLE
Fix tooltip count not displaying correctly for items

### DIFF
--- a/src/main/java/betterquesting/api2/client/gui/resources/textures/OreDictTexture.java
+++ b/src/main/java/betterquesting/api2/client/gui/resources/textures/OreDictTexture.java
@@ -47,7 +47,7 @@ public class OreDictTexture extends SlideShowTexture {
                     list.add(new ItemTexture(bis, showCount, keepAspect));
                 });
             } else {
-                list.add(new ItemTexture(stack));
+                list.add(new ItemTexture(stack, showCount, keepAspect));
             }
             return list;
         }

--- a/src/main/java/bq_standard/client/gui/rewards/PanelRewardChoice.java
+++ b/src/main/java/bq_standard/client/gui/rewards/PanelRewardChoice.java
@@ -56,7 +56,6 @@ public class PanelRewardChoice extends CanvasMinimum {
             BigItemStack stack = reward.choices.get(i);
             GuiRectangle guiRectangle = new GuiRectangle(40, i * 18, 18, 18, 0);
             PanelItemSlot is = PanelItemSlotBuilder.forValue(stack, guiRectangle)
-                .showCount(true)
                 .build();
             this.addPanel(is);
 

--- a/src/main/java/bq_standard/client/gui/rewards/PanelRewardItem.java
+++ b/src/main/java/bq_standard/client/gui/rewards/PanelRewardItem.java
@@ -30,7 +30,6 @@ public class PanelRewardItem extends CanvasMinimum {
             BigItemStack stack = reward.items.get(i);
             GuiRectangle rectangle = new GuiRectangle(0, i * 18, 18, 18, 0);
             PanelItemSlot is = PanelItemSlotBuilder.forValue(stack, rectangle)
-                .showCount(true)
                 .build();
             this.addPanel(is);
 


### PR DESCRIPTION
This PR aims to fix [this issue](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/20933).

The fix is as outlined in the proposal.

### Examples

**showCount=false for quest rewards (Consistent with current appearance):**
<img width="544" height="176" alt="image" src="https://github.com/user-attachments/assets/bcba5a27-548b-48f5-b5bb-2af1afd09289" />
<img width="535" height="190" alt="image" src="https://github.com/user-attachments/assets/8c60eca7-2255-464e-af51-53941066abe6" />



 **Enabling showCount for quest rewards for demonstration:**
<img width="548" height="167" alt="image" src="https://github.com/user-attachments/assets/178749e1-50fb-47d9-aae8-c019ad6ec9f0" />
<img width="553" height="207" alt="image" src="https://github.com/user-attachments/assets/6abe8413-d774-422e-8413-18562a7945de" />

### Notes:
- Does not address the issue of all items (as far as I can tell) rendering as oredicttextures, instead of the regular itemtexture.