### PR TITLE
Fix syncing on lan servers

### DIFF
--- a/src/main/java/betterquesting/api2/utils/ParticipantInfo.java
+++ b/src/main/java/betterquesting/api2/utils/ParticipantInfo.java
@@ -57,8 +57,7 @@ public class ParticipantInfo {
             allPlayerIds.add(memberId);
 
             for (EntityPlayerMP playerMP : server.getConfigurationManager().playerEntityList) {
-                if (playerMP.getGameProfile()
-                    .getId()
+                if (QuestingAPI.getQuestingUUID(playerMP)
                     .equals(memberId)) {
                     activePlayers.add(playerMP);
                     activePlayerIds.add(memberId);

--- a/src/main/java/betterquesting/blocks/BlockObservationStation.java
+++ b/src/main/java/betterquesting/blocks/BlockObservationStation.java
@@ -11,6 +11,7 @@ import net.minecraft.util.IIcon;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 
+import betterquesting.api.api.QuestingAPI;
 import betterquesting.core.BetterQuesting;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
@@ -41,8 +42,7 @@ public class BlockObservationStation extends BlockContainer {
         TileEntity tile = w.getTileEntity(x, y, z);
         if (!(tile instanceof TileObservationStation)) return;
         TileObservationStation os = (TileObservationStation) tile;
-        os.owner = player.getGameProfile()
-            .getId();
+        os.owner = QuestingAPI.getQuestingUUID(player);
     }
 
     @SideOnly(Side.CLIENT)

--- a/src/main/java/betterquesting/blocks/TileObservationStation.java
+++ b/src/main/java/betterquesting/blocks/TileObservationStation.java
@@ -112,8 +112,7 @@ public class TileObservationStation extends TileEntity {
         if (server == null) return null;
 
         for (EntityPlayerMP player : (List<EntityPlayerMP>) server.getConfigurationManager().playerEntityList) {
-            if (player.getGameProfile()
-                .getId()
+            if (QuestingAPI.getQuestingUUID(player)
                 .equals(uuid)) return player;
         }
 

--- a/src/main/java/betterquesting/blocks/TileSubmitStation.java
+++ b/src/main/java/betterquesting/blocks/TileSubmitStation.java
@@ -25,6 +25,7 @@ import net.minecraftforge.fluids.IFluidHandler;
 
 import com.google.common.collect.Maps;
 
+import betterquesting.api.api.QuestingAPI;
 import betterquesting.api.properties.NativeProps;
 import betterquesting.api.questing.IQuest;
 import betterquesting.api.questing.tasks.IFluidTask;
@@ -318,8 +319,7 @@ public class TileSubmitStation extends TileEntity implements IFluidHandler, ISid
         if (server == null) return null;
 
         for (EntityPlayerMP player : (List<EntityPlayerMP>) server.getConfigurationManager().playerEntityList) {
-            if (player.getGameProfile()
-                .getId()
+            if (QuestingAPI.getQuestingUUID(player)
                 .equals(uuid)) return player;
         }
 

--- a/src/main/java/betterquesting/commands/admin/QuestCommandLives.java
+++ b/src/main/java/betterquesting/commands/admin/QuestCommandLives.java
@@ -82,8 +82,7 @@ public class QuestCommandLives extends QuestCommandBase {
                 LifeDatabase.INSTANCE.setLives(playerID, value);
                 EntityPlayerMP target = null;
                 for (EntityPlayerMP p : (List<EntityPlayerMP>) server.getConfigurationManager().playerEntityList) {
-                    if (p.getGameProfile()
-                        .getId()
+                    if (QuestingAPI.getQuestingUUID(p)
                         .equals(playerID)) {
                         target = p;
                         break;
@@ -107,8 +106,7 @@ public class QuestCommandLives extends QuestCommandBase {
                 LifeDatabase.INSTANCE.setLives(playerID, lives);
                 EntityPlayerMP target = null;
                 for (EntityPlayerMP p : (List<EntityPlayerMP>) server.getConfigurationManager().playerEntityList) {
-                    if (p.getGameProfile()
-                        .getId()
+                    if (QuestingAPI.getQuestingUUID(p)
                         .equals(playerID)) {
                         target = p;
                         break;

--- a/src/main/java/betterquesting/commands/admin/QuestCommandReset.java
+++ b/src/main/java/betterquesting/commands/admin/QuestCommandReset.java
@@ -11,6 +11,7 @@ import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.ChatComponentTranslation;
 
+import betterquesting.api.api.QuestingAPI;
 import betterquesting.api.properties.NativeProps;
 import betterquesting.api.questing.IQuest;
 import betterquesting.api.utils.UuidConverter;
@@ -76,8 +77,7 @@ public class QuestCommandReset extends QuestCommandBase {
         EntityPlayerMP player = null;
         if (uuid != null) {
             for (EntityPlayerMP p : (List<EntityPlayerMP>) server.getConfigurationManager().playerEntityList) {
-                if (p.getGameProfile()
-                    .getId()
+                if (QuestingAPI.getQuestingUUID(p)
                     .equals(uuid)) {
                     player = p;
                     break;

--- a/src/main/java/betterquesting/network/handlers/NetNameSync.java
+++ b/src/main/java/betterquesting/network/handlers/NetNameSync.java
@@ -17,6 +17,7 @@ import net.minecraft.util.StringUtils;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.util.Constants;
 
+import betterquesting.api.api.QuestingAPI;
 import betterquesting.api.events.DatabaseEvent;
 import betterquesting.api.events.DatabaseEvent.DBType;
 import betterquesting.api.network.QuestingPacket;
@@ -91,8 +92,7 @@ public class NetNameSync {
 
         for (UUID playerID : party.getMembers()) {
             for (EntityPlayerMP playerMP : server.getConfigurationManager().playerEntityList) {
-                if (playerMP.getGameProfile()
-                    .getId()
+                if (QuestingAPI.getQuestingUUID(playerMP)
                     .equals(playerID)) {
                     onlinePlayerList.add(playerMP);
                     break;

--- a/src/main/java/betterquesting/network/handlers/NetPartyAction.java
+++ b/src/main/java/betterquesting/network/handlers/NetPartyAction.java
@@ -277,10 +277,10 @@ public class NetPartyAction {
 
         EntityPlayerMP player = null;
         for (EntityPlayerMP playerMP : server.getConfigurationManager().playerEntityList) {
-            if (playerMP.getGameProfile()
-                .getId()
+            if (QuestingAPI.getQuestingUUID(playerMP)
                 .equals(playerID)) {
                 player = playerMP;
+                break;
             }
         }
 

--- a/src/main/java/betterquesting/network/handlers/NetPartySync.java
+++ b/src/main/java/betterquesting/network/handlers/NetPartySync.java
@@ -15,6 +15,7 @@ import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.util.Constants;
 
+import betterquesting.api.api.QuestingAPI;
 import betterquesting.api.events.DatabaseEvent;
 import betterquesting.api.events.DatabaseEvent.DBType;
 import betterquesting.api.network.QuestingPacket;
@@ -60,9 +61,7 @@ public class NetPartySync {
         ArrayList<EntityPlayerMP> onlineMembers = new ArrayList<>();
 
         for (EntityPlayerMP player : server.getConfigurationManager().playerEntityList) {
-            UUID playerId = player.getGameProfile()
-                .getId();
-            if (partyMemberIds.contains(playerId)) {
+            if (partyMemberIds.contains(QuestingAPI.getQuestingUUID(player))) {
                 onlineMembers.add(player);
                 if (onlineMembers.size() == partyMemberIds.size()) {
                     break;

--- a/src/main/java/betterquesting/network/handlers/NetQuestEdit.java
+++ b/src/main/java/betterquesting/network/handlers/NetQuestEdit.java
@@ -227,8 +227,7 @@ public class NetQuestEdit {
 
         EntityPlayerMP player = null;
         for (EntityPlayerMP playerMP : server.getConfigurationManager().playerEntityList) {
-            if (playerMP.getGameProfile()
-                .getId()
+            if (QuestingAPI.getQuestingUUID(playerMP)
                 .equals(playerID)) {
                 player = playerMP;
                 break;

--- a/src/main/java/betterquesting/questing/party/PartyInvitations.java
+++ b/src/main/java/betterquesting/questing/party/PartyInvitations.java
@@ -139,8 +139,7 @@ public class PartyInvitations implements INBTPartial<NBTTagList, UUID> {
 
             EntityPlayerMP player = null;
             for (EntityPlayerMP playerMP : server.getConfigurationManager().playerEntityList) {
-                if (playerMP.getGameProfile()
-                    .getId()
+                if (QuestingAPI.getQuestingUUID(playerMP)
                     .equals(playerId)) {
                     player = playerMP;
                     break;

--- a/src/main/java/betterquesting/storage/NameCache.java
+++ b/src/main/java/betterquesting/storage/NameCache.java
@@ -15,6 +15,7 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
 import net.minecraft.server.MinecraftServer;
 
+import betterquesting.api.api.QuestingAPI;
 import betterquesting.api.storage.INameCache;
 
 public final class NameCache implements INameCache {
@@ -26,10 +27,7 @@ public final class NameCache implements INameCache {
     @Override
     public synchronized boolean updateName(@Nonnull EntityPlayerMP player) {
         MinecraftServer server = player.mcServer;
-        NBTTagCompound tag = cache.computeIfAbsent(
-            player.getGameProfile()
-                .getId(),
-            (key) -> new NBTTagCompound());
+        NBTTagCompound tag = cache.computeIfAbsent(QuestingAPI.getQuestingUUID(player), (key) -> new NBTTagCompound());
 
         String name = player.getGameProfile()
             .getName();


### PR DESCRIPTION
- switched over to `QuestingAPI.getQuestingUUID(player)` instead of `player.getGameProfile().getId()`. #207 has similar idea, but it didn't cover all places and added some extra changes which could break other stuff