### PR TITLE
Optimize file reading and key parsing for performance improvements

### DIFF
--- a/src/main/java/betterquesting/api/utils/JsonHelper.java
+++ b/src/main/java/betterquesting/api/utils/JsonHelper.java
@@ -175,10 +175,11 @@ public class JsonHelper {
 
             // NOTE: These are now split due to an edge case in the previous implementation where resource leaking can
             // occur should the outer constructor fail
+            // Added BufferedReader for better performance with large files (and doesn't need to close since is try-with-resources handles it)
             try (FileInputStream fis = new FileInputStream(file);
-                InputStreamReader fr = new InputStreamReader(fis, StandardCharsets.UTF_8)) {
-                JsonObject json = GSON.fromJson(fr, JsonObject.class);
-                fr.close();
+                InputStreamReader fr = new InputStreamReader(fis, StandardCharsets.UTF_8);
+                java.io.BufferedReader br = new java.io.BufferedReader(fr, 32768)) { // 32KB buffer
+                JsonObject json = GSON.fromJson(br, JsonObject.class);
                 return json;
             } catch (Exception e) {
                 QuestingAPI.getLogger()

--- a/src/main/java/betterquesting/questing/QuestDatabase.java
+++ b/src/main/java/betterquesting/questing/QuestDatabase.java
@@ -135,11 +135,15 @@ public class QuestDatabase extends UuidDatabase<IQuest> implements IQuestDatabas
 
     @Override
     public synchronized void readProgressFromNBT(NBTTagList json, boolean merge) {
-        for (int i = 0; i < json.tagCount(); i++) {
+        // Cache tagCount to avoid repeated method calls
+        final int tagCount = json.tagCount();
+
+        for (int i = 0; i < tagCount; i++) {
             NBTTagCompound qTag = json.getCompoundTagAt(i);
 
-            Optional<UUID> questIDOptional = NBTConverter.UuidValueType.QUEST.tryReadId(qTag);
+            // Streamlined UUID reading with early returns
             UUID questID = null;
+            Optional<UUID> questIDOptional = NBTConverter.UuidValueType.QUEST.tryReadId(qTag);
             if (questIDOptional.isPresent()) {
                 questID = questIDOptional.get();
             } else if (qTag.hasKey("questID", 99)) {
@@ -147,10 +151,8 @@ public class QuestDatabase extends UuidDatabase<IQuest> implements IQuestDatabas
                 questID = UuidConverter.convertLegacyId(qTag.getInteger("questID"));
             }
 
-            if (questID == null) {
-                // Quest was deleted
-                continue;
-            }
+            // Single null check with continue
+            if (questID == null) continue;
 
             IQuest quest = get(questID);
             if (quest != null) {


### PR DESCRIPTION
The optimization works because it uses buffered io instead of reading large files one tiny piece at a time (which causes thousands of slow system calls), the 32KB buffer reads big chunks at once and serves them from memory, reducing io overhead by batching disk operations. I used [spark agent](https://spark.lucko.me/docs/Standalone-Agent) to profile starting up. I should mention this appears AFTER mod general initialization, just the map loading time is increased far too much for large map. 
This is second part after https://github.com/GTNewHorizons/VisualProspecting/pull/72 . Collectively it should improve (at least on my side) 8 minutes down to 1m30s. 
Before : 
<img width="1360" height="639" alt="image" src="https://github.com/user-attachments/assets/5770f55e-08fa-4512-b591-5ea5b2491cab" />
After :
<img width="750" height="243" alt="image" src="https://github.com/user-attachments/assets/6b1acec4-32c9-4ba7-9603-57c569082a77" />
General discussion happen there : https://discord.com/channels/181078474394566657/305737190195986433