### PR TITLE
Remove Text Formatting From Items in Reward/Task Panel

### DIFF
--- a/src/main/java/bq_standard/client/gui/rewards/PanelRewardChoice.java
+++ b/src/main/java/bq_standard/client/gui/rewards/PanelRewardChoice.java
@@ -4,6 +4,7 @@ import java.util.Map;
 import java.util.UUID;
 
 import net.minecraft.client.Minecraft;
+import net.minecraft.util.EnumChatFormatting;
 
 import org.lwjgl.util.vector.Vector4f;
 
@@ -63,8 +64,9 @@ public class PanelRewardChoice extends CanvasMinimum {
                 new PanelTextBox(
                     new GuiRectangle(62, i * 18 + 4, listWidth - 22, 14, 0),
                     stack.stackSize + " "
-                        + stack.getBaseStack()
-                            .getDisplayName()).setColor(PresetColor.TEXT_MAIN.getColor()));
+                        + EnumChatFormatting.getTextWithoutFormattingCodes(
+                            stack.getBaseStack()
+                                .getDisplayName())).setColor(PresetColor.TEXT_MAIN.getColor()));
 
             final int sID = i;
             is.setCallback(value -> NetRewardChoice.requestChoice(qID, rID, sID));

--- a/src/main/java/bq_standard/client/gui/rewards/PanelRewardItem.java
+++ b/src/main/java/bq_standard/client/gui/rewards/PanelRewardItem.java
@@ -1,5 +1,7 @@
 package bq_standard.client.gui.rewards;
 
+import net.minecraft.util.EnumChatFormatting;
+
 import betterquesting.api.utils.BigItemStack;
 import betterquesting.api2.client.gui.misc.GuiRectangle;
 import betterquesting.api2.client.gui.misc.IGuiRect;
@@ -37,8 +39,9 @@ public class PanelRewardItem extends CanvasMinimum {
                 new PanelTextBox(
                     new GuiRectangle(22, i * 18 + 4, listWidth - 22, 14, 0),
                     stack.stackSize + " "
-                        + stack.getBaseStack()
-                            .getDisplayName()).setColor(PresetColor.TEXT_MAIN.getColor()));
+                        + EnumChatFormatting.getTextWithoutFormattingCodes(
+                            stack.getBaseStack()
+                                .getDisplayName())).setColor(PresetColor.TEXT_MAIN.getColor()));
         }
 
         recalcSizes();

--- a/src/main/java/bq_standard/client/gui/tasks/PanelTaskItemBase.java
+++ b/src/main/java/bq_standard/client/gui/tasks/PanelTaskItemBase.java
@@ -107,8 +107,9 @@ public abstract class PanelTaskItemBase<T extends TaskProgressableBase<int[]>> e
         StringBuilder sb = new StringBuilder();
         BigItemStack stack = itemSlots[index].getStoredValue();
         sb.append(
-            stack.getBaseStack()
-                .getDisplayName());
+            EnumChatFormatting.getTextWithoutFormattingCodes(
+                stack.getBaseStack()
+                    .getDisplayName()));
 
         if (oreDictName[index] != null) sb.append(" (")
             .append(oreDictName[index])


### PR DESCRIPTION
The colors and other formatting that comes native to certain items makes them impossible to see between themes. This just removes it outright since it's completely unnecessary in the first place.

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/25108