### PR TITLE
fix questId copy on macos

### DIFF
--- a/src/main/java/betterquesting/client/gui2/GuiBookmarks.java
+++ b/src/main/java/betterquesting/client/gui2/GuiBookmarks.java
@@ -1,7 +1,5 @@
 package betterquesting.client.gui2;
 
-import java.awt.Toolkit;
-import java.awt.datatransfer.StringSelection;
 import java.util.UUID;
 import java.util.function.Consumer;
 
@@ -141,22 +139,13 @@ public class GuiBookmarks extends GuiScreenCanvas {
                             .addButton(QuestTranslation.translate("betterquesting.btn.share_quest"), null, questSharer);
 
                         Runnable copyQuestId = () -> {
-                            StringSelection stringToCopy = new StringSelection(UuidConverter.encodeUuid(questId));
-                            try {
-                                Toolkit.getDefaultToolkit()
-                                    .getSystemClipboard()
-                                    .setContents(stringToCopy, null);
-                                mc.thePlayer.addChatMessage(
-                                    new ChatComponentText(
-                                        QuestTranslation.translate("betterquesting.msg.copy_quest_copied")));
-                                mc.thePlayer.addChatMessage(
-                                    new ChatComponentText(
-                                        "  " + EnumChatFormatting.AQUA + UuidConverter.encodeUuid(questId)));
-                            } catch (IllegalStateException e) {
-                                mc.thePlayer.addChatMessage(
-                                    new ChatComponentText(
-                                        QuestTranslation.translate("betterquesting.msg.copy_quest_failed")));
-                            }
+                            String questIdString = UuidConverter.encodeUuid(questId);
+                            GuiScreen.setClipboardString(questIdString);
+                            mc.thePlayer.addChatMessage(
+                                new ChatComponentText(
+                                    QuestTranslation.translate("betterquesting.msg.copy_quest_copied")));
+                            mc.thePlayer
+                                .addChatMessage(new ChatComponentText("  " + EnumChatFormatting.AQUA + questIdString));
                             closePopup();
                         };
                         popup.addButton(QuestTranslation.translate("betterquesting.btn.copy_quest"), null, copyQuestId);

--- a/src/main/java/betterquesting/client/gui2/GuiQuestLines.java
+++ b/src/main/java/betterquesting/client/gui2/GuiQuestLines.java
@@ -3,8 +3,6 @@ package betterquesting.client.gui2;
 import static betterquesting.api.storage.BQ_Settings.alwaysDrawImplicit;
 import static betterquesting.api.storage.BQ_Settings.forceMonochromeText;
 
-import java.awt.Toolkit;
-import java.awt.datatransfer.StringSelection;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -624,22 +622,13 @@ public class GuiQuestLines extends GuiScreenCanvas implements IPEventListener, I
                             .addButton(QuestTranslation.translate("betterquesting.btn.share_quest"), null, questSharer);
 
                         Runnable copyQuestId = () -> {
-                            StringSelection stringToCopy = new StringSelection(UuidConverter.encodeUuid(questId));
-                            try {
-                                Toolkit.getDefaultToolkit()
-                                    .getSystemClipboard()
-                                    .setContents(stringToCopy, null);
-                                mc.thePlayer.addChatMessage(
-                                    new ChatComponentText(
-                                        QuestTranslation.translate("betterquesting.msg.copy_quest_copied")));
-                                mc.thePlayer.addChatMessage(
-                                    new ChatComponentText(
-                                        "  " + EnumChatFormatting.AQUA + UuidConverter.encodeUuid(questId)));
-                            } catch (IllegalStateException e) {
-                                mc.thePlayer.addChatMessage(
-                                    new ChatComponentText(
-                                        QuestTranslation.translate("betterquesting.msg.copy_quest_failed")));
-                            }
+                            String questIdString = UuidConverter.encodeUuid(questId);
+                            GuiScreen.setClipboardString(questIdString);
+                            mc.thePlayer.addChatMessage(
+                                new ChatComponentText(
+                                    QuestTranslation.translate("betterquesting.msg.copy_quest_copied")));
+                            mc.thePlayer
+                                .addChatMessage(new ChatComponentText("  " + EnumChatFormatting.AQUA + questIdString));
                             closePopup();
                         };
                         popup.addButton(QuestTranslation.translate("betterquesting.btn.copy_quest"), null, copyQuestId);


### PR DESCRIPTION
fixes GTNewHorizons/GT-New-Horizons-Modpack/issues/24492

Most of the project already uses `GuiScreen.setClipboardString`. Replaced two left outstanding copy implementations

`GuiScreen.setClipboardString` has the same code as the code I replaced in this pr:
<img width="908" height="366" alt="image" src="https://github.com/user-attachments/assets/add5381e-ebbd-445b-bcab-2c6505b4b8d3" />

But lwjgl3ify replaces this method (along with `getClipboardString`) to use SDL clipboard api in this mixin:
https://github.com/GTNewHorizons/lwjgl3ify/blob/ac5b982f4d07654aaa0e2d8394d55eeca5114b36/src/main/java/me/eigenraven/lwjgl3ify/mixins/early/game/MixinGuiScreen.java