### PR TITLE
Add Quest Dep Arrow Option to QB

### DIFF
--- a/src/main/java/betterquesting/api/storage/BQ_Settings.java
+++ b/src/main/java/betterquesting/api/storage/BQ_Settings.java
@@ -37,6 +37,7 @@ public class BQ_Settings {
     public static boolean viewModeAllQuestLine = false;
     public static boolean viewModeBtn = false;
     public static boolean alwaysDrawImplicit = false;
+    public static boolean showDependencyArrows = false;
     public static boolean forceMonochromeText = false;
     public static boolean urlDebug = false;
     public static boolean loadDefaultsOnStartup = true;

--- a/src/main/java/betterquesting/api2/client/gui/panels/content/PanelLine.java
+++ b/src/main/java/betterquesting/api2/client/gui/panels/content/PanelLine.java
@@ -37,11 +37,6 @@ public class PanelLine implements IGuiPanel {
     }
 
     public PanelLine(IGuiRect start, IGuiRect end, IGuiLine line, int width, IGuiColor color, int drawOrder,
-        ShouldDrawPredicate shouldDraw, boolean drawArrowHead) {
-        this(start, end, line, width, color, drawOrder, shouldDraw, drawArrowHead, null);
-    }
-
-    public PanelLine(IGuiRect start, IGuiRect end, IGuiLine line, int width, IGuiColor color, int drawOrder,
         ShouldDrawPredicate shouldDraw, boolean drawArrowHead, ScaleSupplier scaleSupplier) {
         this.start = start;
         this.end = end;

--- a/src/main/java/betterquesting/api2/client/gui/panels/content/PanelLine.java
+++ b/src/main/java/betterquesting/api2/client/gui/panels/content/PanelLine.java
@@ -23,26 +23,33 @@ public class PanelLine implements IGuiPanel {
     private final IGuiColor color;
     private final int width;
     private final boolean drawArrowHead;
+    private final ScaleSupplier scaleSupplier;
 
     private boolean enabled = true;
 
     public PanelLine(IGuiRect start, IGuiRect end, IGuiLine line, int width, IGuiColor color, int drawOrder) {
-        this(start, end, line, width, color, drawOrder, null, false);
+        this(start, end, line, width, color, drawOrder, null, false, null);
     }
 
     public PanelLine(IGuiRect start, IGuiRect end, IGuiLine line, int width, IGuiColor color, int drawOrder,
         ShouldDrawPredicate shouldDraw) {
-        this(start, end, line, width, color, drawOrder, shouldDraw, false);
+        this(start, end, line, width, color, drawOrder, shouldDraw, false, null);
     }
 
     public PanelLine(IGuiRect start, IGuiRect end, IGuiLine line, int width, IGuiColor color, int drawOrder,
         ShouldDrawPredicate shouldDraw, boolean drawArrowHead) {
+        this(start, end, line, width, color, drawOrder, shouldDraw, drawArrowHead, null);
+    }
+
+    public PanelLine(IGuiRect start, IGuiRect end, IGuiLine line, int width, IGuiColor color, int drawOrder,
+        ShouldDrawPredicate shouldDraw, boolean drawArrowHead, ScaleSupplier scaleSupplier) {
         this.start = start;
         this.end = end;
         this.line = line;
         this.width = width;
         this.color = color;
         this.drawArrowHead = drawArrowHead;
+        this.scaleSupplier = scaleSupplier;
         this.bounds = new GuiRectangle(0, 0, 0, 0, drawOrder);
         this.shouldDraw = shouldDraw;
         this.bounds.setParent(start);
@@ -93,8 +100,10 @@ public class PanelLine implements IGuiPanel {
 
         float dirX = deltaX / lineLength;
         float dirY = deltaY / lineLength;
-        float defaultMarkerLength = Math.max(3F, width * 0.85F);
-        float markerSpacing = 24F;
+        float zoom = scaleSupplier == null ? 1F : Math.max(0.2F, scaleSupplier.getScale());
+        float zoomScale = zoom < 1F ? Math.min(1.75F, (float) Math.pow(1F / zoom, 0.7F)) : 1F;
+        float defaultMarkerLength = Math.max(3F, width * 0.85F) * zoomScale;
+        float markerSpacing = 48F;
         float startEdge = getEdgeDistance(start, dirX, dirY);
         float endEdge = getEdgeDistance(end, dirX, dirY);
         float visibleStart = startEdge;
@@ -114,9 +123,8 @@ public class PanelLine implements IGuiPanel {
         GL11.glDisable(GL11.GL_TEXTURE_2D);
         GL11.glDisable(GL11.GL_LINE_STIPPLE);
         color.applyGlColor();
-        GL11.glLineWidth(Math.max(1F, width * 0.4F));
 
-        GL11.glBegin(GL11.GL_LINES);
+        GL11.glBegin(GL11.GL_TRIANGLES);
         for (int step = 0;; step++) {
             float offset = step * markerSpacing;
             boolean drewAny = false;
@@ -147,7 +155,6 @@ public class PanelLine implements IGuiPanel {
         }
         GL11.glEnd();
 
-        GL11.glLineWidth(1F);
         GL11.glEnable(GL11.GL_TEXTURE_2D);
         GL11.glColor4f(1F, 1F, 1F, 1F);
     }
@@ -165,9 +172,8 @@ public class PanelLine implements IGuiPanel {
         float normalY = dirX;
 
         GL11.glVertex2f(tipX, tipY);
-        GL11.glVertex2f(baseX + normalX * markerWidth, baseY + normalY * markerWidth);
-        GL11.glVertex2f(tipX, tipY);
         GL11.glVertex2f(baseX - normalX * markerWidth, baseY - normalY * markerWidth);
+        GL11.glVertex2f(baseX + normalX * markerWidth, baseY + normalY * markerWidth);
     }
 
     private float getEdgeDistance(IGuiRect rect, float dirX, float dirY) {
@@ -206,5 +212,10 @@ public class PanelLine implements IGuiPanel {
     public interface ShouldDrawPredicate {
 
         boolean shouldDraw(int mx_mc, int my_mc, float partialTicks);
+    }
+
+    public interface ScaleSupplier {
+
+        float getScale();
     }
 }

--- a/src/main/java/betterquesting/api2/client/gui/panels/content/PanelLine.java
+++ b/src/main/java/betterquesting/api2/client/gui/panels/content/PanelLine.java
@@ -22,20 +22,27 @@ public class PanelLine implements IGuiPanel {
     private final IGuiRect end;
     private final IGuiColor color;
     private final int width;
+    private final boolean drawArrowHead;
 
     private boolean enabled = true;
 
     public PanelLine(IGuiRect start, IGuiRect end, IGuiLine line, int width, IGuiColor color, int drawOrder) {
-        this(start, end, line, width, color, drawOrder, null);
+        this(start, end, line, width, color, drawOrder, null, false);
     }
 
     public PanelLine(IGuiRect start, IGuiRect end, IGuiLine line, int width, IGuiColor color, int drawOrder,
         ShouldDrawPredicate shouldDraw) {
+        this(start, end, line, width, color, drawOrder, shouldDraw, false);
+    }
+
+    public PanelLine(IGuiRect start, IGuiRect end, IGuiLine line, int width, IGuiColor color, int drawOrder,
+        ShouldDrawPredicate shouldDraw, boolean drawArrowHead) {
         this.start = start;
         this.end = end;
         this.line = line;
         this.width = width;
         this.color = color;
+        this.drawArrowHead = drawArrowHead;
         this.bounds = new GuiRectangle(0, 0, 0, 0, drawOrder);
         this.shouldDraw = shouldDraw;
         this.bounds.setParent(start);
@@ -64,8 +71,111 @@ public class PanelLine implements IGuiPanel {
         if (shouldDraw == null || shouldDraw.shouldDraw(mx, my, partialTick)) {
             GL11.glPushMatrix();
             line.drawLine(start, end, width, color, partialTick);
+            if (drawArrowHead) {
+                drawArrowMarkers();
+            }
             GL11.glPopMatrix();
         }
+    }
+
+    private void drawArrowMarkers() {
+        float startX = start.getX() + start.getWidth() / 2F;
+        float startY = start.getY() + start.getHeight() / 2F;
+        float endX = end.getX() + end.getWidth() / 2F;
+        float endY = end.getY() + end.getHeight() / 2F;
+        float deltaX = endX - startX;
+        float deltaY = endY - startY;
+        float lineLength = (float) Math.sqrt(deltaX * deltaX + deltaY * deltaY);
+
+        if (lineLength <= 0.001F) {
+            return;
+        }
+
+        float dirX = deltaX / lineLength;
+        float dirY = deltaY / lineLength;
+        float defaultMarkerLength = Math.max(3F, width * 0.85F);
+        float markerSpacing = 24F;
+        float startEdge = getEdgeDistance(start, dirX, dirY);
+        float endEdge = getEdgeDistance(end, dirX, dirY);
+        float visibleStart = startEdge;
+        float visibleEnd = lineLength - endEdge;
+        float visibleLength = Math.max(0F, visibleEnd - visibleStart);
+        float markerLength = Math.min(defaultMarkerLength, Math.max(1.5F, visibleLength - 2F));
+        float markerWidth = Math.max(1F, markerLength * 0.45F);
+        float halfMarkerLength = markerLength / 2F;
+        float minMarkerCenter = visibleStart + halfMarkerLength;
+        float maxMarkerCenter = visibleEnd - halfMarkerLength;
+        float centerPos = (visibleStart + visibleEnd) / 2F;
+
+        if (maxMarkerCenter < minMarkerCenter) {
+            minMarkerCenter = maxMarkerCenter = centerPos;
+        }
+
+        GL11.glDisable(GL11.GL_TEXTURE_2D);
+        GL11.glDisable(GL11.GL_LINE_STIPPLE);
+        color.applyGlColor();
+        GL11.glLineWidth(Math.max(1F, width * 0.4F));
+
+        GL11.glBegin(GL11.GL_LINES);
+        for (int step = 0;; step++) {
+            float offset = step * markerSpacing;
+            boolean drewAny = false;
+
+            if (step == 0) {
+                if (centerPos >= minMarkerCenter && centerPos <= maxMarkerCenter) {
+                    addArrowMarker(startX, startY, dirX, dirY, centerPos, markerLength, markerWidth);
+                    drewAny = true;
+                }
+            } else {
+                float lowerPos = centerPos - offset;
+                float upperPos = centerPos + offset;
+
+                if (lowerPos >= minMarkerCenter && lowerPos <= maxMarkerCenter) {
+                    addArrowMarker(startX, startY, dirX, dirY, lowerPos, markerLength, markerWidth);
+                    drewAny = true;
+                }
+
+                if (upperPos >= minMarkerCenter && upperPos <= maxMarkerCenter) {
+                    addArrowMarker(startX, startY, dirX, dirY, upperPos, markerLength, markerWidth);
+                    drewAny = true;
+                }
+            }
+
+            if (!drewAny && centerPos - offset < minMarkerCenter && centerPos + offset > maxMarkerCenter) {
+                break;
+            }
+        }
+        GL11.glEnd();
+
+        GL11.glLineWidth(1F);
+        GL11.glEnable(GL11.GL_TEXTURE_2D);
+        GL11.glColor4f(1F, 1F, 1F, 1F);
+    }
+
+    private void addArrowMarker(float startX, float startY, float dirX, float dirY, float linePos, float markerLength,
+        float markerWidth) {
+        float halfMarkerLength = markerLength / 2F;
+        float centerX = startX + dirX * linePos;
+        float centerY = startY + dirY * linePos;
+        float tipX = centerX + dirX * halfMarkerLength;
+        float tipY = centerY + dirY * halfMarkerLength;
+        float baseX = centerX - dirX * halfMarkerLength;
+        float baseY = centerY - dirY * halfMarkerLength;
+        float normalX = -dirY;
+        float normalY = dirX;
+
+        GL11.glVertex2f(tipX, tipY);
+        GL11.glVertex2f(baseX + normalX * markerWidth, baseY + normalY * markerWidth);
+        GL11.glVertex2f(tipX, tipY);
+        GL11.glVertex2f(baseX - normalX * markerWidth, baseY - normalY * markerWidth);
+    }
+
+    private float getEdgeDistance(IGuiRect rect, float dirX, float dirY) {
+        float halfWidth = rect.getWidth() / 2F;
+        float halfHeight = rect.getHeight() / 2F;
+        float distX = Math.abs(dirX) < 0.001F ? Float.POSITIVE_INFINITY : halfWidth / Math.abs(dirX);
+        float distY = Math.abs(dirY) < 0.001F ? Float.POSITIVE_INFINITY : halfHeight / Math.abs(dirY);
+        return Math.min(distX, distY);
     }
 
     @Override

--- a/src/main/java/betterquesting/api2/client/gui/panels/lists/CanvasQuestLine.java
+++ b/src/main/java/betterquesting/api2/client/gui/panels/lists/CanvasQuestLine.java
@@ -215,7 +215,8 @@ public class CanvasQuestLine extends CanvasScrolling {
                             main ? 8 : 4,
                             txLineCol,
                             1,
-                            predicate));
+                            predicate,
+                            true));
                 }
             }
         }

--- a/src/main/java/betterquesting/api2/client/gui/panels/lists/CanvasQuestLine.java
+++ b/src/main/java/betterquesting/api2/client/gui/panels/lists/CanvasQuestLine.java
@@ -216,7 +216,7 @@ public class CanvasQuestLine extends CanvasScrolling {
                             txLineCol,
                             1,
                             predicate,
-                            true,
+                            BQ_Settings.showDependencyArrows,
                             this::getZoom));
                 }
             }

--- a/src/main/java/betterquesting/api2/client/gui/panels/lists/CanvasQuestLine.java
+++ b/src/main/java/betterquesting/api2/client/gui/panels/lists/CanvasQuestLine.java
@@ -216,7 +216,8 @@ public class CanvasQuestLine extends CanvasScrolling {
                             txLineCol,
                             1,
                             predicate,
-                            true));
+                            true,
+                            this::getZoom));
                 }
             }
         }

--- a/src/main/java/betterquesting/client/gui2/GuiQuestLines.java
+++ b/src/main/java/betterquesting/client/gui2/GuiQuestLines.java
@@ -491,6 +491,38 @@ public class GuiQuestLines extends GuiScreenCanvas implements IPEventListener, I
         cvBackground.addPanel(btnViewMode);
         yOff += 16;
 
+        // Dependency Arrow Button
+        final PanelButton btnDependencyArrows = new PanelButton(
+            new GuiTransform(GuiAlign.TOP_LEFT, 8, yOff, 32, 16, -2),
+            -1,
+            "");
+        final Runnable updateDependencyArrowButton = () -> {
+            btnDependencyArrows.setIcon(
+                PresetIcon.ICON_TWO_WAY.getTexture(),
+                BQ_Settings.showDependencyArrows ? new GuiColorStatic(0xFFFFFFFF) : new GuiColorStatic(0xFF444444),
+                0);
+            btnDependencyArrows.setTooltip(
+                Arrays.asList(
+                    QuestTranslation.translate("betterquesting.btn.show_dependency_arrows"),
+                    QuestTranslation.translate("betterquesting.tooltip.cycle." + BQ_Settings.showDependencyArrows)));
+        };
+        updateDependencyArrowButton.run();
+        btnDependencyArrows.setClickAction((b) -> {
+            BQ_Settings.showDependencyArrows = !BQ_Settings.showDependencyArrows;
+            ConfigHandler.config.get(
+                Configuration.CATEGORY_GENERAL,
+                "Show dependency arrows",
+                false,
+                "If true, quest dependency lines will render directional arrows. This property can be changed by the GUI.")
+                .set(BQ_Settings.showDependencyArrows);
+            ConfigHandler.config.save();
+
+            updateDependencyArrowButton.run();
+            refreshGui();
+        });
+        cvBackground.addPanel(btnDependencyArrows);
+        yOff += 16;
+
         // Quest Color Button
         final PanelButton btnMonoText = new PanelButton(
             new GuiTransform(GuiAlign.TOP_LEFT, 8, yOff, 32, 16, -2),

--- a/src/main/java/betterquesting/handlers/ConfigHandler.java
+++ b/src/main/java/betterquesting/handlers/ConfigHandler.java
@@ -118,6 +118,11 @@ public class ConfigHandler {
             Configuration.CATEGORY_GENERAL,
             false,
             "If true, always draw implicit dependency. This property can be changed by the GUI");
+        BQ_Settings.showDependencyArrows = config.getBoolean(
+            "Show dependency arrows",
+            Configuration.CATEGORY_GENERAL,
+            false,
+            "If true, quest dependency lines will render directional arrows. This property can be changed by the GUI.");
         BQ_Settings.forceMonochromeText = config.getBoolean(
             "Force Monochrome Text",
             Configuration.CATEGORY_GENERAL,

--- a/src/main/resources/assets/betterquesting/lang/en_US.lang
+++ b/src/main/resources/assets/betterquesting/lang/en_US.lang
@@ -67,6 +67,7 @@ betterquesting.btn.unbookmark_quest=Unbookmark
 betterquesting.btn.share_quest=Share to Chat
 betterquesting.btn.copy_quest=Copy Quest ID
 betterquesting.btn.force_monochrome=Show Quest Colors
+betterquesting.btn.show_dependency_arrows=Show Dependency Arrows
 
 betterquesting.home.exit=Exit
 betterquesting.home.quests=Quests


### PR DESCRIPTION
Off by default, togglable on side panel. Simply a visual tool.

Normal:
<img width="2424" height="1233" alt="image" src="https://github.com/user-attachments/assets/6337066a-6221-4aee-8aab-990be7479ebd" />

Arrow Examples:
<img width="2412" height="1212" alt="image" src="https://github.com/user-attachments/assets/3b59d165-1401-4f82-b19f-0f7e1a2eef90" />
<img width="1632" height="989" alt="image" src="https://github.com/user-attachments/assets/69caf889-b336-455c-89e9-6e3e1069f79e" />


Adjusts with zoom:
<img width="1639" height="981" alt="image" src="https://github.com/user-attachments/assets/571af7a2-2e04-47e4-b28b-9a54a86aaa35" />
<img width="2409" height="1200" alt="image" src="https://github.com/user-attachments/assets/aca0d9c5-eb19-4118-b95b-6eadb7a0d5e6" />
<img width="2081" height="1027" alt="image" src="https://github.com/user-attachments/assets/f394120a-1650-44ae-8f91-9e73093448f9" />
