### PR TITLE
Fix scroll container to current position when new items are added

### DIFF
--- a/src/main/java/betterquesting/api2/client/gui/panels/lists/CanvasItemDatabase.java
+++ b/src/main/java/betterquesting/api2/client/gui/panels/lists/CanvasItemDatabase.java
@@ -109,7 +109,11 @@ public class CanvasItemDatabase extends CanvasSearch<ItemStack, Item> {
         int x = (index % (cachedWidth / 18)) * 18;
         int y = (index / (cachedWidth / 18)) * 18;
 
+        int currentScrollY = this.getScrollY();
+
         this.addPanel(new PanelItemSlot(new GuiRectangle(x, y, 18, 18, 0), btnId, new BigItemStack(stack)));
+
+        if (this.getScrollY() > currentScrollY) this.setScrollY(currentScrollY);
 
         return true;
     }

--- a/src/main/java/betterquesting/api2/client/gui/panels/lists/CanvasItemDatabase.java
+++ b/src/main/java/betterquesting/api2/client/gui/panels/lists/CanvasItemDatabase.java
@@ -113,7 +113,10 @@ public class CanvasItemDatabase extends CanvasSearch<ItemStack, Item> {
 
         this.addPanel(new PanelItemSlot(new GuiRectangle(x, y, 18, 18, 0), btnId, new BigItemStack(stack)));
 
-        if (this.getScrollY() > currentScrollY) this.setScrollY(currentScrollY);
+        if (this.getScrollY() > currentScrollY) {
+            this.setScrollY(currentScrollY);
+            this.updatePanelScroll();
+        }
 
         return true;
     }


### PR DESCRIPTION
`CanvasItemDatabase` was observed to have a scroll drift as items were filtered in from the registry continue to be added off screen, causing any scroll state to be moved with the growing list or grid of selectable items.

https://github.com/user-attachments/assets/d110d1cd-6cf8-4530-92eb-a0803da12215

Longer comparison is available on Discord: https://discord.com/channels/181078474394566657/603348502637969419/1497779607955443892