### PR TITLE
Add QuestContextMenuRegistry for external context menu entries

### DIFF
--- a/src/main/java/betterquesting/api2/client/gui/context/IQuestContextMenuEntry.java
+++ b/src/main/java/betterquesting/api2/client/gui/context/IQuestContextMenuEntry.java
@@ -10,9 +10,9 @@ import betterquesting.api.questing.IQuest;
  */
 public interface IQuestContextMenuEntry {
 
-	/** Display label shown in the context menu. */
-	String getLabel(UUID questId, IQuest quest);
+    /** Display label shown in the context menu. */
+    String getLabel(UUID questId, IQuest quest);
 
-	/** Called when the player clicks this entry. The popup is closed automatically after this runs. */
-	Runnable getAction(UUID questId, IQuest quest);
+    /** Called when the player clicks this entry. The popup is closed automatically after this runs. */
+    Runnable getAction(UUID questId, IQuest quest);
 }

--- a/src/main/java/betterquesting/api2/client/gui/context/IQuestContextMenuEntry.java
+++ b/src/main/java/betterquesting/api2/client/gui/context/IQuestContextMenuEntry.java
@@ -13,6 +13,6 @@ public interface IQuestContextMenuEntry {
 	/** Display label shown in the context menu. */
 	String getLabel(UUID questId, IQuest quest);
 
-	/** Called when the player clicks this entry. Close the popup yourself if needed. */
+	/** Called when the player clicks this entry. The popup is closed automatically after this runs. */
 	Runnable getAction(UUID questId, IQuest quest);
 }

--- a/src/main/java/betterquesting/api2/client/gui/context/IQuestContextMenuEntry.java
+++ b/src/main/java/betterquesting/api2/client/gui/context/IQuestContextMenuEntry.java
@@ -1,0 +1,18 @@
+package betterquesting.api2.client.gui.context;
+
+import java.util.UUID;
+
+import betterquesting.api.questing.IQuest;
+
+/**
+ * Provides additional entries for the quest right-click context menu.
+ * Register via {@link QuestContextMenuRegistry#register(IQuestContextMenuEntry)}.
+ */
+public interface IQuestContextMenuEntry {
+
+	/** Display label shown in the context menu. */
+	String getLabel(UUID questId, IQuest quest);
+
+	/** Called when the player clicks this entry. Close the popup yourself if needed. */
+	Runnable getAction(UUID questId, IQuest quest);
+}

--- a/src/main/java/betterquesting/api2/client/gui/context/QuestContextMenuRegistry.java
+++ b/src/main/java/betterquesting/api2/client/gui/context/QuestContextMenuRegistry.java
@@ -1,0 +1,23 @@
+package betterquesting.api2.client.gui.context;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/** Static registry for external context menu entries added to BQ quest popups. */
+public final class QuestContextMenuRegistry {
+
+	private static final List<IQuestContextMenuEntry> entries = new ArrayList<>();
+
+	private QuestContextMenuRegistry() {}
+
+	/** Call during mod init to add a custom entry to every quest's right-click menu. */
+	public static void register(IQuestContextMenuEntry entry) {
+		entries.add(entry);
+	}
+
+	/** Returns a read-only snapshot of all registered entries. */
+	public static List<IQuestContextMenuEntry> getEntries() {
+		return Collections.unmodifiableList(entries);
+	}
+}

--- a/src/main/java/betterquesting/api2/client/gui/context/QuestContextMenuRegistry.java
+++ b/src/main/java/betterquesting/api2/client/gui/context/QuestContextMenuRegistry.java
@@ -7,17 +7,18 @@ import java.util.List;
 /** Static registry for external context menu entries added to BQ quest popups. */
 public final class QuestContextMenuRegistry {
 
-	private static final List<IQuestContextMenuEntry> entries = new ArrayList<>();
+	private static final List<IQuestContextMenuEntry> entries = Collections.synchronizedList(new ArrayList<>());
 
 	private QuestContextMenuRegistry() {}
 
 	/** Call during mod init to add a custom entry to every quest's right-click menu. */
 	public static void register(IQuestContextMenuEntry entry) {
+		if (entry == null) throw new IllegalArgumentException("entry cannot be null");
 		entries.add(entry);
 	}
 
 	/** Returns a read-only snapshot of all registered entries. */
 	public static List<IQuestContextMenuEntry> getEntries() {
-		return Collections.unmodifiableList(entries);
+		return new ArrayList<>(entries);
 	}
 }

--- a/src/main/java/betterquesting/api2/client/gui/context/QuestContextMenuRegistry.java
+++ b/src/main/java/betterquesting/api2/client/gui/context/QuestContextMenuRegistry.java
@@ -7,18 +7,18 @@ import java.util.List;
 /** Static registry for external context menu entries added to BQ quest popups. */
 public final class QuestContextMenuRegistry {
 
-	private static final List<IQuestContextMenuEntry> entries = Collections.synchronizedList(new ArrayList<>());
+    private static final List<IQuestContextMenuEntry> entries = Collections.synchronizedList(new ArrayList<>());
 
-	private QuestContextMenuRegistry() {}
+    private QuestContextMenuRegistry() {}
 
-	/** Call during mod init to add a custom entry to every quest's right-click menu. */
-	public static void register(IQuestContextMenuEntry entry) {
-		if (entry == null) throw new IllegalArgumentException("entry cannot be null");
-		entries.add(entry);
-	}
+    /** Call during mod init to add a custom entry to every quest's right-click menu. */
+    public static void register(IQuestContextMenuEntry entry) {
+        if (entry == null) throw new IllegalArgumentException("entry cannot be null");
+        entries.add(entry);
+    }
 
-	/** Returns a read-only snapshot of all registered entries. */
-	public static List<IQuestContextMenuEntry> getEntries() {
-		return new ArrayList<>(entries);
-	}
+    /** Returns a read-only snapshot of all registered entries. */
+    public static List<IQuestContextMenuEntry> getEntries() {
+        return new ArrayList<>(entries);
+    }
 }

--- a/src/main/java/betterquesting/client/gui2/GuiQuestLines.java
+++ b/src/main/java/betterquesting/client/gui2/GuiQuestLines.java
@@ -65,6 +65,8 @@ import betterquesting.api2.client.gui.panels.lists.CanvasHoverTray;
 import betterquesting.api2.client.gui.panels.lists.CanvasQuestLine;
 import betterquesting.api2.client.gui.panels.lists.CanvasScrolling;
 import betterquesting.api2.client.gui.popups.PopChoiceExt;
+import betterquesting.api2.client.gui.context.IQuestContextMenuEntry;
+import betterquesting.api2.client.gui.context.QuestContextMenuRegistry;
 import betterquesting.api2.client.gui.popups.PopContextMenuHoverSub;
 import betterquesting.api2.client.gui.resources.colors.GuiColorPulse;
 import betterquesting.api2.client.gui.resources.colors.GuiColorStatic;
@@ -593,7 +595,7 @@ public class GuiQuestLines extends GuiScreenCanvas implements IPEventListener, I
                             RenderUtils
                                 .getStringWidth(QuestTranslation.translate("betterquesting.btn.view_dependants"), fr));
 
-                        int menuItemCount = 5; // bookmark, share, copy, deps, dependants
+                        int menuItemCount = 5 + QuestContextMenuRegistry.getEntries().size(); // bookmark, share, copy, deps, dependants + external
                         PopContextMenuHoverSub popup = new PopContextMenuHoverSub(
                             new GuiRectangle(mx, my, maxWidth + 20, menuItemCount * 16),
                             true);
@@ -680,6 +682,16 @@ public class GuiQuestLines extends GuiScreenCanvas implements IPEventListener, I
                             popup.addSubMenu(
                                 QuestTranslation.translate("betterquesting.btn.view_dependants"),
                                 dependantEntries);
+                        }
+
+                        // External entries registered by other mods
+                        for (IQuestContextMenuEntry ext : QuestContextMenuRegistry.getEntries()) {
+                            final IQuest capturedQuest = theQuest;
+                            final UUID capturedId = questId;
+                            popup.addButton(ext.getLabel(capturedId, capturedQuest), null, () -> {
+                                ext.getAction(capturedId, capturedQuest).run();
+                                closePopup();
+                            });
                         }
 
                         openPopup(popup);

--- a/src/main/java/betterquesting/client/gui2/GuiQuestLines.java
+++ b/src/main/java/betterquesting/client/gui2/GuiQuestLines.java
@@ -44,6 +44,8 @@ import betterquesting.api.utils.RenderUtils;
 import betterquesting.api.utils.UuidConverter;
 import betterquesting.api2.cache.QuestCache;
 import betterquesting.api2.client.gui.GuiScreenCanvas;
+import betterquesting.api2.client.gui.context.IQuestContextMenuEntry;
+import betterquesting.api2.client.gui.context.QuestContextMenuRegistry;
 import betterquesting.api2.client.gui.controls.IPanelButton;
 import betterquesting.api2.client.gui.controls.PanelButton;
 import betterquesting.api2.client.gui.controls.PanelButtonQuest;
@@ -65,8 +67,6 @@ import betterquesting.api2.client.gui.panels.lists.CanvasHoverTray;
 import betterquesting.api2.client.gui.panels.lists.CanvasQuestLine;
 import betterquesting.api2.client.gui.panels.lists.CanvasScrolling;
 import betterquesting.api2.client.gui.popups.PopChoiceExt;
-import betterquesting.api2.client.gui.context.IQuestContextMenuEntry;
-import betterquesting.api2.client.gui.context.QuestContextMenuRegistry;
 import betterquesting.api2.client.gui.popups.PopContextMenuHoverSub;
 import betterquesting.api2.client.gui.resources.colors.GuiColorPulse;
 import betterquesting.api2.client.gui.resources.colors.GuiColorStatic;
@@ -595,7 +595,8 @@ public class GuiQuestLines extends GuiScreenCanvas implements IPEventListener, I
                             RenderUtils
                                 .getStringWidth(QuestTranslation.translate("betterquesting.btn.view_dependants"), fr));
 
-                        int menuItemCount = 5 + QuestContextMenuRegistry.getEntries().size(); // bookmark, share, copy, deps, dependants + external
+                        int menuItemCount = 5 + QuestContextMenuRegistry.getEntries()
+                            .size(); // bookmark, share, copy, deps, dependants + external
                         PopContextMenuHoverSub popup = new PopContextMenuHoverSub(
                             new GuiRectangle(mx, my, maxWidth + 20, menuItemCount * 16),
                             true);
@@ -689,7 +690,8 @@ public class GuiQuestLines extends GuiScreenCanvas implements IPEventListener, I
                             final IQuest capturedQuest = theQuest;
                             final UUID capturedId = questId;
                             popup.addButton(ext.getLabel(capturedId, capturedQuest), null, () -> {
-                                ext.getAction(capturedId, capturedQuest).run();
+                                ext.getAction(capturedId, capturedQuest)
+                                    .run();
                                 closePopup();
                             });
                         }


### PR DESCRIPTION
Adds a simple extension point so other mods can register custom entries into the quest right-click context menu without patching GuiQuestLines.

`IQuestContextMenuEntry` defines the label and action. `QuestContextMenuRegistry.register()` is called during mod init. `GuiQuestLines` picks up registered entries and adds them to the popup before it opens, closing the popup automatically after each action runs.

The registry uses a synchronized list internally and returns a snapshot on `getEntries()` to avoid ConcurrentModificationException.