### PR TITLE
Update native style button to include associated formatting

### DIFF
--- a/src/main/java/betterquesting/client/gui2/editors/GuiTextEditor.java
+++ b/src/main/java/betterquesting/client/gui2/editors/GuiTextEditor.java
@@ -143,7 +143,7 @@ public class GuiTextEditor extends GuiScreenCanvas implements IPEventListener, I
                 new PanelButtonStorage<>(
                     new GuiRectangle(0, (i + macroCount) * 16, 100, 16),
                     1,
-                    tfValues[i].getFriendlyName(),
+                    String.format("%s%s§r", tfValues[i].toString(), tfValues[i].getFriendlyName()),
                     tfValues[i].toString()));
         }
 


### PR DESCRIPTION
Updated the native button styles to be applied to the text on the buttons themselves. I've been asked to check this does not conflict with #199, which - with local testing - currently does not conflict when merging.

I cannot be sure whether the obfuscation style being applied would be of any benefit being applied to itself, or the current method of applying the styling themselves.

A potential change for `PanelButton~id` to `2` was abandoned to prevent conflicts with #199 as well, where it alters the logic for `~id` type 1 to check for selected text and apply a format reset wrapper.

| Before | After |
|--------|--------|
| <img width="202" height="830" alt="javaw_F68ITM0kNR" src="https://github.com/user-attachments/assets/e8b12b19-aa66-4056-8ba1-8614e53db6de" /> | <img width="225" height="828" alt="javaw_7cJReerIBn" src="https://github.com/user-attachments/assets/ff1fc3d2-8ef4-40c0-a872-32f10745d350" /> | 

### Options considered

1. `&6gold&r` - wrap text (current)
2. `&6#&r gold` / `gold &6#&r` - single character
3. `&6#&r gold &6#&r` - double characters
5. _Something else_