### PR TITLE
Canvas search optimizations

### DIFF
--- a/src/main/java/betterquesting/api2/client/gui/panels/lists/CanvasEntityDatabase.java
+++ b/src/main/java/betterquesting/api2/client/gui/panels/lists/CanvasEntityDatabase.java
@@ -45,7 +45,8 @@ public class CanvasEntityDatabase extends CanvasSearch<String, String> {
             return false;
         }
 
-        this.addPanel(new PanelButtonStorage<>(new GuiRectangle(0, index * 16, cachedWidth, 16, 0), btnId, ee, ee));
+        this.addBatchPanel(
+            new PanelButtonStorage<>(new GuiRectangle(0, index * 16, cachedWidth, 16, 0), btnId, ee, ee));
 
         return true;
     }

--- a/src/main/java/betterquesting/api2/client/gui/panels/lists/CanvasFluidDatabase.java
+++ b/src/main/java/betterquesting/api2/client/gui/panels/lists/CanvasFluidDatabase.java
@@ -69,7 +69,7 @@ public class CanvasFluidDatabase extends CanvasSearch<FluidStack, Fluid> {
         int x = (index % (cachedWidth / 18)) * 18;
         int y = (index / (cachedWidth / 18)) * 18;
 
-        this.addPanel(new PanelFluidSlot(new GuiRectangle(x, y, 18, 18, 0), btnId, stack));
+        this.addBatchPanel(new PanelFluidSlot(new GuiRectangle(x, y, 18, 18, 0), btnId, stack));
 
         return true;
     }

--- a/src/main/java/betterquesting/api2/client/gui/panels/lists/CanvasItemDatabase.java
+++ b/src/main/java/betterquesting/api2/client/gui/panels/lists/CanvasItemDatabase.java
@@ -111,11 +111,10 @@ public class CanvasItemDatabase extends CanvasSearch<ItemStack, Item> {
 
         int currentScrollY = this.getScrollY();
 
-        this.addPanel(new PanelItemSlot(new GuiRectangle(x, y, 18, 18, 0), btnId, new BigItemStack(stack)));
+        this.addBatchPanel(new PanelItemSlot(new GuiRectangle(x, y, 18, 18, 0), btnId, new BigItemStack(stack)));
 
         if (this.getScrollY() > currentScrollY) {
             this.setScrollY(currentScrollY);
-            this.updatePanelScroll();
         }
 
         return true;

--- a/src/main/java/betterquesting/api2/client/gui/panels/lists/CanvasItemDatabase.java
+++ b/src/main/java/betterquesting/api2/client/gui/panels/lists/CanvasItemDatabase.java
@@ -109,14 +109,7 @@ public class CanvasItemDatabase extends CanvasSearch<ItemStack, Item> {
         int x = (index % (cachedWidth / 18)) * 18;
         int y = (index / (cachedWidth / 18)) * 18;
 
-        int currentScrollY = this.getScrollY();
-
         this.addBatchPanel(new PanelItemSlot(new GuiRectangle(x, y, 18, 18, 0), btnId, new BigItemStack(stack)));
-
-        if (this.getScrollY() > currentScrollY) {
-            this.setScrollY(currentScrollY);
-        }
-
         return true;
     }
 }

--- a/src/main/java/betterquesting/api2/client/gui/panels/lists/CanvasScrolling.java
+++ b/src/main/java/betterquesting/api2/client/gui/panels/lists/CanvasScrolling.java
@@ -1,5 +1,6 @@
 package betterquesting.api2.client.gui.panels.lists;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -54,6 +55,8 @@ public class CanvasScrolling implements IGuiCanvas {
     // Enables the auto-disabling panels outside the cropped region. Useful for very large lists
     private boolean useBlocking = true;
     private final CanvasCullingManager cullingManager = new CanvasCullingManager();
+
+    private boolean requiresSorting;
 
     public CanvasScrolling(IGuiRect rect) {
         this.transform = rect;
@@ -442,11 +445,39 @@ public class CanvasScrolling implements IGuiCanvas {
         addCulledPanel(panel, true);
     }
 
+    public void addCulledPanels(Collection<IGuiPanel> panels, boolean useCulling) {
+        guiPanels.addAll(panels);
+
+        for (IGuiPanel panel : panels) {
+            if (requiresSorting || panel.getTransform()
+                .getDepth()
+                != guiPanels.get(0)
+                    .getTransform()
+                    .getDepth()) {
+                requiresSorting = true;
+            }
+            cullingManager.addPanel(panel, useCulling);
+            panel.initPanel();
+        }
+
+        if (requiresSorting) {
+            guiPanels.sort(ComparatorGuiDepth.INSTANCE);
+        }
+        this.refreshScrollBounds();
+    }
+
     public void addCulledPanel(IGuiPanel panel, boolean useCulling) {
         if (panel == null || guiPanels.contains(panel)) return;
 
         guiPanels.add(panel);
-        guiPanels.sort(ComparatorGuiDepth.INSTANCE);
+        if (requiresSorting || panel.getTransform()
+            .getDepth()
+            != guiPanels.get(0)
+                .getTransform()
+                .getDepth()) {
+            requiresSorting = true;
+            guiPanels.sort(ComparatorGuiDepth.INSTANCE);
+        }
 
         cullingManager.addPanel(panel, useCulling);
 
@@ -560,6 +591,7 @@ public class CanvasScrolling implements IGuiCanvas {
     public void resetCanvas() {
         guiPanels.clear();
         cullingManager.reset();
+        requiresSorting = false;
         refreshScrollBounds();
     }
 

--- a/src/main/java/betterquesting/api2/client/gui/panels/lists/CanvasScrolling.java
+++ b/src/main/java/betterquesting/api2/client/gui/panels/lists/CanvasScrolling.java
@@ -3,7 +3,9 @@ package betterquesting.api2.client.gui.panels.lists;
 import java.util.Collection;
 import java.util.List;
 import java.util.ListIterator;
+import java.util.Objects;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.stream.Collectors;
 
 import javax.annotation.Nonnull;
 
@@ -446,6 +448,10 @@ public class CanvasScrolling implements IGuiCanvas {
     }
 
     public void addCulledPanels(Collection<IGuiPanel> panels, boolean useCulling) {
+        if (panels == null) return;
+        panels = panels.stream()
+            .filter(Objects::nonNull)
+            .collect(Collectors.toList());
         guiPanels.addAll(panels);
 
         for (IGuiPanel panel : panels) {

--- a/src/main/java/betterquesting/api2/client/gui/panels/lists/CanvasSearch.java
+++ b/src/main/java/betterquesting/api2/client/gui/panels/lists/CanvasSearch.java
@@ -98,7 +98,14 @@ public abstract class CanvasSearch<T, E> extends CanvasScrolling {
             if (addResult(pendingResults.poll(), searchIdx, resultWidth)) searchIdx++;
         }
         searchTime.stop();
+
+        int currentScrollY = this.getScrollY();
         addCulledPanels(batch, true);
+        if (this.getScrollY() > currentScrollY) {
+            this.setScrollY(currentScrollY);
+            updatePanelScroll();
+        }
+
         batch.clear();
     }
 

--- a/src/main/java/betterquesting/api2/client/gui/panels/lists/CanvasSearch.java
+++ b/src/main/java/betterquesting/api2/client/gui/panels/lists/CanvasSearch.java
@@ -3,11 +3,14 @@ package betterquesting.api2.client.gui.panels.lists;
 import java.util.ArrayDeque;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import com.google.common.base.Stopwatch;
 
 import betterquesting.api2.client.gui.misc.IGuiRect;
+import betterquesting.api2.client.gui.panels.IGuiPanel;
 
 public abstract class CanvasSearch<T, E> extends CanvasScrolling {
 
@@ -18,6 +21,7 @@ public abstract class CanvasSearch<T, E> extends CanvasScrolling {
     private int searchIdx = 0; // Where are we in the ongoing search?
     private ArrayDeque<T> pendingResults = new ArrayDeque<>();
     private final boolean deduplicate;
+    private List<IGuiPanel> batch = new LinkedList<>();
 
     public CanvasSearch(IGuiRect rect, boolean deduplicate) {
         super(rect);
@@ -66,7 +70,6 @@ public abstract class CanvasSearch<T, E> extends CanvasScrolling {
 
         searchTime.reset()
             .start();
-
         while (searching.hasNext() && searchTime.elapsed(TimeUnit.MILLISECONDS) < 10) {
             E entry = searching.next();
 
@@ -90,11 +93,19 @@ public abstract class CanvasSearch<T, E> extends CanvasScrolling {
         searchTime.reset()
             .start();
 
-        while (!pendingResults.isEmpty() && searchTime.elapsed(TimeUnit.MILLISECONDS) < 100) {
+        batch.clear();
+        while (!pendingResults.isEmpty() && searchTime.elapsed(TimeUnit.MILLISECONDS) < 10) {
             if (addResult(pendingResults.poll(), searchIdx, resultWidth)) searchIdx++;
         }
-
         searchTime.stop();
+        addCulledPanels(batch, true);
+        batch.clear();
+    }
+
+    protected void addBatchPanel(IGuiPanel panel) {
+        if (panel != null) {
+            batch.add(panel);
+        }
     }
 
     protected abstract Iterator<E> getIterator();

--- a/src/main/java/betterquesting/client/gui2/editors/GuiPrerequisiteEditor.java
+++ b/src/main/java/betterquesting/client/gui2/editors/GuiPrerequisiteEditor.java
@@ -132,14 +132,14 @@ public class GuiPrerequisiteEditor extends GuiScreenCanvas implements IPEventLis
                     entry);
                 btnAdd.setIcon(PresetIcon.ICON_POSITIVE.getTexture());
                 btnAdd.setActive(!containsReq(quest, entry.getKey()));
-                this.addPanel(btnAdd);
+                this.addBatchPanel(btnAdd);
 
                 PanelButtonStorage<Map.Entry<UUID, IQuest>> btnEdit = new PanelButtonStorage<>(
                     new GuiRectangle(16, index * 16, width - 32, 16, 0),
                     1,
                     QuestTranslation.translateQuestName(entry),
                     entry);
-                this.addPanel(btnEdit);
+                this.addBatchPanel(btnEdit);
 
                 PanelButtonStorage<Map.Entry<UUID, IQuest>> btnDel = new PanelButtonStorage<>(
                     new GuiRectangle(width - 16, index * 16, 16, 16, 0),
@@ -147,7 +147,7 @@ public class GuiPrerequisiteEditor extends GuiScreenCanvas implements IPEventLis
                     "",
                     entry);
                 btnDel.setIcon(PresetIcon.ICON_TRASH.getTexture());
-                this.addPanel(btnDel);
+                this.addBatchPanel(btnDel);
 
                 return true;
             }

--- a/src/main/java/betterquesting/client/gui2/editors/GuiQuestLineAddRemove.java
+++ b/src/main/java/betterquesting/client/gui2/editors/GuiQuestLineAddRemove.java
@@ -157,14 +157,14 @@ public class GuiQuestLineAddRemove extends GuiScreenCanvas implements IPEventLis
                     entry);
                 btnAdd.setIcon(PresetIcon.ICON_POSITIVE.getTexture());
                 btnAdd.setActive(questLine != null && questLine.get(entry.getKey()) == null);
-                this.addPanel(btnAdd);
+                this.addBatchPanel(btnAdd);
 
                 PanelButtonStorage<Map.Entry<UUID, IQuest>> btnEdit = new PanelButtonStorage<>(
                     new GuiRectangle(16, index * 16, width - 32, 16, 0),
                     1,
                     QuestTranslation.translateQuestName(entry),
                     entry);
-                this.addPanel(btnEdit);
+                this.addBatchPanel(btnEdit);
 
                 PanelButtonStorage<Map.Entry<UUID, IQuest>> btnDel = new PanelButtonStorage<>(
                     new GuiRectangle(width - 16, index * 16, 16, 16, 0),
@@ -172,7 +172,7 @@ public class GuiQuestLineAddRemove extends GuiScreenCanvas implements IPEventLis
                     "",
                     entry);
                 btnDel.setIcon(PresetIcon.ICON_TRASH.getTexture());
-                this.addPanel(btnDel);
+                this.addBatchPanel(btnDel);
 
                 return true;
             }

--- a/src/main/java/betterquesting/client/gui2/editors/GuiRewardEditor.java
+++ b/src/main/java/betterquesting/client/gui2/editors/GuiRewardEditor.java
@@ -132,7 +132,7 @@ public class GuiRewardEditor extends GuiScreenCanvas implements IPEventListener,
 
             @Override
             protected boolean addResult(IFactoryData<IReward, NBTTagCompound> entry, int index, int cachedWidth) {
-                this.addPanel(
+                this.addBatchPanel(
                     new PanelButtonStorage<>(
                         new GuiRectangle(0, index * 16, cachedWidth, 16, 0),
                         1,

--- a/src/main/java/betterquesting/client/gui2/editors/GuiTaskEditor.java
+++ b/src/main/java/betterquesting/client/gui2/editors/GuiTaskEditor.java
@@ -132,7 +132,7 @@ public class GuiTaskEditor extends GuiScreenCanvas implements IPEventListener, I
 
             @Override
             protected boolean addResult(IFactoryData<ITask, NBTTagCompound> entry, int index, int cachedWidth) {
-                this.addPanel(
+                this.addBatchPanel(
                     new PanelButtonStorage<>(
                         new GuiRectangle(0, index * 16, cachedWidth, 16, 0),
                         1,


### PR DESCRIPTION
3 main changes:
- Panels are added in batches rather than individually to reduce the number of calculations
- Panels are only sorted by depth if there is more than one depth value
- Reduced the max time to add panels from 100ms to 10ms so the fps isn't limited to 10 while the panels are being added

These changes are most noticeable on the page with every item on the right. Now the list of items get added significantly quicker and the UI won't feel super laggy while they are being added.

**Time to build entire item list:**
Before: 12m 22s
After: 13s

There are probably more optimizations to be made but I think this is already a significant improvement