### PR TITLE
Fix no reward crash

### DIFF
--- a/src/main/java/betterquesting/client/gui2/GuiQuest.java
+++ b/src/main/java/betterquesting/client/gui2/GuiQuest.java
@@ -244,10 +244,10 @@ public class GuiQuest extends GuiScreenCanvas implements IPEventListener, INeeds
                     QuestTranslation.translate("betterquesting.btn.claim"));
                 btnClaim.setActive(false);
                 cvInner.addPanel(btnClaim);
-
-                rectReward = new GuiTransform(new Vector4f(0F, 0.5F, 0.5F, 1F), new GuiPadding(0, 0, 8, 16), 0);
-                rectReward.setParent(cvInner.getTransform());
             }
+
+            rectReward = new GuiTransform(new Vector4f(0F, 0.5F, 0.5F, 1F), new GuiPadding(0, 0, 8, 16), 0);
+            rectReward.setParent(cvInner.getTransform());
 
             refreshRewardPanel();
         } else {


### PR DESCRIPTION
Fixes [this issue](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/24324)

rectReward previously wasn't initialized if rewards were disabled, but when they were vending machine trades associated with a quest it would keep calling refreshRewardpanel <-> initPanel. Somehow this only caused a crash in MP.

Tested in SP & MP daily 461.