### PR TITLE
NetQuestEdit refactor

### DIFF
--- a/src/main/java/betterquesting/client/gui2/editors/GuiPrerequisiteEditor.java
+++ b/src/main/java/betterquesting/client/gui2/editors/GuiPrerequisiteEditor.java
@@ -8,8 +8,6 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 
 import net.minecraft.client.gui.GuiScreen;
-import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.nbt.NBTTagList;
 
 import org.lwjgl.input.Keyboard;
 
@@ -19,7 +17,6 @@ import betterquesting.api.client.gui.misc.INeedsRefresh;
 import betterquesting.api.client.gui.misc.IVolatileScreen;
 import betterquesting.api.questing.IQuest;
 import betterquesting.api.questing.IQuest.RequirementType;
-import betterquesting.api.utils.NBTConverter;
 import betterquesting.api2.client.gui.GuiScreenCanvas;
 import betterquesting.api2.client.gui.controls.IPanelButton;
 import betterquesting.api2.client.gui.controls.PanelButton;
@@ -276,20 +273,10 @@ public class GuiPrerequisiteEditor extends GuiScreenCanvas implements IPEventLis
         } else if (btn.getButtonID() == 4 && btn instanceof PanelButtonStorage) // Delete
         {
             Map.Entry<UUID, IQuest> entry = ((PanelButtonStorage<Map.Entry<UUID, IQuest>>) btn).getStoredValue();
-            NBTTagCompound payload = new NBTTagCompound();
-            payload.setTag(
-                "questIDs",
-                NBTConverter.UuidValueType.QUEST.writeIds(Collections.singletonList(entry.getKey())));
-            payload.setInteger("action", 1);
-            NetQuestEdit.sendEdit(payload);
+            NetQuestEdit.requestDelete(Collections.singletonList(entry.getKey()));
         } else if (btn.getButtonID() == 5) // New
         {
-            NBTTagCompound payload = new NBTTagCompound();
-            NBTTagList dataList = new NBTTagList();
-            NBTTagCompound entry = new NBTTagCompound();
-            dataList.appendTag(entry);
-            payload.setTag("data", dataList);
-            NetQuestEdit.sendEdit(payload);
+            NetQuestEdit.requestCreate();
         } else if (btn.getButtonID() == 6) // set type
         {
             Map.Entry<UUID, IQuest> entry = ((PanelButtonStorage<Map.Entry<UUID, IQuest>>) btn).getStoredValue();
@@ -317,14 +304,6 @@ public class GuiPrerequisiteEditor extends GuiScreenCanvas implements IPEventLis
     }
 
     private void SendChanges() {
-        NBTTagCompound payload = new NBTTagCompound();
-        NBTTagList dataList = new NBTTagList();
-        NBTTagCompound entry = new NBTTagCompound();
-        NBTConverter.UuidValueType.QUEST.writeId(questID, entry);
-        entry.setTag("config", quest.writeToNBT(new NBTTagCompound()));
-        dataList.appendTag(entry);
-        payload.setTag("data", dataList);
-        payload.setInteger("action", 0);
-        NetQuestEdit.sendEdit(payload);
+        NetQuestEdit.requestEdit(Collections.singletonMap(questID, quest));
     }
 }

--- a/src/main/java/betterquesting/client/gui2/editors/GuiQuestEditor.java
+++ b/src/main/java/betterquesting/client/gui2/editors/GuiQuestEditor.java
@@ -1,10 +1,10 @@
 package betterquesting.client.gui2.editors;
 
+import java.util.Collections;
 import java.util.UUID;
 
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.nbt.NBTTagList;
 
 import org.lwjgl.input.Keyboard;
 
@@ -14,7 +14,6 @@ import betterquesting.api.enums.EnumLogic;
 import betterquesting.api.enums.EnumQuestVisibility;
 import betterquesting.api.properties.NativeProps;
 import betterquesting.api.questing.IQuest;
-import betterquesting.api.utils.NBTConverter;
 import betterquesting.api2.client.gui.GuiScreenCanvas;
 import betterquesting.api2.client.gui.controls.IPanelButton;
 import betterquesting.api2.client.gui.controls.PanelButton;
@@ -288,13 +287,6 @@ public class GuiQuestEditor extends GuiScreenCanvas implements IPEventListener, 
     }
 
     private void SendChanges() {
-        NBTTagCompound payload = new NBTTagCompound();
-        NBTTagList dataList = new NBTTagList();
-        NBTTagCompound entry = NBTConverter.UuidValueType.QUEST.writeId(questID);
-        entry.setTag("config", quest.writeToNBT(new NBTTagCompound()));
-        dataList.appendTag(entry);
-        payload.setTag("data", dataList);
-        payload.setInteger("action", 0);
-        NetQuestEdit.sendEdit(payload);
+        NetQuestEdit.requestEdit(Collections.singletonMap(questID, quest));
     }
 }

--- a/src/main/java/betterquesting/client/gui2/editors/GuiQuestLineAddRemove.java
+++ b/src/main/java/betterquesting/client/gui2/editors/GuiQuestLineAddRemove.java
@@ -8,8 +8,6 @@ import java.util.UUID;
 import javax.annotation.Nullable;
 
 import net.minecraft.client.gui.GuiScreen;
-import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.nbt.NBTTagList;
 
 import org.lwjgl.input.Keyboard;
 
@@ -20,7 +18,6 @@ import betterquesting.api.client.gui.misc.IVolatileScreen;
 import betterquesting.api.questing.IQuest;
 import betterquesting.api.questing.IQuestLine;
 import betterquesting.api.questing.IQuestLineEntry;
-import betterquesting.api.utils.NBTConverter;
 import betterquesting.api2.client.gui.GuiScreenCanvas;
 import betterquesting.api2.client.gui.controls.IPanelButton;
 import betterquesting.api2.client.gui.controls.PanelButton;
@@ -262,30 +259,13 @@ public class GuiQuestLineAddRemove extends GuiScreenCanvas implements IPEventLis
         } else if (btn.getButtonID() == 4) // Delete
         {
             Map.Entry<UUID, IQuest> entry = ((PanelButtonStorage<Map.Entry<UUID, IQuest>>) btn).getStoredValue();
-            NBTTagCompound payload = new NBTTagCompound();
-            payload.setTag(
-                "questIDs",
-                NBTConverter.UuidValueType.QUEST.writeIds(Collections.singletonList(entry.getKey())));
-            payload.setInteger("action", 1);
-            NetQuestEdit.sendEdit(payload);
+            NetQuestEdit.requestDelete(Collections.singletonList(entry.getKey()));
         } else if (btn.getButtonID() == 5) // New
         {
-            NBTTagCompound payload = new NBTTagCompound();
-            NBTTagList dataList = new NBTTagList();
-            NBTTagCompound entry = new NBTTagCompound();
-            dataList.appendTag(entry);
-            payload.setTag("data", dataList);
-            payload.setInteger("action", 3);
-            NetQuestEdit.sendEdit(payload);
+            NetQuestEdit.requestCreate();
         } else if (btn.getButtonID() == 6) // Error resolve
         {
-            NBTTagCompound payload = new NBTTagCompound();
-            payload.setTag(
-                "questIDs",
-                NBTConverter.UuidValueType.QUEST
-                    .writeIds(Collections.singletonList(((PanelButtonStorage<UUID>) btn).getStoredValue())));
-            payload.setInteger("action", 1);
-            NetQuestEdit.sendEdit(payload);
+            NetQuestEdit.requestDelete(Collections.singletonList(((PanelButtonStorage<UUID>) btn).getStoredValue()));
         }
     }
 

--- a/src/main/java/betterquesting/client/gui2/editors/GuiRewardEditor.java
+++ b/src/main/java/betterquesting/client/gui2/editors/GuiRewardEditor.java
@@ -1,6 +1,7 @@
 package betterquesting.client.gui2.editors;
 
 import java.util.ArrayDeque;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
@@ -8,7 +9,6 @@ import java.util.UUID;
 
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.nbt.NBTTagList;
 import net.minecraft.util.EnumChatFormatting;
 
 import org.lwjgl.util.vector.Vector4f;
@@ -19,7 +19,6 @@ import betterquesting.api.client.gui.misc.INeedsRefresh;
 import betterquesting.api.client.gui.misc.IVolatileScreen;
 import betterquesting.api.questing.IQuest;
 import betterquesting.api.questing.rewards.IReward;
-import betterquesting.api.utils.NBTConverter;
 import betterquesting.api2.client.gui.GuiScreenCanvas;
 import betterquesting.api2.client.gui.controls.IPanelButton;
 import betterquesting.api2.client.gui.controls.PanelButton;
@@ -259,13 +258,6 @@ public class GuiRewardEditor extends GuiScreenCanvas implements IPEventListener,
     }
 
     private void SendChanges() {
-        NBTTagCompound payload = new NBTTagCompound();
-        NBTTagList dataList = new NBTTagList();
-        NBTTagCompound entry = NBTConverter.UuidValueType.QUEST.writeId(qID);
-        entry.setTag("config", quest.writeToNBT(new NBTTagCompound()));
-        dataList.appendTag(entry);
-        payload.setTag("data", dataList);
-        payload.setInteger("action", 0);
-        NetQuestEdit.sendEdit(payload);
+        NetQuestEdit.requestEdit(Collections.singletonMap(qID, quest));
     }
 }

--- a/src/main/java/betterquesting/client/gui2/editors/GuiTaskEditor.java
+++ b/src/main/java/betterquesting/client/gui2/editors/GuiTaskEditor.java
@@ -1,6 +1,7 @@
 package betterquesting.client.gui2.editors;
 
 import java.util.ArrayDeque;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
@@ -8,7 +9,6 @@ import java.util.UUID;
 
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.nbt.NBTTagList;
 import net.minecraft.util.EnumChatFormatting;
 
 import org.lwjgl.util.vector.Vector4f;
@@ -19,7 +19,6 @@ import betterquesting.api.client.gui.misc.INeedsRefresh;
 import betterquesting.api.client.gui.misc.IVolatileScreen;
 import betterquesting.api.questing.IQuest;
 import betterquesting.api.questing.tasks.ITask;
-import betterquesting.api.utils.NBTConverter;
 import betterquesting.api2.client.gui.GuiScreenCanvas;
 import betterquesting.api2.client.gui.controls.IPanelButton;
 import betterquesting.api2.client.gui.controls.PanelButton;
@@ -259,13 +258,6 @@ public class GuiTaskEditor extends GuiScreenCanvas implements IPEventListener, I
     }
 
     private void SendChanges() {
-        NBTTagCompound payload = new NBTTagCompound();
-        NBTTagList dataList = new NBTTagList();
-        NBTTagCompound entry = NBTConverter.UuidValueType.QUEST.writeId(qID);
-        entry.setTag("config", quest.writeToNBT(new NBTTagCompound()));
-        dataList.appendTag(entry);
-        payload.setTag("data", dataList);
-        payload.setInteger("action", 0);
-        NetQuestEdit.sendEdit(payload);
+        NetQuestEdit.requestEdit(Collections.singletonMap(qID, quest));
     }
 }

--- a/src/main/java/betterquesting/client/toolbox/tools/ToolboxToolComplete.java
+++ b/src/main/java/betterquesting/client/toolbox/tools/ToolboxToolComplete.java
@@ -66,7 +66,7 @@ public class ToolboxToolComplete implements IToolboxTool {
                     .getKey());
         }
 
-        NetQuestEdit.requestSetState(questIDs, true);
+        NetQuestEdit.requestComplete(questIDs, true);
 
         return true;
     }
@@ -97,7 +97,7 @@ public class ToolboxToolComplete implements IToolboxTool {
                     .getKey());
         }
 
-        NetQuestEdit.requestSetState(questIDs, true);
+        NetQuestEdit.requestComplete(questIDs, true);
 
         return true;
     }

--- a/src/main/java/betterquesting/client/toolbox/tools/ToolboxToolComplete.java
+++ b/src/main/java/betterquesting/client/toolbox/tools/ToolboxToolComplete.java
@@ -5,12 +5,9 @@ import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
-import net.minecraft.nbt.NBTTagCompound;
-
 import org.lwjgl.input.Keyboard;
 
 import betterquesting.api.client.toolbox.IToolboxTool;
-import betterquesting.api.utils.NBTConverter;
 import betterquesting.api2.client.gui.controls.PanelButtonQuest;
 import betterquesting.api2.client.gui.panels.lists.CanvasQuestLine;
 import betterquesting.client.gui2.editors.designer.PanelToolController;
@@ -69,11 +66,7 @@ public class ToolboxToolComplete implements IToolboxTool {
                     .getKey());
         }
 
-        NBTTagCompound payload = new NBTTagCompound();
-        payload.setTag("questIDs", NBTConverter.UuidValueType.QUEST.writeIds(questIDs));
-        payload.setBoolean("state", true);
-        payload.setInteger("action", 2);
-        NetQuestEdit.sendEdit(payload);
+        NetQuestEdit.requestSetState(questIDs, true);
 
         return true;
     }
@@ -104,11 +97,7 @@ public class ToolboxToolComplete implements IToolboxTool {
                     .getKey());
         }
 
-        NBTTagCompound payload = new NBTTagCompound();
-        payload.setTag("questIDs", NBTConverter.UuidValueType.QUEST.writeIds(questIDs));
-        payload.setBoolean("state", true);
-        payload.setInteger("action", 2);
-        NetQuestEdit.sendEdit(payload);
+        NetQuestEdit.requestSetState(questIDs, true);
 
         return true;
     }

--- a/src/main/java/betterquesting/client/toolbox/tools/ToolboxToolCopy.java
+++ b/src/main/java/betterquesting/client/toolbox/tools/ToolboxToolCopy.java
@@ -2,6 +2,7 @@ package betterquesting.client.toolbox.tools;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -9,15 +10,10 @@ import java.util.Set;
 import java.util.UUID;
 
 import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.nbt.NBTTagList;
-
-import com.google.common.collect.BiMap;
-import com.google.common.collect.HashBiMap;
 
 import betterquesting.api.client.toolbox.IToolboxTool;
 import betterquesting.api.questing.IQuest;
 import betterquesting.api.questing.IQuestLine;
-import betterquesting.api.utils.NBTConverter;
 import betterquesting.api2.client.gui.controls.PanelButtonQuest;
 import betterquesting.api2.client.gui.misc.GuiRectangle;
 import betterquesting.api2.client.gui.panels.lists.CanvasQuestLine;
@@ -26,6 +22,7 @@ import betterquesting.client.toolbox.ToolboxTabMain;
 import betterquesting.network.handlers.NetChapterEdit;
 import betterquesting.network.handlers.NetQuestEdit;
 import betterquesting.questing.QuestDatabase;
+import betterquesting.questing.QuestInstance;
 import betterquesting.questing.QuestLineDatabase;
 import betterquesting.questing.QuestLineEntry;
 
@@ -110,122 +107,108 @@ public class ToolboxToolCopy implements IToolboxTool {
                 return false;
             }
 
-        if (grabList.size() <= 0) {
+        if (grabList.size() == 0) {
             PanelButtonQuest btnClicked = gui.getButtonAt(mx, my);
+            if (btnClicked == null) return false;
 
-            if (btnClicked != null) // Pickup the group or the single one if none are selected
-            {
-                if (PanelToolController.selected.size() > 0) {
-                    if (!PanelToolController.selected.contains(btnClicked)) return false;
+            // Pickup the group or the single one if none are selected
+            if (PanelToolController.selected.size() > 0) {
+                if (!PanelToolController.selected.contains(btnClicked)) return false;
 
-                    for (PanelButtonQuest btn : PanelToolController.selected) {
-                        GuiRectangle rect = new GuiRectangle(btn.rect);
-                        grabList.add(
-                            new GrabEntry(
-                                new PanelButtonQuest(rect, -1, "", btn.getStoredValue()),
-                                rect.x - btnClicked.rect.x,
-                                rect.y - btnClicked.rect.y));
-                    }
-                } else {
+                for (PanelButtonQuest btn : PanelToolController.selected) {
+                    GuiRectangle rect = new GuiRectangle(btn.rect);
                     grabList.add(
                         new GrabEntry(
-                            new PanelButtonQuest(
-                                new GuiRectangle(btnClicked.rect),
-                                -1,
-                                "",
-                                btnClicked.getStoredValue()),
-                            0,
-                            0));
+                            new PanelButtonQuest(rect, -1, "", btn.getStoredValue()),
+                            rect.x - btnClicked.rect.x,
+                            rect.y - btnClicked.rect.y));
                 }
-
-                return true;
+            } else {
+                grabList.add(
+                    new GrabEntry(
+                        new PanelButtonQuest(new GuiRectangle(btnClicked.rect), -1, "", btnClicked.getStoredValue()),
+                        0,
+                        0));
             }
 
-            return false;
+            return true;
         }
 
         // Pre-sync
-        IQuestLine qLine = gui.getQuestLine();
-        UUID lID = QuestLineDatabase.INSTANCE.lookupKey(qLine);
+        IQuestLine questLine = gui.getQuestLine();
+        UUID questLineId = QuestLineDatabase.INSTANCE.lookupKey(questLine);
 
-        // Turn Set into List so that we can access by index.
-        List<UUID> nextIDs = new ArrayList<>(getNextIDs(grabList.size()));
-        BiMap<UUID, UUID> remappedIDs = HashBiMap.create(grabList.size());
+        ArrayList<UUID> newIDs = new ArrayList<>(generateNewIDs(grabList.size()));
+        HashMap<UUID, UUID> remappedIDs = new HashMap<>(grabList.size());
 
         for (int i = 0; i < grabList.size(); i++) {
             remappedIDs.put(
                 grabList.get(i).btn.getStoredValue()
                     .getKey(),
-                nextIDs.get(i));
+                newIDs.get(i));
         }
 
-        NBTTagList qdList = new NBTTagList();
+        HashMap<UUID, IQuest> questsToCreate = new HashMap<>();
 
         for (int i = 0; i < grabList.size(); i++) {
             GrabEntry grab = grabList.get(i);
             IQuest quest = grab.btn.getStoredValue()
                 .getValue();
-            UUID qID = nextIDs.get(i);
+            UUID newQuestId = newIDs.get(i);
 
-            if (qLine.get(qID) == null) {
-                qLine.put(qID, new QuestLineEntry(grab.btn.rect.x, grab.btn.rect.y, grab.btn.rect.w, grab.btn.rect.h));
-            }
+            questLine.put(
+                newQuestId,
+                new QuestLineEntry(grab.btn.rect.x, grab.btn.rect.y, grab.btn.rect.w, grab.btn.rect.h));
 
-            NBTTagCompound questTags = quest.writeToNBT(new NBTTagCompound());
-            Set<UUID> reqs = new HashSet<>(quest.getRequirements());
+            HashSet<UUID> reqsCopy = new HashSet<>(quest.getRequirements());
+            boolean hasReqsChanged = false;
 
             for (Map.Entry<UUID, UUID> entry : remappedIDs.entrySet()) {
-                if (reqs.contains(entry.getKey())) {
-                    reqs.remove(entry.getKey());
-                    reqs.add(entry.getValue());
+                if (reqsCopy.remove(entry.getKey())) {
+                    reqsCopy.add(entry.getValue());
+                    hasReqsChanged = true;
                 }
             }
 
-            // We can't tamper with the original so we change it in NBT post-write
-            NBTTagList tagList = new NBTTagList();
-            for (UUID questID : reqs) {
-                NBTTagCompound tag = NBTConverter.UuidValueType.QUEST.writeId(questID);
-
-                // We need the pre-remapped ID so that we can look up the prerequisite type.
-                UUID oldID = remappedIDs.inverse()
-                    .getOrDefault(questID, questID);
-                IQuest.RequirementType requirementType = quest.getRequirementType(oldID);
-                if (requirementType != IQuest.RequirementType.NORMAL) {
-                    tag.setByte("type", requirementType.id());
-                }
-
-                tagList.appendTag(tag);
+            if (!hasReqsChanged) {
+                questsToCreate.put(newQuestId, quest);
+                continue;
             }
-            questTags.setTag("preRequisites", tagList);
 
-            NBTTagCompound tagEntry = new NBTTagCompound();
-            NBTConverter.UuidValueType.QUEST.writeId(qID, tagEntry);
-            tagEntry.setTag("config", questTags);
-            qdList.appendTag(tagEntry);
+            IQuest questCopy = new QuestInstance();
+            questCopy.readFromNBT(quest.writeToNBT(new NBTTagCompound()));
+
+            // setRequirements removes requirement types not present in the reqsCopy,
+            // but not adds any new types, hence the loop for setting requirement types
+            questCopy.setRequirements(reqsCopy);
+            for (UUID oldId : quest.getRequirements()) {
+                UUID newId = remappedIDs.get(oldId);
+                IQuest.RequirementType requirementType = quest.getRequirementType(oldId);
+                questCopy.setRequirementType(newId, requirementType);
+            }
+
+            questsToCreate.put(newQuestId, questCopy);
         }
 
         grabList.clear();
 
         // Send new quests
-        NBTTagCompound quPayload = new NBTTagCompound();
-        quPayload.setTag("data", qdList);
-        quPayload.setInteger("action", 3);
-        NetQuestEdit.sendEdit(quPayload);
+        NetQuestEdit.requestCreate(questsToCreate);
 
         // Send quest line edits
-        NetChapterEdit.requestEdit(lID, qLine);
+        NetChapterEdit.requestEdit(questLineId, questLine);
 
         return true;
     }
 
-    private static Set<UUID> getNextIDs(int num) {
-        Set<UUID> nextIds = new HashSet<>();
-        while (nextIds.size() < num) {
+    private static Set<UUID> generateNewIDs(int count) {
+        Set<UUID> newIds = new HashSet<>();
+        while (newIds.size() < count) {
             // In the extremely unlikely event of a collision,
-            // we'll handle it automatically due to nextIds being a Set
-            nextIds.add(QuestDatabase.INSTANCE.generateKey());
+            // we'll handle it automatically due to newIds being a Set
+            newIds.add(QuestDatabase.INSTANCE.generateKey());
         }
-        return nextIds;
+        return newIds;
     }
 
     @Override

--- a/src/main/java/betterquesting/client/toolbox/tools/ToolboxToolCopy.java
+++ b/src/main/java/betterquesting/client/toolbox/tools/ToolboxToolCopy.java
@@ -183,8 +183,10 @@ public class ToolboxToolCopy implements IToolboxTool {
             questCopy.setRequirements(reqsCopy);
             for (UUID oldId : quest.getRequirements()) {
                 UUID newId = remappedIDs.get(oldId);
-                IQuest.RequirementType requirementType = quest.getRequirementType(oldId);
-                questCopy.setRequirementType(newId, requirementType);
+                if (newId != null) {
+                    IQuest.RequirementType requirementType = quest.getRequirementType(oldId);
+                    questCopy.setRequirementType(newId, requirementType);
+                }
             }
 
             questsToCreate.put(newQuestId, questCopy);

--- a/src/main/java/betterquesting/client/toolbox/tools/ToolboxToolDelete.java
+++ b/src/main/java/betterquesting/client/toolbox/tools/ToolboxToolDelete.java
@@ -5,12 +5,9 @@ import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
-import net.minecraft.nbt.NBTTagCompound;
-
 import org.lwjgl.input.Keyboard;
 
 import betterquesting.api.client.toolbox.IToolboxTool;
-import betterquesting.api.utils.NBTConverter;
 import betterquesting.api2.client.gui.controls.PanelButtonQuest;
 import betterquesting.api2.client.gui.panels.lists.CanvasQuestLine;
 import betterquesting.client.gui2.editors.designer.PanelToolController;
@@ -63,10 +60,7 @@ public class ToolboxToolDelete implements IToolboxTool {
                     .getKey());
         }
 
-        NBTTagCompound payload = new NBTTagCompound();
-        payload.setTag("questIDs", NBTConverter.UuidValueType.QUEST.writeIds(questIDs));
-        payload.setInteger("action", 1);
-        NetQuestEdit.sendEdit(payload);
+        NetQuestEdit.requestDelete(questIDs);
 
         return true;
     }
@@ -97,10 +91,7 @@ public class ToolboxToolDelete implements IToolboxTool {
                     .getKey());
         }
 
-        NBTTagCompound payload = new NBTTagCompound();
-        payload.setTag("questIDs", NBTConverter.UuidValueType.QUEST.writeIds(questIDs));
-        payload.setInteger("action", 1);
-        NetQuestEdit.sendEdit(payload);
+        NetQuestEdit.requestDelete(questIDs);
 
         return true;
     }

--- a/src/main/java/betterquesting/client/toolbox/tools/ToolboxToolFrame.java
+++ b/src/main/java/betterquesting/client/toolbox/tools/ToolboxToolFrame.java
@@ -1,9 +1,8 @@
 package betterquesting.client.toolbox.tools;
 
 import java.util.Collections;
-import java.util.LinkedHashMap;
+import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
 
 import org.lwjgl.input.Keyboard;
@@ -70,7 +69,7 @@ public class ToolboxToolFrame implements IToolboxTool {
             .getValue()
             .getProperty(NativeProps.MAIN);
 
-        Map<UUID, IQuest> questsToEdit = new LinkedHashMap<>();
+        HashMap<UUID, IQuest> questsToEdit = new HashMap<>();
         for (PanelButtonQuest btn : btnList) {
             btn.getStoredValue()
                 .getValue()

--- a/src/main/java/betterquesting/client/toolbox/tools/ToolboxToolFrame.java
+++ b/src/main/java/betterquesting/client/toolbox/tools/ToolboxToolFrame.java
@@ -1,16 +1,16 @@
 package betterquesting.client.toolbox.tools;
 
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
-
-import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.nbt.NBTTagList;
+import java.util.Map;
+import java.util.UUID;
 
 import org.lwjgl.input.Keyboard;
 
 import betterquesting.api.client.toolbox.IToolboxTool;
 import betterquesting.api.properties.NativeProps;
-import betterquesting.api.utils.NBTConverter;
+import betterquesting.api.questing.IQuest;
 import betterquesting.api2.client.gui.controls.PanelButtonQuest;
 import betterquesting.api2.client.gui.panels.lists.CanvasQuestLine;
 import betterquesting.client.gui2.editors.designer.PanelToolController;
@@ -70,27 +70,19 @@ public class ToolboxToolFrame implements IToolboxTool {
             .getValue()
             .getProperty(NativeProps.MAIN);
 
-        NBTTagList dataList = new NBTTagList();
+        Map<UUID, IQuest> questsToEdit = new LinkedHashMap<>();
         for (PanelButtonQuest btn : btnList) {
             btn.getStoredValue()
                 .getValue()
                 .setProperty(NativeProps.MAIN, state);
 
-            NBTTagCompound entry = NBTConverter.UuidValueType.QUEST.writeId(
+            questsToEdit.put(
                 btn.getStoredValue()
-                    .getKey());
-            entry.setTag(
-                "config",
+                    .getKey(),
                 btn.getStoredValue()
-                    .getValue()
-                    .writeToNBT(new NBTTagCompound()));
-            dataList.appendTag(entry);
+                    .getValue());
         }
-
-        NBTTagCompound payload = new NBTTagCompound();
-        payload.setTag("data", dataList);
-        payload.setInteger("action", 0);
-        NetQuestEdit.sendEdit(payload);
+        NetQuestEdit.requestEdit(questsToEdit);
     }
 
     @Override

--- a/src/main/java/betterquesting/client/toolbox/tools/ToolboxToolIcon.java
+++ b/src/main/java/betterquesting/client/toolbox/tools/ToolboxToolIcon.java
@@ -1,9 +1,8 @@
 package betterquesting.client.toolbox.tools;
 
 import java.util.Collections;
-import java.util.LinkedHashMap;
+import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
 
 import net.minecraft.client.Minecraft;
@@ -58,7 +57,7 @@ public class ToolboxToolIcon implements IToolboxTool {
     private void changeIcon(List<PanelButtonQuest> list, BigItemStack refItem) {
         Minecraft mc = Minecraft.getMinecraft();
         mc.displayGuiScreen(new GuiItemSelection(mc.currentScreen, refItem, value -> {
-            Map<UUID, IQuest> questsToEdit = new LinkedHashMap<>();
+            HashMap<UUID, IQuest> questsToEdit = new HashMap<>();
             for (PanelButtonQuest b : list) {
                 b.getStoredValue()
                     .getValue()

--- a/src/main/java/betterquesting/client/toolbox/tools/ToolboxToolIcon.java
+++ b/src/main/java/betterquesting/client/toolbox/tools/ToolboxToolIcon.java
@@ -1,18 +1,19 @@
 package betterquesting.client.toolbox.tools;
 
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 
 import net.minecraft.client.Minecraft;
-import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.nbt.NBTTagList;
 
 import org.lwjgl.input.Keyboard;
 
 import betterquesting.api.client.toolbox.IToolboxTool;
 import betterquesting.api.properties.NativeProps;
+import betterquesting.api.questing.IQuest;
 import betterquesting.api.utils.BigItemStack;
-import betterquesting.api.utils.NBTConverter;
 import betterquesting.api2.client.gui.controls.PanelButtonQuest;
 import betterquesting.api2.client.gui.panels.lists.CanvasQuestLine;
 import betterquesting.client.gui2.editors.designer.PanelToolController;
@@ -57,27 +58,19 @@ public class ToolboxToolIcon implements IToolboxTool {
     private void changeIcon(List<PanelButtonQuest> list, BigItemStack refItem) {
         Minecraft mc = Minecraft.getMinecraft();
         mc.displayGuiScreen(new GuiItemSelection(mc.currentScreen, refItem, value -> {
-            NBTTagList dataList = new NBTTagList();
+            Map<UUID, IQuest> questsToEdit = new LinkedHashMap<>();
             for (PanelButtonQuest b : list) {
                 b.getStoredValue()
                     .getValue()
                     .setProperty(NativeProps.ICON, value);
 
-                NBTTagCompound entry = NBTConverter.UuidValueType.QUEST.writeId(
+                questsToEdit.put(
                     b.getStoredValue()
-                        .getKey());
-                entry.setTag(
-                    "config",
+                        .getKey(),
                     b.getStoredValue()
-                        .getValue()
-                        .writeToNBT(new NBTTagCompound()));
-                dataList.appendTag(entry);
+                        .getValue());
             }
-
-            NBTTagCompound payload = new NBTTagCompound();
-            payload.setTag("data", dataList);
-            payload.setInteger("action", 0);
-            NetQuestEdit.sendEdit(payload);
+            NetQuestEdit.requestEdit(questsToEdit);
         }));
     }
 

--- a/src/main/java/betterquesting/client/toolbox/tools/ToolboxToolLink.java
+++ b/src/main/java/betterquesting/client/toolbox/tools/ToolboxToolLink.java
@@ -1,9 +1,8 @@
 package betterquesting.client.toolbox.tools;
 
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
+import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
 
 import betterquesting.api.client.toolbox.IToolboxTool;
@@ -111,7 +110,7 @@ public class ToolboxToolLink implements IToolboxTool {
                     .getValue();
                 boolean mod2 = false;
 
-                Map<UUID, IQuest> questsToEdit = new LinkedHashMap<>();
+                HashMap<UUID, IQuest> questsToEdit = new HashMap<>();
 
                 for (PanelButtonQuest b1 : linking) {
                     IQuest q1 = b1.getStoredValue()

--- a/src/main/java/betterquesting/client/toolbox/tools/ToolboxToolLink.java
+++ b/src/main/java/betterquesting/client/toolbox/tools/ToolboxToolLink.java
@@ -1,15 +1,13 @@
 package betterquesting.client.toolbox.tools;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
-
-import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.nbt.NBTTagList;
 
 import betterquesting.api.client.toolbox.IToolboxTool;
 import betterquesting.api.questing.IQuest;
-import betterquesting.api.utils.NBTConverter;
 import betterquesting.api2.client.gui.controls.PanelButtonQuest;
 import betterquesting.api2.client.gui.misc.GuiRectangle;
 import betterquesting.api2.client.gui.panels.lists.CanvasQuestLine;
@@ -113,7 +111,7 @@ public class ToolboxToolLink implements IToolboxTool {
                     .getValue();
                 boolean mod2 = false;
 
-                NBTTagList dataList = new NBTTagList();
+                Map<UUID, IQuest> questsToEdit = new LinkedHashMap<>();
 
                 for (PanelButtonQuest b1 : linking) {
                     IQuest q1 = b1.getStoredValue()
@@ -147,30 +145,21 @@ public class ToolboxToolLink implements IToolboxTool {
                     }
 
                     if (mod1) {
-                        NBTTagCompound entry = NBTConverter.UuidValueType.QUEST.writeId(
+                        questsToEdit.put(
                             b1.getStoredValue()
-                                .getKey());
-                        entry.setTag(
-                            "config",
+                                .getKey(),
                             b1.getStoredValue()
-                                .getValue()
-                                .writeToNBT(new NBTTagCompound()));
-                        dataList.appendTag(entry);
+                                .getValue());
                     }
                 }
 
                 if (mod2) {
-                    NBTTagCompound entry = NBTConverter.UuidValueType.QUEST.writeId(
+                    questsToEdit.put(
                         b2.getStoredValue()
-                            .getKey());
-                    entry.setTag("config", q2.writeToNBT(new NBTTagCompound()));
-                    dataList.appendTag(entry);
+                            .getKey(),
+                        q2);
                 }
-
-                NBTTagCompound payload = new NBTTagCompound();
-                payload.setTag("data", dataList);
-                payload.setInteger("action", 0);
-                NetQuestEdit.sendEdit(payload);
+                NetQuestEdit.requestEdit(questsToEdit);
 
                 linking.clear();
                 return true;

--- a/src/main/java/betterquesting/client/toolbox/tools/ToolboxToolNew.java
+++ b/src/main/java/betterquesting/client/toolbox/tools/ToolboxToolNew.java
@@ -4,13 +4,9 @@ import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
-import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.nbt.NBTTagList;
-
 import betterquesting.api.client.toolbox.IToolboxTool;
 import betterquesting.api.questing.IQuestLine;
 import betterquesting.api.questing.IQuestLineEntry;
-import betterquesting.api.utils.NBTConverter;
 import betterquesting.api2.client.gui.controls.PanelButtonQuest;
 import betterquesting.api2.client.gui.misc.GuiRectangle;
 import betterquesting.api2.client.gui.panels.lists.CanvasQuestLine;
@@ -90,13 +86,7 @@ public class ToolboxToolNew implements IToolboxTool {
         }
 
         // Sync Quest
-        NBTTagCompound quPayload = new NBTTagCompound();
-        NBTTagList qdList = new NBTTagList();
-        NBTTagCompound qTag = NBTConverter.UuidValueType.QUEST.writeId(qID);
-        qdList.appendTag(qTag);
-        quPayload.setTag("data", qdList);
-        quPayload.setInteger("action", 3);
-        NetQuestEdit.sendEdit(quPayload);
+        NetQuestEdit.requestCreate(qID);
 
         // Sync Line
         NetChapterEdit.requestEdit(lID, qLine);

--- a/src/main/java/betterquesting/client/toolbox/tools/ToolboxToolReset.java
+++ b/src/main/java/betterquesting/client/toolbox/tools/ToolboxToolReset.java
@@ -52,7 +52,7 @@ public class ToolboxToolReset implements IToolboxTool {
                     .getKey());
         }
 
-        NetQuestEdit.requestSetState(questIDs, false);
+        NetQuestEdit.requestComplete(questIDs, false);
         DirtyPlayerMarker.markDirty(Minecraft.getMinecraft().thePlayer.getUniqueID());
 
         return true;
@@ -95,7 +95,7 @@ public class ToolboxToolReset implements IToolboxTool {
                     .getKey());
         }
 
-        NetQuestEdit.requestSetState(questIDs, false);
+        NetQuestEdit.requestComplete(questIDs, false);
         DirtyPlayerMarker.markDirty(Minecraft.getMinecraft().thePlayer.getUniqueID());
 
         return true;

--- a/src/main/java/betterquesting/client/toolbox/tools/ToolboxToolReset.java
+++ b/src/main/java/betterquesting/client/toolbox/tools/ToolboxToolReset.java
@@ -6,12 +6,10 @@ import java.util.List;
 import java.util.UUID;
 
 import net.minecraft.client.Minecraft;
-import net.minecraft.nbt.NBTTagCompound;
 
 import org.lwjgl.input.Keyboard;
 
 import betterquesting.api.client.toolbox.IToolboxTool;
-import betterquesting.api.utils.NBTConverter;
 import betterquesting.api2.client.gui.controls.PanelButtonQuest;
 import betterquesting.api2.client.gui.panels.lists.CanvasQuestLine;
 import betterquesting.api2.utils.DirtyPlayerMarker;
@@ -54,11 +52,7 @@ public class ToolboxToolReset implements IToolboxTool {
                     .getKey());
         }
 
-        NBTTagCompound payload = new NBTTagCompound();
-        payload.setTag("questIDs", NBTConverter.UuidValueType.QUEST.writeIds(questIDs));
-        payload.setBoolean("state", false);
-        payload.setInteger("action", 2);
-        NetQuestEdit.sendEdit(payload);
+        NetQuestEdit.requestSetState(questIDs, false);
         DirtyPlayerMarker.markDirty(Minecraft.getMinecraft().thePlayer.getUniqueID());
 
         return true;
@@ -101,11 +95,7 @@ public class ToolboxToolReset implements IToolboxTool {
                     .getKey());
         }
 
-        NBTTagCompound payload = new NBTTagCompound();
-        payload.setTag("questIDs", NBTConverter.UuidValueType.QUEST.writeIds(questIDs));
-        payload.setBoolean("state", false);
-        payload.setInteger("action", 2);
-        NetQuestEdit.sendEdit(payload);
+        NetQuestEdit.requestSetState(questIDs, false);
         DirtyPlayerMarker.markDirty(Minecraft.getMinecraft().thePlayer.getUniqueID());
 
         return true;

--- a/src/main/java/betterquesting/commands/admin/QuestCommandComplete.java
+++ b/src/main/java/betterquesting/commands/admin/QuestCommandComplete.java
@@ -76,7 +76,7 @@ public class QuestCommandComplete extends QuestCommandBase {
         if (args[1].trim()
             .equalsIgnoreCase("all")) {
             ArrayList<UUID> allIds = new ArrayList<>(QuestDatabase.INSTANCE.keySet());
-            NetQuestEdit.setQuestStates(allIds, true, uuid);
+            NetQuestEdit.completeQuests(allIds, true, uuid);
             sender
                 .addChatMessage(new ChatComponentTranslation("betterquesting.cmd.complete_all", allIds.size(), pName));
             return;
@@ -89,7 +89,7 @@ public class QuestCommandComplete extends QuestCommandBase {
             throw getException(command);
         }
 
-        NetQuestEdit.setQuestStates(Collections.singletonList(id), true, uuid);
+        NetQuestEdit.completeQuests(Collections.singletonList(id), true, uuid);
         sender.addChatMessage(
             new ChatComponentTranslation(
                 "betterquesting.cmd.complete",

--- a/src/main/java/betterquesting/network/handlers/NetQuestEdit.java
+++ b/src/main/java/betterquesting/network/handlers/NetQuestEdit.java
@@ -2,6 +2,7 @@ package betterquesting.network.handlers;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -17,6 +18,7 @@ import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.util.Constants;
 
 import org.apache.logging.log4j.Level;
+import org.jetbrains.annotations.NotNull;
 
 import betterquesting.api.api.QuestingAPI;
 import betterquesting.api.events.DatabaseEvent;
@@ -48,6 +50,7 @@ public class NetQuestEdit {
     private static final int ACTION_CREATE = 3;
 
     private static final String TAG_ACTION = "action";
+    private static final String TAG_CONFIG = "config";
     private static final String TAG_DATA = "data";
     private static final String TAG_QUEST_IDS = "questIDs";
     private static final String TAG_STATE = "state";
@@ -60,10 +63,82 @@ public class NetQuestEdit {
         }
     }
 
-    // TODO: Make these use proper methods for each action rather than directly assembling the payload
     @SideOnly(Side.CLIENT)
-    public static void sendEdit(NBTTagCompound payload) {
+    public static void requestEdit(@NotNull Map<UUID, IQuest> questsToEdit) {
+        NBTTagList data = writeQuestData(questsToEdit);
+        if (data.tagCount() == 0) {
+            return;
+        }
+
+        NBTTagCompound payload = new NBTTagCompound();
+        payload.setInteger(TAG_ACTION, ACTION_EDIT);
+        payload.setTag(TAG_DATA, data);
         PacketSender.INSTANCE.sendToServer(new QuestingPacket(ID_NAME, payload));
+    }
+
+    @SideOnly(Side.CLIENT)
+    public static void requestDelete(@NotNull Collection<UUID> questIDs) {
+        if (questIDs.isEmpty()) {
+            return;
+        }
+
+        NBTTagCompound payload = new NBTTagCompound();
+        payload.setInteger(TAG_ACTION, ACTION_DELETE);
+        payload.setTag(TAG_QUEST_IDS, NBTConverter.UuidValueType.QUEST.writeIds(questIDs));
+        PacketSender.INSTANCE.sendToServer(new QuestingPacket(ID_NAME, payload));
+    }
+
+    @SideOnly(Side.CLIENT)
+    public static void requestSetState(@NotNull Collection<UUID> questIDs, boolean state) {
+        if (questIDs.isEmpty()) {
+            return;
+        }
+
+        NBTTagCompound payload = new NBTTagCompound();
+        payload.setInteger(TAG_ACTION, ACTION_SET_STATE);
+        payload.setTag(TAG_QUEST_IDS, NBTConverter.UuidValueType.QUEST.writeIds(questIDs));
+        payload.setBoolean(TAG_STATE, state);
+        PacketSender.INSTANCE.sendToServer(new QuestingPacket(ID_NAME, payload));
+    }
+
+    @SideOnly(Side.CLIENT)
+    public static void requestCreate(@NotNull Map<UUID, IQuest> questsToCreate) {
+        NBTTagList data = writeQuestData(questsToCreate);
+        if (data.tagCount() == 0) {
+            return;
+        }
+
+        NBTTagCompound payload = new NBTTagCompound();
+        payload.setInteger(TAG_ACTION, ACTION_CREATE);
+        payload.setTag(TAG_DATA, data);
+        PacketSender.INSTANCE.sendToServer(new QuestingPacket(ID_NAME, payload));
+    }
+
+    @SideOnly(Side.CLIENT)
+    public static void requestCreate(@NotNull UUID questID) {
+        requestCreate(Collections.singletonMap(questID, null));
+    }
+
+    @SideOnly(Side.CLIENT)
+    public static void requestCreate() {
+        requestCreate(QuestDatabase.INSTANCE.generateKey());
+    }
+
+    @SideOnly(Side.CLIENT)
+    private static NBTTagList writeQuestData(@NotNull Map<UUID, IQuest> quests) {
+        NBTTagList data = new NBTTagList();
+        quests.forEach((questID, quest) -> {
+            if (questID == null) {
+                return;
+            }
+
+            NBTTagCompound entry = NBTConverter.UuidValueType.QUEST.writeId(questID);
+            if (quest != null) {
+                entry.setTag(TAG_CONFIG, quest.writeToNBT(new NBTTagCompound()));
+            }
+            data.appendTag(entry);
+        });
+        return data;
     }
 
     private static void onServer(Tuple2<NBTTagCompound, EntityPlayerMP> message) {
@@ -106,7 +181,7 @@ public class NetQuestEdit {
 
             IQuest quest = QuestDatabase.INSTANCE.get(questID);
             if (quest != null) {
-                quest.readFromNBT(entry.getCompoundTag("config"));
+                quest.readFromNBT(entry.getCompoundTag(TAG_CONFIG));
             }
         }
 
@@ -212,8 +287,8 @@ public class NetQuestEdit {
                 quest = QuestDatabase.INSTANCE.createNew(questID);
             }
 
-            if (entry.hasKey("config", Constants.NBT.TAG_COMPOUND)) {
-                quest.readFromNBT(entry.getCompoundTag("config"));
+            if (entry.hasKey(TAG_CONFIG, Constants.NBT.TAG_COMPOUND)) {
+                quest.readFromNBT(entry.getCompoundTag(TAG_CONFIG));
             }
         }
 

--- a/src/main/java/betterquesting/network/handlers/NetQuestEdit.java
+++ b/src/main/java/betterquesting/network/handlers/NetQuestEdit.java
@@ -21,6 +21,7 @@ import org.apache.logging.log4j.Level;
 import org.jetbrains.annotations.NotNull;
 
 import betterquesting.api.api.QuestingAPI;
+import betterquesting.api.enums.EnumLogic;
 import betterquesting.api.events.DatabaseEvent;
 import betterquesting.api.events.DatabaseEvent.DBType;
 import betterquesting.api.network.QuestingPacket;
@@ -238,24 +239,19 @@ public class NetQuestEdit {
 
             quest.setComplete(playerID, 0);
 
-            int done = 0;
+            EnumLogic logic = quest.getProperty(NativeProps.LOGIC_TASK);
+            int tasksCount = quest.getTasks()
+                .size();
+            int completedTasksCount = 0;
 
-            if (!quest.getProperty(NativeProps.LOGIC_TASK)
-                .getResult(
-                    done,
-                    quest.getTasks()
-                        .size())) {
+            if (!logic.getResult(completedTasksCount, tasksCount)) {
                 for (DBEntry<ITask> task : quest.getTasks()
                     .getEntries()) {
                     task.getValue()
                         .setComplete(playerID);
-                    done++;
+                    completedTasksCount++;
 
-                    if (quest.getProperty(NativeProps.LOGIC_TASK)
-                        .getResult(
-                            done,
-                            quest.getTasks()
-                                .size())) {
+                    if (logic.getResult(completedTasksCount, tasksCount)) {
                         break; // Only complete enough quests to claim the reward
                     }
                 }

--- a/src/main/java/betterquesting/network/handlers/NetQuestEdit.java
+++ b/src/main/java/betterquesting/network/handlers/NetQuestEdit.java
@@ -50,11 +50,12 @@ public class NetQuestEdit {
     private static final int ACTION_COMPLETE = 2;
     private static final int ACTION_CREATE = 3;
 
+    // Old key strings are kept for API compat
     private static final String TAG_ACTION = "action";
-    private static final String TAG_QUEST_LIST = "questList";
-    private static final String TAG_QUEST = "quest";
+    private static final String TAG_QUEST_LIST = "data";
+    private static final String TAG_QUEST = "config";
     private static final String TAG_QUEST_IDS = "questIDs";
-    private static final String TAG_COMPLETE = "complete";
+    private static final String TAG_COMPLETE = "state";
 
     public static void registerHandler() {
         PacketTypeRegistry.INSTANCE.registerServerHandler(ID_NAME, NetQuestEdit::onServer);
@@ -62,6 +63,15 @@ public class NetQuestEdit {
         if (BetterQuesting.proxy.isClient()) {
             PacketTypeRegistry.INSTANCE.registerClientHandler(ID_NAME, NetQuestEdit::onClient);
         }
+    }
+
+    /**
+     * @deprecated use request methods instead. This method is kept for API compat
+     */
+    @Deprecated
+    @SideOnly(Side.CLIENT)
+    public static void sendEdit(NBTTagCompound payload) {
+        PacketSender.INSTANCE.sendToServer(new QuestingPacket(ID_NAME, payload));
     }
 
     @SideOnly(Side.CLIENT)

--- a/src/main/java/betterquesting/network/handlers/NetQuestEdit.java
+++ b/src/main/java/betterquesting/network/handlers/NetQuestEdit.java
@@ -42,6 +42,16 @@ public class NetQuestEdit {
 
     private static final ResourceLocation ID_NAME = new ResourceLocation("betterquesting:quest_edit");
 
+    private static final int ACTION_EDIT = 0;
+    private static final int ACTION_DELETE = 1;
+    private static final int ACTION_SET_STATE = 2; // or it can be called SET_COMPLETED (based on state)
+    private static final int ACTION_CREATE = 3;
+
+    private static final String TAG_ACTION = "action";
+    private static final String TAG_DATA = "data";
+    private static final String TAG_QUEST_IDS = "questIDs";
+    private static final String TAG_STATE = "state";
+
     public static void registerHandler() {
         PacketTypeRegistry.INSTANCE.registerServerHandler(ID_NAME, NetQuestEdit::onServer);
 
@@ -50,70 +60,39 @@ public class NetQuestEdit {
         }
     }
 
+    // TODO: Make these use proper methods for each action rather than directly assembling the payload
     @SideOnly(Side.CLIENT)
-    public static void sendEdit(NBTTagCompound payload) // TODO: Make these use proper methods for each action rather
-                                                        // than directly assembling the payload
-    {
+    public static void sendEdit(NBTTagCompound payload) {
         PacketSender.INSTANCE.sendToServer(new QuestingPacket(ID_NAME, payload));
     }
 
     private static void onServer(Tuple2<NBTTagCompound, EntityPlayerMP> message) {
+        NBTTagCompound payload = message.getFirst();
         EntityPlayerMP sender = message.getSecond();
-        MinecraftServer server = sender.mcServer;
-        if (server == null) return; // Here mostly just to keep intellisense happy
 
-        boolean isOP = server.getConfigurationManager()
+        boolean isOP = sender.mcServer.getConfigurationManager()
             .func_152596_g(sender.getGameProfile());
 
-        if (!isOP) // OP pre-check
-        {
-            BetterQuesting.logger.log(
-                Level.WARN,
-                "Player " + sender.getCommandSenderName()
-                    + " (UUID:"
-                    + QuestingAPI.getQuestingUUID(sender)
-                    + ") tried to edit quests without OP permissions!");
+        if (!isOP) {
             sender.addChatComponentMessage(
                 new ChatComponentText(EnumChatFormatting.RED + "You need to be OP to edit quests!"));
-            return; // Player is not operator. Do nothing
+            return;
         }
 
-        NBTTagCompound tag = message.getFirst();
         UUID senderID = QuestingAPI.getQuestingUUID(sender);
-        int action = !message.getFirst()
-            .hasKey("action", 99) ? -1
-                : message.getFirst()
-                    .getInteger("action");
+        int action = payload.hasKey(TAG_ACTION, Constants.NBT.TAG_ANY_NUMERIC) ? payload.getInteger(TAG_ACTION) : -1;
 
         switch (action) {
-            case 0: {
-                editQuests(tag.getTagList("data", 10));
-                break;
-            }
-            case 1: {
-                deleteQuests(NBTConverter.UuidValueType.QUEST.readIds(tag, "questIDs"));
-                break;
-            }
-            case 2: {
-                // TODO: Allow the editor to send a target player name/UUID
-                setQuestStates(
-                    NBTConverter.UuidValueType.QUEST.readIds(tag, "questIDs"),
-                    tag.getBoolean("state"),
-                    senderID);
-                break;
-            }
-            case 3: {
-                createQuests(tag.getTagList("data", 10));
-                break;
-            }
-            default: {
-                BetterQuesting.logger.log(
-                    Level.ERROR,
-                    "Invalid quest edit action '" + action
-                        + "'. Full payload:\n"
-                        + message.getFirst()
-                            .toString());
-            }
+            case ACTION_EDIT -> editQuests(payload.getTagList(TAG_DATA, Constants.NBT.TAG_COMPOUND));
+            case ACTION_DELETE -> deleteQuests(NBTConverter.UuidValueType.QUEST.readIds(payload, TAG_QUEST_IDS));
+            // TODO: Allow the editor to send a target player name/UUID
+            case ACTION_SET_STATE -> setQuestStates(
+                NBTConverter.UuidValueType.QUEST.readIds(payload, TAG_QUEST_IDS),
+                payload.getBoolean(TAG_STATE),
+                senderID);
+            case ACTION_CREATE -> createQuests(payload.getTagList(TAG_DATA, Constants.NBT.TAG_COMPOUND));
+            default -> BetterQuesting.logger
+                .log(Level.ERROR, "Invalid quest edit action '{}'. Full payload:\n{}", action, payload);
         }
     }
 
@@ -145,8 +124,8 @@ public class NetQuestEdit {
         SaveLoadHandler.INSTANCE.markDirty();
 
         NBTTagCompound payload = new NBTTagCompound();
-        payload.setTag("questIDs", NBTConverter.UuidValueType.QUEST.writeIds(questIDs));
-        payload.setInteger("action", 1);
+        payload.setTag(TAG_QUEST_IDS, NBTConverter.UuidValueType.QUEST.writeIds(questIDs));
+        payload.setInteger(TAG_ACTION, ACTION_DELETE);
         PacketSender.INSTANCE.sendToAll(new QuestingPacket(ID_NAME, payload));
     }
 
@@ -161,58 +140,51 @@ public class NetQuestEdit {
         }
 
         EntityPlayerMP player = null;
-        for (Object o : server.getConfigurationManager().playerEntityList) {
-            if (((EntityPlayerMP) o).getGameProfile()
+        for (EntityPlayerMP playerMP : server.getConfigurationManager().playerEntityList) {
+            if (playerMP.getGameProfile()
                 .getId()
                 .equals(targetID)) {
-                player = (EntityPlayerMP) o;
+                player = playerMP;
             }
         }
 
         for (Map.Entry<UUID, IQuest> entry : questMap.entrySet()) {
+            IQuest quest = entry.getValue();
+
             if (!state) {
-                entry.getValue()
-                    .resetUser(targetID, true);
+                quest.resetUser(targetID, true);
                 continue;
             }
 
-            if (entry.getValue()
-                .isComplete(targetID)) {
-                entry.getValue()
-                    .setClaimed(targetID, 0);
+            if (quest.isComplete(targetID)) {
+                quest.setClaimed(targetID, 0);
             } else {
-                entry.getValue()
-                    .setComplete(targetID, 0);
+                quest.setComplete(targetID, 0);
 
                 int done = 0;
 
-                if (!entry.getValue()
-                    .getProperty(NativeProps.LOGIC_TASK)
+                if (!quest.getProperty(NativeProps.LOGIC_TASK)
                     .getResult(
                         done,
-                        entry.getValue()
-                            .getTasks()
-                            .size())) // Preliminary check
-                {
-                    for (DBEntry<ITask> task : entry.getValue()
-                        .getTasks()
+                        quest.getTasks()
+                            .size())) {
+                    for (DBEntry<ITask> task : quest.getTasks()
                         .getEntries()) {
                         task.getValue()
                             .setComplete(targetID);
                         done++;
 
-                        if (entry.getValue()
-                            .getProperty(NativeProps.LOGIC_TASK)
+                        if (quest.getProperty(NativeProps.LOGIC_TASK)
                             .getResult(
                                 done,
-                                entry.getValue()
-                                    .getTasks()
+                                quest.getTasks()
                                     .size())) {
                             break; // Only complete enough quests to claim the reward
                         }
                     }
                 }
             }
+
             if (player != null) {
                 BetterQuesting.logger
                     .info("{} ({}) completed quest {}", player.getDisplayName(), targetID, entry.getKey());
@@ -249,14 +221,13 @@ public class NetQuestEdit {
         NetQuestSync.sendSync(null, questIDs, true, false);
     }
 
+    // Imparts edit specific changes
     @SideOnly(Side.CLIENT)
-    private static void onClient(NBTTagCompound message) // Imparts edit specific changes
-    {
-        int action = !message.hasKey("action", 99) ? -1 : message.getInteger("action");
+    private static void onClient(NBTTagCompound payload) {
+        int action = payload.hasKey(TAG_ACTION, Constants.NBT.TAG_ANY_NUMERIC) ? payload.getInteger(TAG_ACTION) : -1;
 
-        if (action == 1) // Change to a switch statement when more actions are required
-        {
-            for (UUID uuid : NBTConverter.UuidValueType.QUEST.readIds(message, "questIDs")) {
+        if (action == ACTION_DELETE) {
+            for (UUID uuid : NBTConverter.UuidValueType.QUEST.readIds(payload, TAG_QUEST_IDS)) {
                 QuestDatabase.INSTANCE.remove(uuid);
                 QuestLineDatabase.INSTANCE.removeQuest(uuid);
             }
@@ -264,10 +235,4 @@ public class NetQuestEdit {
             MinecraftForge.EVENT_BUS.post(new DatabaseEvent.Update(DBType.CHAPTER));
         }
     }
-
-    public static void log(String msg) {
-        // I don't like this but it's all I can think of
-        BetterQuesting.logger.log(Level.INFO, msg);
-    }
-
 }

--- a/src/main/java/betterquesting/network/handlers/NetQuestEdit.java
+++ b/src/main/java/betterquesting/network/handlers/NetQuestEdit.java
@@ -287,7 +287,7 @@ public class NetQuestEdit {
             NBTTagCompound entry = data.getCompoundTagAt(i);
             // Previous sendEdit API allowed to not pass a quest id
             UUID questID = NBTConverter.UuidValueType.QUEST.tryReadId(entry)
-                    .orElseGet(QuestDatabase.INSTANCE::generateKey);
+                .orElseGet(QuestDatabase.INSTANCE::generateKey);
             IQuest quest = QuestDatabase.INSTANCE.createNew(questID);
 
             questIDs.add(questID);

--- a/src/main/java/betterquesting/network/handlers/NetQuestEdit.java
+++ b/src/main/java/betterquesting/network/handlers/NetQuestEdit.java
@@ -285,7 +285,9 @@ public class NetQuestEdit {
         List<UUID> questIDs = new ArrayList<>();
         for (int i = 0; i < data.tagCount(); i++) {
             NBTTagCompound entry = data.getCompoundTagAt(i);
-            UUID questID = NBTConverter.UuidValueType.QUEST.readId(entry);
+            // Previous sendEdit API allowed to not pass a quest id
+            UUID questID = NBTConverter.UuidValueType.QUEST.tryReadId(entry)
+                    .orElseGet(QuestDatabase.INSTANCE::generateKey);
             IQuest quest = QuestDatabase.INSTANCE.createNew(questID);
 
             questIDs.add(questID);

--- a/src/main/java/betterquesting/network/handlers/NetQuestEdit.java
+++ b/src/main/java/betterquesting/network/handlers/NetQuestEdit.java
@@ -177,10 +177,10 @@ public class NetQuestEdit {
         for (int i = 0; i < data.tagCount(); i++) {
             NBTTagCompound entry = data.getCompoundTagAt(i);
             UUID questID = NBTConverter.UuidValueType.QUEST.readId(entry);
-            questIDs.add(questID);
-
             IQuest quest = QuestDatabase.INSTANCE.get(questID);
+
             if (quest != null) {
+                questIDs.add(questID);
                 quest.readFromNBT(entry.getCompoundTag(TAG_QUEST));
             }
         }
@@ -233,29 +233,30 @@ public class NetQuestEdit {
 
             if (quest.isComplete(playerID)) {
                 quest.setClaimed(playerID, 0);
-            } else {
-                quest.setComplete(playerID, 0);
+                continue;
+            }
 
-                int done = 0;
+            quest.setComplete(playerID, 0);
 
-                if (!quest.getProperty(NativeProps.LOGIC_TASK)
-                    .getResult(
-                        done,
-                        quest.getTasks()
-                            .size())) {
-                    for (DBEntry<ITask> task : quest.getTasks()
-                        .getEntries()) {
-                        task.getValue()
-                            .setComplete(playerID);
-                        done++;
+            int done = 0;
 
-                        if (quest.getProperty(NativeProps.LOGIC_TASK)
-                            .getResult(
-                                done,
-                                quest.getTasks()
-                                    .size())) {
-                            break; // Only complete enough quests to claim the reward
-                        }
+            if (!quest.getProperty(NativeProps.LOGIC_TASK)
+                .getResult(
+                    done,
+                    quest.getTasks()
+                        .size())) {
+                for (DBEntry<ITask> task : quest.getTasks()
+                    .getEntries()) {
+                    task.getValue()
+                        .setComplete(playerID);
+                    done++;
+
+                    if (quest.getProperty(NativeProps.LOGIC_TASK)
+                        .getResult(
+                            done,
+                            quest.getTasks()
+                                .size())) {
+                        break; // Only complete enough quests to claim the reward
                     }
                 }
             }
@@ -277,16 +278,10 @@ public class NetQuestEdit {
         List<UUID> questIDs = new ArrayList<>();
         for (int i = 0; i < data.tagCount(); i++) {
             NBTTagCompound entry = data.getCompoundTagAt(i);
+            UUID questID = NBTConverter.UuidValueType.QUEST.readId(entry);
+            IQuest quest = QuestDatabase.INSTANCE.createNew(questID);
 
-            UUID questID = NBTConverter.UuidValueType.QUEST.tryReadId(entry)
-                .orElseGet(QuestDatabase.INSTANCE::generateKey);
             questIDs.add(questID);
-
-            IQuest quest = QuestDatabase.INSTANCE.get(questID);
-            if (quest == null) {
-                quest = QuestDatabase.INSTANCE.createNew(questID);
-            }
-
             if (entry.hasKey(TAG_QUEST, Constants.NBT.TAG_COMPOUND)) {
                 quest.readFromNBT(entry.getCompoundTag(TAG_QUEST));
             }

--- a/src/main/java/betterquesting/network/handlers/NetQuestEdit.java
+++ b/src/main/java/betterquesting/network/handlers/NetQuestEdit.java
@@ -46,14 +46,14 @@ public class NetQuestEdit {
 
     private static final int ACTION_EDIT = 0;
     private static final int ACTION_DELETE = 1;
-    private static final int ACTION_SET_STATE = 2; // or it can be called SET_COMPLETED (based on state)
+    private static final int ACTION_COMPLETE = 2;
     private static final int ACTION_CREATE = 3;
 
     private static final String TAG_ACTION = "action";
-    private static final String TAG_CONFIG = "config";
-    private static final String TAG_DATA = "data";
+    private static final String TAG_QUEST_LIST = "questList";
+    private static final String TAG_QUEST = "quest";
     private static final String TAG_QUEST_IDS = "questIDs";
-    private static final String TAG_STATE = "state";
+    private static final String TAG_COMPLETE = "complete";
 
     public static void registerHandler() {
         PacketTypeRegistry.INSTANCE.registerServerHandler(ID_NAME, NetQuestEdit::onServer);
@@ -65,14 +65,14 @@ public class NetQuestEdit {
 
     @SideOnly(Side.CLIENT)
     public static void requestEdit(@NotNull Map<UUID, IQuest> questsToEdit) {
-        NBTTagList data = writeQuestData(questsToEdit);
-        if (data.tagCount() == 0) {
+        NBTTagList questList = writeQuestList(questsToEdit);
+        if (questList.tagCount() == 0) {
             return;
         }
 
         NBTTagCompound payload = new NBTTagCompound();
         payload.setInteger(TAG_ACTION, ACTION_EDIT);
-        payload.setTag(TAG_DATA, data);
+        payload.setTag(TAG_QUEST_LIST, questList);
         PacketSender.INSTANCE.sendToServer(new QuestingPacket(ID_NAME, payload));
     }
 
@@ -89,28 +89,28 @@ public class NetQuestEdit {
     }
 
     @SideOnly(Side.CLIENT)
-    public static void requestSetState(@NotNull Collection<UUID> questIDs, boolean state) {
+    public static void requestComplete(@NotNull Collection<UUID> questIDs, boolean complete) {
         if (questIDs.isEmpty()) {
             return;
         }
 
         NBTTagCompound payload = new NBTTagCompound();
-        payload.setInteger(TAG_ACTION, ACTION_SET_STATE);
+        payload.setInteger(TAG_ACTION, ACTION_COMPLETE);
         payload.setTag(TAG_QUEST_IDS, NBTConverter.UuidValueType.QUEST.writeIds(questIDs));
-        payload.setBoolean(TAG_STATE, state);
+        payload.setBoolean(TAG_COMPLETE, complete);
         PacketSender.INSTANCE.sendToServer(new QuestingPacket(ID_NAME, payload));
     }
 
     @SideOnly(Side.CLIENT)
     public static void requestCreate(@NotNull Map<UUID, IQuest> questsToCreate) {
-        NBTTagList data = writeQuestData(questsToCreate);
-        if (data.tagCount() == 0) {
+        NBTTagList questList = writeQuestList(questsToCreate);
+        if (questList.tagCount() == 0) {
             return;
         }
 
         NBTTagCompound payload = new NBTTagCompound();
         payload.setInteger(TAG_ACTION, ACTION_CREATE);
-        payload.setTag(TAG_DATA, data);
+        payload.setTag(TAG_QUEST_LIST, questList);
         PacketSender.INSTANCE.sendToServer(new QuestingPacket(ID_NAME, payload));
     }
 
@@ -125,8 +125,8 @@ public class NetQuestEdit {
     }
 
     @SideOnly(Side.CLIENT)
-    private static NBTTagList writeQuestData(@NotNull Map<UUID, IQuest> quests) {
-        NBTTagList data = new NBTTagList();
+    private static NBTTagList writeQuestList(@NotNull Map<UUID, IQuest> quests) {
+        NBTTagList questList = new NBTTagList();
         quests.forEach((questID, quest) -> {
             if (questID == null) {
                 return;
@@ -134,11 +134,11 @@ public class NetQuestEdit {
 
             NBTTagCompound entry = NBTConverter.UuidValueType.QUEST.writeId(questID);
             if (quest != null) {
-                entry.setTag(TAG_CONFIG, quest.writeToNBT(new NBTTagCompound()));
+                entry.setTag(TAG_QUEST, quest.writeToNBT(new NBTTagCompound()));
             }
-            data.appendTag(entry);
+            questList.appendTag(entry);
         });
-        return data;
+        return questList;
     }
 
     private static void onServer(Tuple2<NBTTagCompound, EntityPlayerMP> message) {
@@ -158,14 +158,14 @@ public class NetQuestEdit {
         int action = payload.hasKey(TAG_ACTION, Constants.NBT.TAG_ANY_NUMERIC) ? payload.getInteger(TAG_ACTION) : -1;
 
         switch (action) {
-            case ACTION_EDIT -> editQuests(payload.getTagList(TAG_DATA, Constants.NBT.TAG_COMPOUND));
+            case ACTION_EDIT -> editQuests(payload.getTagList(TAG_QUEST_LIST, Constants.NBT.TAG_COMPOUND));
             case ACTION_DELETE -> deleteQuests(NBTConverter.UuidValueType.QUEST.readIds(payload, TAG_QUEST_IDS));
             // TODO: Allow the editor to send a target player name/UUID
-            case ACTION_SET_STATE -> setQuestStates(
+            case ACTION_COMPLETE -> completeQuests(
                 NBTConverter.UuidValueType.QUEST.readIds(payload, TAG_QUEST_IDS),
-                payload.getBoolean(TAG_STATE),
+                payload.getBoolean(TAG_COMPLETE),
                 senderID);
-            case ACTION_CREATE -> createQuests(payload.getTagList(TAG_DATA, Constants.NBT.TAG_COMPOUND));
+            case ACTION_CREATE -> createQuests(payload.getTagList(TAG_QUEST_LIST, Constants.NBT.TAG_COMPOUND));
             default -> BetterQuesting.logger
                 .log(Level.ERROR, "Invalid quest edit action '{}'. Full payload:\n{}", action, payload);
         }
@@ -181,7 +181,7 @@ public class NetQuestEdit {
 
             IQuest quest = QuestDatabase.INSTANCE.get(questID);
             if (quest != null) {
-                quest.readFromNBT(entry.getCompoundTag(TAG_CONFIG));
+                quest.readFromNBT(entry.getCompoundTag(TAG_QUEST));
             }
         }
 
@@ -199,13 +199,13 @@ public class NetQuestEdit {
         SaveLoadHandler.INSTANCE.markDirty();
 
         NBTTagCompound payload = new NBTTagCompound();
-        payload.setTag(TAG_QUEST_IDS, NBTConverter.UuidValueType.QUEST.writeIds(questIDs));
         payload.setInteger(TAG_ACTION, ACTION_DELETE);
+        payload.setTag(TAG_QUEST_IDS, NBTConverter.UuidValueType.QUEST.writeIds(questIDs));
         PacketSender.INSTANCE.sendToAll(new QuestingPacket(ID_NAME, payload));
     }
 
     // Serverside only
-    public static void setQuestStates(Collection<UUID> questIDs, boolean state, UUID targetID) {
+    public static void completeQuests(Collection<UUID> questIDs, boolean state, UUID playerID) {
         Map<UUID, IQuest> questMap = QuestDatabase.INSTANCE.filterKeys(questIDs);
 
         MinecraftServer server = FMLCommonHandler.instance()
@@ -218,7 +218,7 @@ public class NetQuestEdit {
         for (EntityPlayerMP playerMP : server.getConfigurationManager().playerEntityList) {
             if (playerMP.getGameProfile()
                 .getId()
-                .equals(targetID)) {
+                .equals(playerID)) {
                 player = playerMP;
             }
         }
@@ -227,14 +227,14 @@ public class NetQuestEdit {
             IQuest quest = entry.getValue();
 
             if (!state) {
-                quest.resetUser(targetID, true);
+                quest.resetUser(playerID, true);
                 continue;
             }
 
-            if (quest.isComplete(targetID)) {
-                quest.setClaimed(targetID, 0);
+            if (quest.isComplete(playerID)) {
+                quest.setClaimed(playerID, 0);
             } else {
-                quest.setComplete(targetID, 0);
+                quest.setComplete(playerID, 0);
 
                 int done = 0;
 
@@ -246,7 +246,7 @@ public class NetQuestEdit {
                     for (DBEntry<ITask> task : quest.getTasks()
                         .getEntries()) {
                         task.getValue()
-                            .setComplete(targetID);
+                            .setComplete(playerID);
                         done++;
 
                         if (quest.getProperty(NativeProps.LOGIC_TASK)
@@ -262,7 +262,7 @@ public class NetQuestEdit {
 
             if (player != null) {
                 BetterQuesting.logger
-                    .info("{} ({}) completed quest {}", player.getDisplayName(), targetID, entry.getKey());
+                    .info("{} ({}) completed quest {}", player.getDisplayName(), playerID, entry.getKey());
             }
         }
 
@@ -287,8 +287,8 @@ public class NetQuestEdit {
                 quest = QuestDatabase.INSTANCE.createNew(questID);
             }
 
-            if (entry.hasKey(TAG_CONFIG, Constants.NBT.TAG_COMPOUND)) {
-                quest.readFromNBT(entry.getCompoundTag(TAG_CONFIG));
+            if (entry.hasKey(TAG_QUEST, Constants.NBT.TAG_COMPOUND)) {
+                quest.readFromNBT(entry.getCompoundTag(TAG_QUEST));
             }
         }
 

--- a/src/main/java/betterquesting/network/handlers/NetQuestEdit.java
+++ b/src/main/java/betterquesting/network/handlers/NetQuestEdit.java
@@ -231,6 +231,7 @@ public class NetQuestEdit {
                 .getId()
                 .equals(playerID)) {
                 player = playerMP;
+                break;
             }
         }
 

--- a/src/main/java/bq_standard/client/gui/editors/tasks/GuiEditTaskHunt.java
+++ b/src/main/java/bq_standard/client/gui/editors/tasks/GuiEditTaskHunt.java
@@ -1,5 +1,6 @@
 package bq_standard.client.gui.editors.tasks;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.UUID;
 
@@ -9,16 +10,12 @@ import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityList;
 import net.minecraft.entity.monster.EntityZombie;
 import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.nbt.NBTTagList;
-import net.minecraft.util.ResourceLocation;
 
 import org.lwjgl.input.Keyboard;
 
 import betterquesting.api.api.ApiReference;
 import betterquesting.api.api.QuestingAPI;
-import betterquesting.api.network.QuestingPacket;
 import betterquesting.api.questing.IQuest;
-import betterquesting.api.utils.NBTConverter;
 import betterquesting.api2.client.gui.GuiScreenCanvas;
 import betterquesting.api2.client.gui.controls.PanelButton;
 import betterquesting.api2.client.gui.controls.PanelTextField;
@@ -36,6 +33,7 @@ import betterquesting.api2.client.gui.themes.presets.PresetColor;
 import betterquesting.api2.client.gui.themes.presets.PresetGUIs;
 import betterquesting.api2.client.gui.themes.presets.PresetTexture;
 import betterquesting.api2.utils.QuestTranslation;
+import betterquesting.network.handlers.NetQuestEdit;
 import bq_standard.tasks.TaskHunt;
 
 public class GuiEditTaskHunt extends GuiScreenCanvas {
@@ -153,27 +151,7 @@ public class GuiEditTaskHunt extends GuiScreenCanvas {
             });
     }
 
-    private static final ResourceLocation QUEST_EDIT = new ResourceLocation("betterquesting:quest_edit"); // TODO:
-                                                                                                          // Really need
-                                                                                                          // to make the
-                                                                                                          // native
-                                                                                                          // packet
-                                                                                                          // types
-                                                                                                          // accessible
-                                                                                                          // in the API
-
     private void sendChanges() {
-        NBTTagCompound payload = new NBTTagCompound();
-        NBTTagList dataList = new NBTTagList();
-        NBTTagCompound entry = NBTConverter.UuidValueType.QUEST.writeId(quest.getKey());
-        entry.setTag(
-            "config",
-            quest.getValue()
-                .writeToNBT(new NBTTagCompound()));
-        dataList.appendTag(entry);
-        payload.setTag("data", dataList);
-        payload.setInteger("action", 0); // Action: Update data
-        QuestingAPI.getAPI(ApiReference.PACKET_SENDER)
-            .sendToServer(new QuestingPacket(QUEST_EDIT, payload));
+        NetQuestEdit.requestEdit(Collections.singletonMap(quest.getKey(), quest.getValue()));
     }
 }

--- a/src/main/java/bq_standard/client/gui/editors/tasks/GuiEditTaskMeeting.java
+++ b/src/main/java/bq_standard/client/gui/editors/tasks/GuiEditTaskMeeting.java
@@ -1,5 +1,6 @@
 package bq_standard.client.gui.editors.tasks;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.UUID;
 
@@ -9,16 +10,12 @@ import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityList;
 import net.minecraft.entity.passive.EntityVillager;
 import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.nbt.NBTTagList;
-import net.minecraft.util.ResourceLocation;
 
 import org.lwjgl.input.Keyboard;
 
 import betterquesting.api.api.ApiReference;
 import betterquesting.api.api.QuestingAPI;
-import betterquesting.api.network.QuestingPacket;
 import betterquesting.api.questing.IQuest;
-import betterquesting.api.utils.NBTConverter;
 import betterquesting.api2.client.gui.GuiScreenCanvas;
 import betterquesting.api2.client.gui.controls.PanelButton;
 import betterquesting.api2.client.gui.controls.PanelTextField;
@@ -36,6 +33,7 @@ import betterquesting.api2.client.gui.themes.presets.PresetColor;
 import betterquesting.api2.client.gui.themes.presets.PresetGUIs;
 import betterquesting.api2.client.gui.themes.presets.PresetTexture;
 import betterquesting.api2.utils.QuestTranslation;
+import betterquesting.network.handlers.NetQuestEdit;
 import bq_standard.tasks.TaskMeeting;
 
 public class GuiEditTaskMeeting extends GuiScreenCanvas {
@@ -151,27 +149,7 @@ public class GuiEditTaskMeeting extends GuiScreenCanvas {
             });
     }
 
-    private static final ResourceLocation QUEST_EDIT = new ResourceLocation("betterquesting:quest_edit"); // TODO:
-                                                                                                          // Really need
-                                                                                                          // to make the
-                                                                                                          // native
-                                                                                                          // packet
-                                                                                                          // types
-                                                                                                          // accessible
-                                                                                                          // in the API
-
     private void sendChanges() {
-        NBTTagCompound payload = new NBTTagCompound();
-        NBTTagList dataList = new NBTTagList();
-        NBTTagCompound entry = NBTConverter.UuidValueType.QUEST.writeId(quest.getKey());
-        entry.setTag(
-            "config",
-            quest.getValue()
-                .writeToNBT(new NBTTagCompound()));
-        dataList.appendTag(entry);
-        payload.setTag("data", dataList);
-        payload.setInteger("action", 0); // Action: Update data
-        QuestingAPI.getAPI(ApiReference.PACKET_SENDER)
-            .sendToServer(new QuestingPacket(QUEST_EDIT, payload));
+        NetQuestEdit.requestEdit(Collections.singletonMap(quest.getKey(), quest.getValue()));
     }
 }

--- a/src/main/java/bq_standard/client/gui/editors/tasks/GuiEditTaskScoreboard.java
+++ b/src/main/java/bq_standard/client/gui/editors/tasks/GuiEditTaskScoreboard.java
@@ -1,20 +1,17 @@
 package bq_standard.client.gui.editors.tasks;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.UUID;
 
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.nbt.NBTTagList;
-import net.minecraft.util.ResourceLocation;
 
 import org.lwjgl.input.Keyboard;
 
 import betterquesting.api.api.ApiReference;
 import betterquesting.api.api.QuestingAPI;
-import betterquesting.api.network.QuestingPacket;
 import betterquesting.api.questing.IQuest;
-import betterquesting.api.utils.NBTConverter;
 import betterquesting.api2.client.gui.GuiScreenCanvas;
 import betterquesting.api2.client.gui.controls.PanelButton;
 import betterquesting.api2.client.gui.controls.PanelButtonStorage;
@@ -31,6 +28,7 @@ import betterquesting.api2.client.gui.themes.presets.PresetColor;
 import betterquesting.api2.client.gui.themes.presets.PresetGUIs;
 import betterquesting.api2.client.gui.themes.presets.PresetTexture;
 import betterquesting.api2.utils.QuestTranslation;
+import betterquesting.network.handlers.NetQuestEdit;
 import bq_standard.tasks.TaskScoreboard;
 import bq_standard.tasks.TaskScoreboard.ScoreOperation;
 
@@ -138,27 +136,7 @@ public class GuiEditTaskScoreboard extends GuiScreenCanvas {
             });
     }
 
-    private static final ResourceLocation QUEST_EDIT = new ResourceLocation("betterquesting:quest_edit"); // TODO:
-                                                                                                          // Really need
-                                                                                                          // to make the
-                                                                                                          // native
-                                                                                                          // packet
-                                                                                                          // types
-                                                                                                          // accessible
-                                                                                                          // in the API
-
     private void sendChanges() {
-        NBTTagCompound payload = new NBTTagCompound();
-        NBTTagList dataList = new NBTTagList();
-        NBTTagCompound entry = NBTConverter.UuidValueType.QUEST.writeId(quest.getKey());
-        entry.setTag(
-            "config",
-            quest.getValue()
-                .writeToNBT(new NBTTagCompound()));
-        dataList.appendTag(entry);
-        payload.setTag("data", dataList);
-        payload.setInteger("action", 0); // Action: Update data
-        QuestingAPI.getAPI(ApiReference.PACKET_SENDER)
-            .sendToServer(new QuestingPacket(QUEST_EDIT, payload));
+        NetQuestEdit.requestEdit(Collections.singletonMap(quest.getKey(), quest.getValue()));
     }
 }


### PR DESCRIPTION
Now there are a few simple methods to request a quest action instead of having to create an NBTTagCompound with hardcoded keys in place

I had to rewrite a bit of ToolboxToolCopy because it was mutating an NBT before sending, so now it's copying a quest and mutating the object instead. It's a bit more work to convert NBTs back and forth, but it's the only way to keep everything encapsulated and clean

Resolved a potential issue with `createQuests`'s ability to mutate an existing quest. Now the code directly creates a new quest without considering an existing quest. All usages of this method pass a new quest id so this change is only about method readability to not be confusing anymore. If someone would try to put an existing id in there, an exception would be thrown by the database, which seems fair to me as it's not a valid operation

I've kept the API compatibility, but I wonder whether we really need to keep it and have we already broken something earlier?

It's part of my overall handlers refactor, but since this single handler required many changes, I've separated it from my main WIP branch.