### PR TITLE
[Memory-opti:fix leak] Fix server leak

### DIFF
--- a/src/main/java/betterquesting/client/gui2/GuiHome.java
+++ b/src/main/java/betterquesting/client/gui2/GuiHome.java
@@ -42,8 +42,8 @@ import betterquesting.client.gui2.editors.nbt.GuiNbtEditor;
 import betterquesting.client.gui2.party.GuiPartyCreate;
 import betterquesting.client.gui2.party.GuiPartyManage;
 import betterquesting.commands.admin.QuestCommandDefaults;
+import betterquesting.core.BetterQuesting;
 import betterquesting.handlers.ConfigHandler;
-import betterquesting.handlers.EventHandler;
 import betterquesting.handlers.SaveLoadHandler;
 import betterquesting.network.handlers.NetSettingSync;
 import betterquesting.questing.party.PartyManager;
@@ -223,18 +223,18 @@ public class GuiHome extends GuiScreenCanvas implements IPEventListener {
             final File qFile = new File(BQ_Settings.defaultDir, "DefaultQuests.json");
 
             if (qDir.exists()) {
-                EventHandler.scheduleServerTask(Executors.callable(() -> {
+                BetterQuesting.proxy.scheduleServerTask(Executors.callable(() -> {
                     QuestCommandDefaults.load(null, null, qDir, false);
                     SaveLoadHandler.INSTANCE.resetUpdate();
-                }));
+                }), true);
 
                 // this.initGui(); // Reset the whole thing
                 doClose();
             } else if (qFile.exists()) {
-                EventHandler.scheduleServerTask(Executors.callable(() -> {
+                BetterQuesting.proxy.scheduleServerTask(Executors.callable(() -> {
                     QuestCommandDefaults.loadLegacy(null, null, qDir, false);
                     SaveLoadHandler.INSTANCE.resetUpdate();
-                }));
+                }), true);
 
                 // this.initGui(); // Reset the whole thing
                 doClose();

--- a/src/main/java/betterquesting/core/BetterQuesting.java
+++ b/src/main/java/betterquesting/core/BetterQuesting.java
@@ -1,15 +1,11 @@
 package betterquesting.core;
 
 import net.minecraft.block.Block;
-import net.minecraft.command.ICommandManager;
-import net.minecraft.command.ServerCommandManager;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
-import net.minecraft.launchwrapper.Launch;
-import net.minecraft.server.MinecraftServer;
 import net.minecraftforge.common.config.Configuration;
 import net.minecraftforge.fluids.FluidRegistry;
 
@@ -18,19 +14,13 @@ import org.apache.logging.log4j.Logger;
 import betterquesting.api.placeholders.EntityPlaceholder;
 import betterquesting.api.placeholders.FluidPlaceholder;
 import betterquesting.api.placeholders.ItemPlaceholder;
-import betterquesting.api.storage.BQ_Settings;
 import betterquesting.blocks.BlockObservationStation;
 import betterquesting.blocks.BlockSubmitStation;
 import betterquesting.blocks.TileObservationStation;
 import betterquesting.blocks.TileSubmitStation;
 import betterquesting.client.CreativeTabQuesting;
-import betterquesting.commands.BQ_CommandAdmin;
-import betterquesting.commands.BQ_CommandDebug;
-import betterquesting.commands.BQ_CommandUser;
-import betterquesting.commands.BQ_CopyProgress;
 import betterquesting.core.proxies.CommonProxy;
 import betterquesting.handlers.ConfigHandler;
-import betterquesting.handlers.SaveLoadHandler;
 import betterquesting.items.ItemExtraLife;
 import betterquesting.items.ItemGuideBook;
 import betterquesting.network.PacketQuesting;
@@ -169,30 +159,12 @@ public class BetterQuesting {
     }
 
     @EventHandler
-    public void serverStart(FMLServerStartingEvent event) {
-        MinecraftServer server = event.getServer();
-        ICommandManager command = server.getCommandManager();
-        ServerCommandManager manager = (ServerCommandManager) command;
-
-        manager.registerCommand(new BQ_CopyProgress());
-        manager.registerCommand(new BQ_CommandAdmin());
-        manager.registerCommand(new BQ_CommandUser());
-
-        if ((Boolean) Launch.blackboard.get("fml.deobfuscatedEnvironment"))
-            manager.registerCommand(new BQ_CommandDebug());
-
-        SaveLoadHandler.INSTANCE.loadDatabases(server);
-        if (BQ_Settings.loadDefaultsOnStartup) {
-            try {
-                manager.executeCommand(server, "/bq_admin default load");
-            } catch (Exception e) {
-                logger.error("Could not load the default quest database", e);
-            }
-        }
+    public void serverStarting(FMLServerStartingEvent event) {
+        proxy.serverStarting(event);
     }
 
     @EventHandler
-    public void serverStop(FMLServerStoppedEvent event) {
-        SaveLoadHandler.INSTANCE.unloadDatabases();
+    public void serverStopped(FMLServerStoppedEvent event) {
+        proxy.serverStopped(event);
     }
 }

--- a/src/main/java/betterquesting/core/proxies/CommonProxy.java
+++ b/src/main/java/betterquesting/core/proxies/CommonProxy.java
@@ -1,10 +1,14 @@
 package betterquesting.core.proxies;
 
+import java.util.concurrent.Callable;
+
 import net.minecraft.command.ICommandManager;
 import net.minecraft.command.ServerCommandManager;
 import net.minecraft.launchwrapper.Launch;
 import net.minecraft.server.MinecraftServer;
 import net.minecraftforge.common.MinecraftForge;
+
+import com.google.common.util.concurrent.ListenableFuture;
 
 import betterquesting.api.storage.BQ_Settings;
 import betterquesting.commands.BQ_CommandAdmin;
@@ -16,12 +20,15 @@ import betterquesting.core.ExpansionLoader;
 import betterquesting.handlers.EventHandler;
 import betterquesting.handlers.GuiHandler;
 import betterquesting.handlers.SaveLoadHandler;
+import betterquesting.handlers.ServerTaskScheduler;
 import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.event.FMLServerStartingEvent;
 import cpw.mods.fml.common.event.FMLServerStoppedEvent;
 import cpw.mods.fml.common.network.NetworkRegistry;
 
 public class CommonProxy {
+
+    private ServerTaskScheduler taskScheduler;
 
     public boolean isClient() {
         return false;
@@ -62,9 +69,26 @@ public class CommonProxy {
                 BetterQuesting.logger.error("Could not load the default quest database", e);
             }
         }
+        this.taskScheduler = new ServerTaskScheduler(Thread.currentThread());
+        FMLCommonHandler.instance()
+            .bus()
+            .register(this.taskScheduler);
     }
 
     public void serverStopped(FMLServerStoppedEvent event) {
         SaveLoadHandler.INSTANCE.unloadDatabases();
+        if (this.taskScheduler != null) {
+            FMLCommonHandler.instance()
+                .bus()
+                .unregister(this.taskScheduler);
+            this.taskScheduler = null;
+        }
+    }
+
+    public <T> ListenableFuture<T> scheduleServerTask(Callable<T> callable) {
+        if (this.taskScheduler != null) {
+            return this.taskScheduler.scheduleServerTask(callable);
+        }
+        return null;
     }
 }

--- a/src/main/java/betterquesting/core/proxies/CommonProxy.java
+++ b/src/main/java/betterquesting/core/proxies/CommonProxy.java
@@ -1,12 +1,24 @@
 package betterquesting.core.proxies;
 
+import net.minecraft.command.ICommandManager;
+import net.minecraft.command.ServerCommandManager;
+import net.minecraft.launchwrapper.Launch;
+import net.minecraft.server.MinecraftServer;
 import net.minecraftforge.common.MinecraftForge;
 
+import betterquesting.api.storage.BQ_Settings;
+import betterquesting.commands.BQ_CommandAdmin;
+import betterquesting.commands.BQ_CommandDebug;
+import betterquesting.commands.BQ_CommandUser;
+import betterquesting.commands.BQ_CopyProgress;
 import betterquesting.core.BetterQuesting;
 import betterquesting.core.ExpansionLoader;
 import betterquesting.handlers.EventHandler;
 import betterquesting.handlers.GuiHandler;
+import betterquesting.handlers.SaveLoadHandler;
 import cpw.mods.fml.common.FMLCommonHandler;
+import cpw.mods.fml.common.event.FMLServerStartingEvent;
+import cpw.mods.fml.common.event.FMLServerStoppedEvent;
 import cpw.mods.fml.common.network.NetworkRegistry;
 
 public class CommonProxy {
@@ -28,4 +40,31 @@ public class CommonProxy {
     }
 
     public void registerRenderers() {}
+
+    public void serverStarting(FMLServerStartingEvent event) {
+        MinecraftServer server = event.getServer();
+        ICommandManager command = server.getCommandManager();
+        ServerCommandManager manager = (ServerCommandManager) command;
+
+        manager.registerCommand(new BQ_CopyProgress());
+        manager.registerCommand(new BQ_CommandAdmin());
+        manager.registerCommand(new BQ_CommandUser());
+
+        if ((Boolean) Launch.blackboard.get("fml.deobfuscatedEnvironment")) {
+            manager.registerCommand(new BQ_CommandDebug());
+        }
+
+        SaveLoadHandler.INSTANCE.loadDatabases(server);
+        if (BQ_Settings.loadDefaultsOnStartup) {
+            try {
+                manager.executeCommand(server, "/bq_admin default load");
+            } catch (Exception e) {
+                BetterQuesting.logger.error("Could not load the default quest database", e);
+            }
+        }
+    }
+
+    public void serverStopped(FMLServerStoppedEvent event) {
+        SaveLoadHandler.INSTANCE.unloadDatabases();
+    }
 }

--- a/src/main/java/betterquesting/core/proxies/CommonProxy.java
+++ b/src/main/java/betterquesting/core/proxies/CommonProxy.java
@@ -37,11 +37,12 @@ public class CommonProxy {
     public void registerHandlers() {
         ExpansionLoader.INSTANCE.initCommonAPIs();
 
-        MinecraftForge.EVENT_BUS.register(EventHandler.INSTANCE);
-        MinecraftForge.TERRAIN_GEN_BUS.register(EventHandler.INSTANCE);
+        final EventHandler handler = new EventHandler();
+        MinecraftForge.EVENT_BUS.register(handler);
+        MinecraftForge.TERRAIN_GEN_BUS.register(handler);
         FMLCommonHandler.instance()
             .bus()
-            .register(EventHandler.INSTANCE);
+            .register(handler);
 
         NetworkRegistry.INSTANCE.registerGuiHandler(BetterQuesting.instance, new GuiHandler());
     }
@@ -85,9 +86,9 @@ public class CommonProxy {
         }
     }
 
-    public <T> ListenableFuture<T> scheduleServerTask(Callable<T> callable) {
+    public <T> ListenableFuture<T> scheduleServerTask(Callable<T> callable, boolean allowImmediate) {
         if (this.taskScheduler != null) {
-            return this.taskScheduler.scheduleServerTask(callable);
+            return this.taskScheduler.scheduleServerTask(callable, allowImmediate);
         }
         return null;
     }

--- a/src/main/java/betterquesting/handlers/EventHandler.java
+++ b/src/main/java/betterquesting/handlers/EventHandler.java
@@ -5,9 +5,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import java.util.concurrent.Callable;
 import java.util.concurrent.Executors;
-import java.util.concurrent.FutureTask;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.entity.EntityPlayerSP;
@@ -34,12 +32,6 @@ import net.minecraftforge.event.entity.EntityJoinWorldEvent;
 import net.minecraftforge.event.entity.living.LivingDeathEvent;
 import net.minecraftforge.event.entity.player.PlayerEvent.Clone;
 import net.minecraftforge.event.world.WorldEvent;
-
-import org.apache.commons.lang3.Validate;
-
-import com.google.common.util.concurrent.Futures;
-import com.google.common.util.concurrent.ListenableFuture;
-import com.google.common.util.concurrent.ListenableFutureTask;
 
 import betterquesting.api.api.QuestingAPI;
 import betterquesting.api.client.gui.misc.INeedsRefresh;
@@ -93,8 +85,6 @@ import cpw.mods.fml.relauncher.SideOnly;
  * Event handling for standard quests and core BetterQuesting functionality
  */
 public class EventHandler {
-
-    public static final EventHandler INSTANCE = new EventHandler();
 
     @SubscribeEvent
     @SideOnly(Side.CLIENT)
@@ -504,39 +494,9 @@ public class EventHandler {
     private final ArrayDeque<EntityPlayerMP> opQueue = new ArrayDeque<>();
     private boolean openToLAN = false;
 
-    private static final ArrayDeque<FutureTask> serverTasks = new ArrayDeque<>();
-    private static Thread serverThread = null;
-
-    @SuppressWarnings("UnstableApiUsage")
-    public static <T> ListenableFuture<T> scheduleServerTask(Callable<T> task) {
-        Validate.notNull(task);
-
-        if (Thread.currentThread() != serverThread) {
-            ListenableFutureTask<T> listenablefuturetask = ListenableFutureTask.create(task);
-
-            synchronized (serverTasks) {
-                serverTasks.add(listenablefuturetask);
-                return listenablefuturetask;
-            }
-        } else {
-            try {
-                return Futures.immediateFuture(task.call());
-            } catch (Exception exception) {
-                return Futures.immediateFailedCheckedFuture(exception);
-            }
-        }
-    }
-
     @SubscribeEvent
     public void onServerTick(ServerTickEvent event) {
         if (event.phase == Phase.START) {
-            if (serverThread == null) serverThread = Thread.currentThread();
-
-            synchronized (serverTasks) {
-                while (!serverTasks.isEmpty()) serverTasks.poll()
-                    .run();
-            }
-
             return;
         }
 

--- a/src/main/java/betterquesting/handlers/ServerTaskScheduler.java
+++ b/src/main/java/betterquesting/handlers/ServerTaskScheduler.java
@@ -1,0 +1,56 @@
+package betterquesting.handlers;
+
+import java.util.ArrayDeque;
+import java.util.concurrent.Callable;
+import java.util.concurrent.FutureTask;
+
+import org.apache.commons.lang3.Validate;
+
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListenableFutureTask;
+
+import cpw.mods.fml.common.eventhandler.SubscribeEvent;
+import cpw.mods.fml.common.gameevent.TickEvent;
+
+public final class ServerTaskScheduler {
+
+    private final ArrayDeque<FutureTask<?>> serverTasks = new ArrayDeque<>();
+    private final Thread serverThread;
+
+    public ServerTaskScheduler(Thread thread) {
+        this.serverThread = thread;
+    }
+
+    @SuppressWarnings("UnstableApiUsage")
+    public <T> ListenableFuture<T> scheduleServerTask(Callable<T> task) {
+        Validate.notNull(task);
+
+        if (Thread.currentThread() != serverThread) {
+            ListenableFutureTask<T> lft = ListenableFutureTask.create(task);
+
+            synchronized (serverTasks) {
+                serverTasks.add(lft);
+                return lft;
+            }
+        } else {
+            try {
+                return Futures.immediateFuture(task.call());
+            } catch (Exception exception) {
+                return Futures.immediateFailedCheckedFuture(exception);
+            }
+        }
+    }
+
+    @SubscribeEvent
+    public void onServerTick(TickEvent.ServerTickEvent event) {
+        if (event.phase == TickEvent.Phase.START) {
+            synchronized (serverTasks) {
+                while (!serverTasks.isEmpty()) {
+                    serverTasks.poll()
+                        .run();
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/betterquesting/handlers/ServerTaskScheduler.java
+++ b/src/main/java/betterquesting/handlers/ServerTaskScheduler.java
@@ -23,10 +23,10 @@ public final class ServerTaskScheduler {
     }
 
     @SuppressWarnings("UnstableApiUsage")
-    public <T> ListenableFuture<T> scheduleServerTask(Callable<T> task) {
+    public <T> ListenableFuture<T> scheduleServerTask(Callable<T> task, boolean allowImmediate) {
         Validate.notNull(task);
 
-        if (Thread.currentThread() != serverThread) {
+        if (!allowImmediate || Thread.currentThread() != serverThread) {
             ListenableFutureTask<T> lft = ListenableFutureTask.create(task);
 
             synchronized (serverTasks) {

--- a/src/main/java/betterquesting/network/PacketQuesting.java
+++ b/src/main/java/betterquesting/network/PacketQuesting.java
@@ -13,7 +13,6 @@ import org.apache.logging.log4j.Level;
 import betterquesting.api.api.QuestingAPI;
 import betterquesting.api2.utils.Tuple2;
 import betterquesting.core.BetterQuesting;
-import betterquesting.handlers.EventHandler;
 import cpw.mods.fml.common.network.ByteBufUtils;
 import cpw.mods.fml.common.network.simpleimpl.IMessage;
 import cpw.mods.fml.common.network.simpleimpl.IMessageHandler;
@@ -74,7 +73,8 @@ public class PacketQuesting implements IMessage {
                     .log(Level.WARN, "Recieved a packet server side with an invalid ID: " + message.getString("ID"));
                 return null;
             } else if (sender != null) {
-                EventHandler.scheduleServerTask(Executors.callable(() -> method.accept(new Tuple2<>(message, sender))));
+                BetterQuesting.proxy
+                    .scheduleServerTask(Executors.callable(() -> method.accept(new Tuple2<>(message, sender))), true);
             }
 
             return null;

--- a/src/main/java/bq_standard/handlers/EventHandler.java
+++ b/src/main/java/bq_standard/handlers/EventHandler.java
@@ -1,11 +1,8 @@
 package bq_standard.handlers;
 
-import java.util.ArrayDeque;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.UUID;
-import java.util.concurrent.Callable;
-import java.util.concurrent.FutureTask;
 import java.util.function.IntSupplier;
 
 import net.minecraft.block.Block;
@@ -24,11 +21,6 @@ import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent.Action;
 import net.minecraftforge.event.world.BlockEvent.BreakEvent;
 import net.minecraftforge.event.world.WorldEvent;
-
-import org.apache.commons.lang3.Validate;
-
-import com.google.common.util.concurrent.ListenableFuture;
-import com.google.common.util.concurrent.ListenableFutureTask;
 
 import betterquesting.api.api.ApiReference;
 import betterquesting.api.api.QuestingAPI;
@@ -56,7 +48,6 @@ import cpw.mods.fml.common.gameevent.PlayerEvent.PlayerLoggedInEvent;
 import cpw.mods.fml.common.gameevent.TickEvent.Phase;
 import cpw.mods.fml.common.gameevent.TickEvent.ServerTickEvent;
 
-@SuppressWarnings("unused")
 public class EventHandler {
 
     @SubscribeEvent(priority = EventPriority.LOWEST)
@@ -309,8 +300,6 @@ public class EventHandler {
         }
     }
 
-    private static final ArrayDeque<FutureTask> serverTasks = new ArrayDeque<>();
-    private static Thread serverThread = null;
     private static final HashSet<EntityPlayer> playerInventoryUpdates = new HashSet<>();
 
     /**
@@ -329,29 +318,9 @@ public class EventHandler {
         }
     }
 
-    // NOTE: This is slightly different to the version in the base mod. This one will not immediately run tasks even if
-    // it's from the same thread.
-    public static <T> ListenableFuture<T> scheduleServerTask(Callable<T> task) {
-        Validate.notNull(task);
-
-        ListenableFutureTask<T> listenablefuturetask = ListenableFutureTask.create(task);
-
-        synchronized (serverTasks) {
-            serverTasks.add(listenablefuturetask);
-            return listenablefuturetask;
-        }
-    }
-
     @SubscribeEvent
     public void onServerTick(ServerTickEvent event) {
         if (event.phase != Phase.START) return;
-        if (serverThread == null) serverThread = Thread.currentThread();
-
-        synchronized (serverTasks) {
-            while (!serverTasks.isEmpty()) serverTasks.poll()
-                .run();
-        }
-
         synchronized (playerInventoryUpdates) {
             for (EntityPlayer player : playerInventoryUpdates) {
                 if (player == null || player.inventory == null) {

--- a/src/main/java/bq_standard/rewards/RewardCommand.java
+++ b/src/main/java/bq_standard/rewards/RewardCommand.java
@@ -18,9 +18,9 @@ import betterquesting.api.questing.rewards.AbstractReward;
 import betterquesting.api.questing.rewards.IReward;
 import betterquesting.api2.client.gui.misc.IGuiRect;
 import betterquesting.api2.client.gui.panels.IGuiPanel;
+import betterquesting.core.BetterQuesting;
 import bq_standard.AdminExecute;
 import bq_standard.client.gui.rewards.PanelRewardCommand;
-import bq_standard.handlers.EventHandler;
 import bq_standard.rewards.factory.FactoryRewardCommand;
 import io.netty.buffer.ByteBuf;
 
@@ -59,12 +59,12 @@ public class RewardCommand extends AbstractReward implements IReward {
             "VAR_UUID",
             QuestingAPI.getQuestingUUID(player)
                 .toString());
-        final MinecraftServer server = MinecraftServer.getServer();
-
         if (viaPlayer) {
-            EventHandler.scheduleServerTask(
-                () -> server.getCommandManager()
-                    .executeCommand(new AdminExecute(player), finCom));
+            BetterQuesting.proxy.scheduleServerTask(
+                () -> MinecraftServer.getServer()
+                    .getCommandManager()
+                    .executeCommand(new AdminExecute(player), finCom),
+                false);
         } else {
             final RewardCommandSender cmdSender = new RewardCommandSender(
                 player.worldObj,
@@ -72,9 +72,11 @@ public class RewardCommand extends AbstractReward implements IReward {
                 (int) player.posY,
                 (int) player.posZ);
 
-            EventHandler.scheduleServerTask(
-                () -> server.getCommandManager()
-                    .executeCommand(cmdSender, finCom));
+            BetterQuesting.proxy.scheduleServerTask(
+                () -> MinecraftServer.getServer()
+                    .getCommandManager()
+                    .executeCommand(cmdSender, finCom),
+                false);
         }
     }
 


### PR DESCRIPTION
It was keeping a static reference to the server thread, and since it was initialized once it meant that if you load two worlds in singleplayer it would keep the reference of the first server instead of the second.

same issue as https://github.com/GTNewHorizons/VendingMachine/pull/77

<img width="602" height="174" alt="image" src="https://github.com/user-attachments/assets/fc2158b5-2e77-47c3-88c6-baa7c4a1a73c" />
<img width="583" height="172" alt="image" src="https://github.com/user-attachments/assets/87f9cbe9-eaa2-4276-b96a-4510979f8b43" />
