### PR TITLE
Change the color of gui divider to match the theme

### DIFF
--- a/src/main/resources/assets/betterquesting/bq_themes.json
+++ b/src/main/resources/assets/betterquesting/bq_themes.json
@@ -213,7 +213,7 @@
       "betterquesting:gui_divider":
       {
         "colorType": "betterquesting:color_static",
-        "color": "FF000000"
+        "color": "FFAB925A"
       },
       "betterquesting:grid_major":
       {
@@ -567,7 +567,7 @@
       "betterquesting:gui_divider":
       {
         "colorType": "betterquesting:color_static",
-        "color": "FFFFFFFF"
+        "color": "FF565656"
       },
       "betterquesting:grid_major":
       {
@@ -904,6 +904,14 @@
         "bounds": [120, 56, 24, 24],
         "padding": [11, 11, 11, 11],
         "sliceMode": 2
+     }
+    },
+    "colors":
+    {
+      "betterquesting:gui_divider":
+      {
+        "colorType": "betterquesting:color_static",
+        "color": "FF754228"
       }
     }
   },
@@ -1100,6 +1108,14 @@
         "atlas": "betterquesting:textures/gui/gui_themes.png",
         "bounds": [168, 56, 24, 24],
         "stretch": true
+     }
+    },
+    "colors":
+    {
+      "betterquesting:gui_divider":
+      {
+        "colorType": "betterquesting:color_static",
+        "color": "FF714F1F"
       }
     }
   },
@@ -1300,6 +1316,14 @@
         "bounds": [216, 56, 24, 24],
         "padding": [11, 11, 11, 11],
         "sliceMode": 2
+     }
+    },
+    "colors":
+    {
+      "betterquesting:gui_divider":
+      {
+        "colorType": "betterquesting:color_static",
+        "color": "FF23423A"
       }
     }
   },
@@ -1510,6 +1534,10 @@
       "betterquesting:text_main": {
         "colorType": "betterquesting:color_static",
         "color": "FF000000"
+      },
+      "betterquesting:gui_divider": {
+        "colorType": "betterquesting:color_static",
+        "color": "FF0B232B"
       }
     }
   },
@@ -1710,6 +1738,14 @@
         "bounds": [72, 136, 24, 24],
         "padding": [10, 10, 10, 10],
         "sliceMode": 1
+     }
+    },
+    "colors":
+    {
+      "betterquesting:gui_divider":
+      {
+        "colorType": "betterquesting:color_static",
+        "color": "FF000000"
       }
     }
   },
@@ -1943,7 +1979,7 @@
       "betterquesting:gui_divider":
       {
         "colorType": "betterquesting:color_static",
-        "color": "FFFFFFFF"
+        "color": "FF919191"
       },
       "betterquesting:grid_major":
       {


### PR DESCRIPTION
Fix this eye sore
(Was white/black)
<img width="1248" height="618" alt="1post" src="https://github.com/user-attachments/assets/192a196b-88db-4890-b007-bbfd8165abfc" />
<img width="1225" height="640" alt="8post" src="https://github.com/user-attachments/assets/7e92ab94-41b7-4c07-83a7-bd6502bc28b4" />
<img width="1213" height="604" alt="2post" src="https://github.com/user-attachments/assets/aab0bf4a-a36c-4db6-a76b-c5165331fad7" />
<img width="1208" height="607" alt="3post" src="https://github.com/user-attachments/assets/68bb0618-7d3b-46b7-849d-6645d1f34474" />
<img width="1230" height="614" alt="4post" src="https://github.com/user-attachments/assets/c64b24dc-c5cb-4c36-b3e7-2809b98c42ba" />
<img width="1221" height="610" alt="5post" src="https://github.com/user-attachments/assets/2212a4ff-4f0f-4597-aaf3-209475016873" />
<img width="1205" height="607" alt="6post" src="https://github.com/user-attachments/assets/d26abde9-e9ee-4667-bd12-3c3d8f6589fe" />
<img width="1211" height="615" alt="7post" src="https://github.com/user-attachments/assets/f35ba20a-aa1d-4831-ab70-1607bf255d45" />
