### PR TITLE
switch over from joml to lwjgl

### DIFF
--- a/src/main/java/betterquesting/api2/client/gui/resources/lines/DirectionalLine.java
+++ b/src/main/java/betterquesting/api2/client/gui/resources/lines/DirectionalLine.java
@@ -2,8 +2,8 @@ package betterquesting.api2.client.gui.resources.lines;
 
 import net.minecraft.util.MathHelper;
 
-import org.joml.Vector2f;
 import org.lwjgl.opengl.GL11;
+import org.lwjgl.util.vector.Vector2f;
 
 import betterquesting.api.storage.BQ_Settings;
 import betterquesting.api2.client.gui.misc.IGuiRect;
@@ -44,7 +44,10 @@ public class DirectionalLine implements IGuiLine {
         Vector2f end = new Vector2f(
             endRect.getX() + endRect.getWidth() / 2f,
             endRect.getY() + endRect.getHeight() / 2f);
-        Vector2f diff = new Vector2f(end).sub(start);
+
+        Vector2f diff = new Vector2f();
+        Vector2f.sub(end, start, diff);
+
         float length = diff.length();
         float angle = (float) Math.atan2(diff.y, diff.x);
         color.applyGlColor();

--- a/src/main/java/betterquesting/api2/client/gui/resources/lines/DirectionalLine.java
+++ b/src/main/java/betterquesting/api2/client/gui/resources/lines/DirectionalLine.java
@@ -44,9 +44,7 @@ public class DirectionalLine implements IGuiLine {
         Vector2f end = new Vector2f(
             endRect.getX() + endRect.getWidth() / 2f,
             endRect.getY() + endRect.getHeight() / 2f);
-
         Vector2f diff = Vector2f.sub(end, start, null);
-
         float length = diff.length();
         float angle = (float) Math.atan2(diff.y, diff.x);
         color.applyGlColor();

--- a/src/main/java/betterquesting/api2/client/gui/resources/lines/DirectionalLine.java
+++ b/src/main/java/betterquesting/api2/client/gui/resources/lines/DirectionalLine.java
@@ -45,8 +45,7 @@ public class DirectionalLine implements IGuiLine {
             endRect.getX() + endRect.getWidth() / 2f,
             endRect.getY() + endRect.getHeight() / 2f);
 
-        Vector2f diff = new Vector2f();
-        Vector2f.sub(end, start, diff);
+        Vector2f diff = Vector2f.sub(end, start, null);
 
         float length = diff.length();
         float angle = (float) Math.atan2(diff.y, diff.x);


### PR DESCRIPTION
After the deps were updated, joml no longer exists at runtime in the dev environment. Doesn't really make sense to include it when the rest of the mod uses lwjgl's vector math. So I switched `DirectionalLine` to use `Vector2f` from lwjgl. Tested ingame and it still works as expected.