### PR TITLE
Mark ignored tasks complete when quest finishes

### DIFF
--- a/src/main/java/betterquesting/questing/QuestInstance.java
+++ b/src/main/java/betterquesting/questing/QuestInstance.java
@@ -335,6 +335,15 @@ public class QuestInstance implements IQuest {
 
             DirtyPlayerMarker.markDirty(uuid);
         }
+
+        // If a quest is completed, we treat optional/ignored tasks as "done" for UI consistency.
+        // These tasks are ignored by completion logic, but leaving them unchecked after completion is confusing.
+        for (DBEntry<ITask> entry : tasks.getEntries()) {
+            ITask task = entry.getValue();
+            if (task != null && task.ignored(uuid)) {
+                task.setComplete(uuid);
+            }
+        }
     }
 
     @Override


### PR DESCRIPTION
This PR improves UI/UX consistency for quests that contain optional tasks.

When a quest is marked as completed for a player, we now also mark all tasks that are flagged as `ignored(...)` (i.e. optional tasks that do not participate in completion logic) as complete for that same player. This prevents confusing states where a quest shows as completed while optional subtasks remain unchecked.

Changes:
- Update `\src\main\java\betterquesting\questing\QuestInstance.java` to auto-complete ignored tasks in `setComplete(UUID uuid, long timestamp)`.