### PR TITLE
Add Color Toggle Option

### DIFF
--- a/src/main/java/betterquesting/api/storage/BQ_Settings.java
+++ b/src/main/java/betterquesting/api/storage/BQ_Settings.java
@@ -37,6 +37,7 @@ public class BQ_Settings {
     public static boolean viewModeAllQuestLine = false;
     public static boolean viewModeBtn = false;
     public static boolean alwaysDrawImplicit = false;
+    public static boolean forceMonochromeText = false;
     public static boolean urlDebug = false;
     public static boolean loadDefaultsOnStartup = true;
     public static boolean logNullQuests = true;

--- a/src/main/java/betterquesting/api2/client/gui/controls/PanelButtonQuest.java
+++ b/src/main/java/betterquesting/api2/client/gui/controls/PanelButtonQuest.java
@@ -38,6 +38,7 @@ import betterquesting.api2.client.gui.themes.presets.PresetTexture;
 import betterquesting.api2.storage.DBEntry;
 import betterquesting.api2.utils.QuestTranslation;
 import betterquesting.client.BookmarkHandler;
+import betterquesting.client.util.GuiTextToggles;
 import betterquesting.questing.QuestDatabase;
 import betterquesting.questing.QuestInstance;
 import betterquesting.storage.QuestSettings;
@@ -155,7 +156,7 @@ public class PanelButtonQuest extends PanelButtonStorage<Map.Entry<UUID, IQuest>
     private List<String> getStandardTooltip(IQuest quest, EntityPlayer player, UUID qID) {
         List<String> list = new ArrayList<>();
 
-        list.add(QuestTranslation.translateQuestName(qID, quest));
+        list.add(GuiTextToggles.applyMonochromeIfEnabled(QuestTranslation.translateQuestName(qID, quest)));
 
         UUID playerID = QuestingAPI.getQuestingUUID(player);
 
@@ -203,14 +204,16 @@ public class PanelButtonQuest extends PanelButtonStorage<Map.Entry<UUID, IQuest>
                         .toUpperCase()
                     + ")");
 
-            // TODO: Make this lookup unnecessary
             QuestDatabase.INSTANCE.filterKeys(quest.getRequirements())
                 .entrySet()
                 .stream()
                 .filter(
                     entry -> !entry.getValue()
                         .isComplete(playerID))
-                .forEach(entry -> list.add(EnumChatFormatting.RED + "- " + QuestTranslation.translateQuestName(entry)));
+                .forEach(
+                    entry -> list.add(
+                        EnumChatFormatting.RED + "- "
+                            + GuiTextToggles.applyMonochromeIfEnabled(QuestTranslation.translateQuestName(entry))));
         } else {
             int n = 0;
 

--- a/src/main/java/betterquesting/api2/client/gui/controls/PanelButtonQuest.java
+++ b/src/main/java/betterquesting/api2/client/gui/controls/PanelButtonQuest.java
@@ -212,8 +212,7 @@ public class PanelButtonQuest extends PanelButtonStorage<Map.Entry<UUID, IQuest>
                         .isComplete(playerID))
                 .forEach(
                     entry -> list.add(
-                        EnumChatFormatting.RED + "- "
-                            + GuiTextToggles.applyMonochromeIfEnabled(QuestTranslation.translateQuestName(entry))));
+                        "- " + GuiTextToggles.applyMonochromeIfEnabled(QuestTranslation.translateQuestName(entry))));
         } else {
             int n = 0;
 

--- a/src/main/java/betterquesting/api2/client/gui/themes/presets/PresetIcon.java
+++ b/src/main/java/betterquesting/api2/client/gui/themes/presets/PresetIcon.java
@@ -46,6 +46,7 @@ public enum PresetIcon {
     ICON_REFRESH("icon_refresh"),
     ICON_ITEM("icon_item"),
     ICON_SCALE("icon_scale"),
+    ICON_PAINT("icon_paint"),
 
     ICON_EXIT("icon_exit"),
     ICON_NOTICE("icon_notice"),
@@ -206,6 +207,9 @@ public enum PresetIcon {
         reg.setDefaultTexture(
             ICON_SCALE.key,
             new SimpleTexture(TX_ICONS, new GuiRectangle(144, 16, 16, 16)).maintainAspect(true));
+        reg.setDefaultTexture(
+            ICON_PAINT.key,
+            new SimpleTexture(TX_ICONS, new GuiRectangle(48, 48, 16, 16)).maintainAspect(true));
         reg.setDefaultTexture(
             ICON_EXIT.key,
             new SimpleTexture(TX_ICONS, new GuiRectangle(160, 0, 16, 16)).maintainAspect(true));

--- a/src/main/java/betterquesting/client/gui2/GuiQuest.java
+++ b/src/main/java/betterquesting/client/gui2/GuiQuest.java
@@ -54,7 +54,7 @@ import betterquesting.api2.client.gui.themes.presets.PresetLine;
 import betterquesting.api2.client.gui.themes.presets.PresetTexture;
 import betterquesting.api2.storage.DBEntry;
 import betterquesting.api2.utils.QuestTranslation;
-import betterquesting.client.gui2.GuiQuestLines.ScrollPosition;
+import betterquesting.client.util.GuiTextToggles;
 import betterquesting.core.BetterQuesting;
 import betterquesting.network.handlers.NetQuestAction;
 import betterquesting.questing.QuestDatabase;
@@ -166,7 +166,8 @@ public class GuiQuest extends GuiScreenCanvas implements IPEventListener, INeeds
 
         PanelTextBox panTxt = new PanelTextBox(
             new GuiTransform(GuiAlign.TOP_EDGE, new GuiPadding(0, 16, 0, -32), 0),
-            QuestTranslation.translateQuestName(questID, quest)).setAlignment(1);
+            GuiTextToggles.applyMonochromeIfEnabled(QuestTranslation.translateQuestName(questID, quest)))
+                .setAlignment(1);
         panTxt.setColor(PresetColor.TEXT_HEADER.getColor());
         cvBackground.addPanel(panTxt);
 
@@ -584,7 +585,7 @@ public class GuiQuest extends GuiScreenCanvas implements IPEventListener, INeeds
                 csDesc.getTransform()
                     .getWidth(),
                 0),
-            questText,
+            GuiTextToggles.applyMonochromeIfEnabled(questText),
             true,
             true);
         paDesc.setColor(PresetColor.TEXT_MAIN.getColor());// .setFontSize(10);

--- a/src/main/java/betterquesting/client/gui2/GuiQuestLines.java
+++ b/src/main/java/betterquesting/client/gui2/GuiQuestLines.java
@@ -1,6 +1,7 @@
 package betterquesting.client.gui2;
 
 import static betterquesting.api.storage.BQ_Settings.alwaysDrawImplicit;
+import static betterquesting.api.storage.BQ_Settings.forceMonochromeText;
 
 import java.awt.Toolkit;
 import java.awt.datatransfer.StringSelection;
@@ -458,6 +459,7 @@ public class GuiQuestLines extends GuiScreenCanvas implements IPEventListener, I
             yOff += 16;
         }
 
+        // Always Draw Implicit Dependency Button
         PanelButton btnViewMode = new PanelButton(new GuiTransform(GuiAlign.TOP_LEFT, 8, yOff, 32, 16, -2), -1, "")
             .setIcon(
                 alwaysDrawImplicit ? PresetIcon.ICON_VISIBILITY_IMPLICIT.getTexture()
@@ -487,6 +489,38 @@ public class GuiQuestLines extends GuiScreenCanvas implements IPEventListener, I
                 QuestTranslation.translate("betterquesting.btn.always_draw_implicit"),
                 QuestTranslation.translate("betterquesting.tooltip.cycle." + alwaysDrawImplicit)));
         cvBackground.addPanel(btnViewMode);
+        yOff += 16;
+
+        // Quest Color Button
+        final PanelButton btnMonoText = new PanelButton(
+            new GuiTransform(GuiAlign.TOP_LEFT, 8, yOff, 32, 16, -2),
+            -1,
+            "");
+        final Runnable updateMonoButton = () -> {
+            btnMonoText.setIcon(
+                PresetIcon.ICON_PAINT.getTexture(),
+                BQ_Settings.forceMonochromeText ? new GuiColorStatic(0xFF444444) : new GuiColorStatic(0xFFFFFFFF),
+                0);
+            btnMonoText.setTooltip(
+                Arrays.asList(
+                    QuestTranslation.translate("betterquesting.btn.force_monochrome"),
+                    QuestTranslation.translate("betterquesting.tooltip.cycle." + !forceMonochromeText)));
+        };
+        updateMonoButton.run();
+        btnMonoText.setClickAction((b) -> {
+            BQ_Settings.forceMonochromeText = !BQ_Settings.forceMonochromeText;
+            ConfigHandler.config.get(
+                Configuration.CATEGORY_GENERAL,
+                "Force Monochrome Text",
+                false,
+                "If true, quest titles and text content will show no color. This property can be changed by the GUI.")
+                .set(BQ_Settings.forceMonochromeText);
+            ConfigHandler.config.save();
+
+            updateMonoButton.run();
+            refreshGui();
+        });
+        cvBackground.addPanel(btnMonoText);
 
         // === CHAPTER VIEWPORT ===
 

--- a/src/main/java/betterquesting/client/util/GuiTextToggles.java
+++ b/src/main/java/betterquesting/client/util/GuiTextToggles.java
@@ -1,0 +1,27 @@
+package betterquesting.client.util;
+
+import java.util.regex.Pattern;
+
+import betterquesting.api.storage.BQ_Settings;
+
+public final class GuiTextToggles {
+
+    private GuiTextToggles() {}
+
+    private static final Pattern COLOR_CODE_REMOVER = Pattern.compile("§[0-9a-fA-F]");
+
+    private static final Pattern BQ_TAG_REMOVER = Pattern
+        .compile("\\[(?:url|warn|note|quest)]|\\[/(?:url|warn|note|quest)]");
+
+    public static String applyMonochromeIfEnabled(String s) {
+        if (s == null) return null;
+
+        s = BQ_TAG_REMOVER.matcher(s)
+            .replaceAll("");
+
+        if (!BQ_Settings.forceMonochromeText) return s;
+
+        return COLOR_CODE_REMOVER.matcher(s)
+            .replaceAll("");
+    }
+}

--- a/src/main/java/betterquesting/handlers/ConfigHandler.java
+++ b/src/main/java/betterquesting/handlers/ConfigHandler.java
@@ -118,6 +118,11 @@ public class ConfigHandler {
             Configuration.CATEGORY_GENERAL,
             false,
             "If true, always draw implicit dependency. This property can be changed by the GUI");
+        BQ_Settings.forceMonochromeText = config.getBoolean(
+            "Force Monochrome Text",
+            Configuration.CATEGORY_GENERAL,
+            false,
+            "If true, quest titles and text content will show no color. This property can be changed by the GUI.");
         BQ_Settings.urlDebug = config.getBoolean(
             "Highlight detected clickable url hotzone.",
             Configuration.CATEGORY_GENERAL,

--- a/src/main/resources/assets/betterquesting/lang/en_US.lang
+++ b/src/main/resources/assets/betterquesting/lang/en_US.lang
@@ -66,6 +66,7 @@ betterquesting.btn.bookmark_quest=Bookmark
 betterquesting.btn.unbookmark_quest=Unbookmark
 betterquesting.btn.share_quest=Share to Chat
 betterquesting.btn.copy_quest=Copy Quest ID
+betterquesting.btn.force_monochrome=Show Quest Colors
 
 betterquesting.home.exit=Exit
 betterquesting.home.quests=Quests


### PR DESCRIPTION
Given the amount of color additions to the quest book lately, I felt like for accessibility purposes or user preference that it was appropriate to add a color toggle switch. Don't get me wrong- I've only heard positive feedback on adding color, but options should exist. Keeps bold, italic, & underline formatting. Works on all theme variants.

| Default Behavior | Toggle Disabled |
|------------------|----------------|
| <img src="https://github.com/user-attachments/assets/de912509-ebb3-4d88-bbbd-f32d1f424fa2" width="350"/> | <img src="https://github.com/user-attachments/assets/fc8a6486-4d02-4b7f-8bcd-9a9b63ca457e" width="350"/> |
| <img src="https://github.com/user-attachments/assets/79aa1595-addd-4f23-85d1-1c51e534782c" width="350"/> | <img width="350" height="197" alt="image" src="https://github.com/user-attachments/assets/538ba01c-8db1-46eb-a558-2b3cefd9f0b0" /> |
| <img src="https://github.com/user-attachments/assets/aa9498ee-b376-4506-8d17-781efedc43a5" width="350"/> | <img src="https://github.com/user-attachments/assets/a94417b2-32ba-4d20-a4e4-78d700f3f8f5" width="350"/> |