### PR TITLE
Add extensible localized text editor actions

### DIFF
--- a/src/main/java/betterquesting/api2/client/gui/controls/PanelTextField.java
+++ b/src/main/java/betterquesting/api2/client/gui/controls/PanelTextField.java
@@ -1,6 +1,9 @@
 package betterquesting.api2.client.gui.controls;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.FontRenderer;
@@ -41,6 +44,8 @@ public class PanelTextField<T> implements IGuiPanel {
     private int maxLength = 32;
 
     private String text;
+    private TextDisplayText displayText = TextDisplayText.identity("");
+    private Function<String, TextDisplayText> displayFormatter = TextDisplayText::identity;
     private String watermark = "";
 
     private int selectStart = 0;
@@ -54,6 +59,9 @@ public class PanelTextField<T> implements IGuiPanel {
     private IValueIO<Float> scrollY;
     private int scrollWidth = 0;
     private int scrollHeight = 0;
+    private List<String> visualLines = Collections.emptyList();
+    private int visualLinesWidth = -1;
+    private int preferredCursorX = -1;
 
     private final IFieldFilter<T> filter;
     private ICallback<T> callback;
@@ -194,8 +202,16 @@ public class PanelTextField<T> implements IGuiPanel {
         return this;
     }
 
+    public PanelTextField<T> setDisplayFormatter(Function<String, TextDisplayText> formatter) {
+        this.displayFormatter = Objects.requireNonNull(formatter, "formatter");
+        updateDisplayText();
+        return this;
+    }
+
     public void setText(String text) {
         this.text = filter.filterText(text);
+        invalidateVisualLines();
+        updateDisplayText();
         updateScrollBounds();
         setCursorPosition(0);
     }
@@ -248,6 +264,8 @@ public class PanelTextField<T> implements IGuiPanel {
         // if(filter.isValid(text))
         {
             this.text = filter.filterText(out.toString());
+            invalidateVisualLines();
+            updateDisplayText();
             updateScrollBounds();
             moveCursorBy(l - selectEnd + used);
 
@@ -298,6 +316,8 @@ public class PanelTextField<T> implements IGuiPanel {
                 // if(filter.isValid(s))
                 {
                     this.text = filter.filterText(s);
+                    invalidateVisualLines();
+                    updateDisplayText();
 
                     updateScrollBounds();
 
@@ -373,6 +393,7 @@ public class PanelTextField<T> implements IGuiPanel {
      * Sets the current position of the cursor.
      */
     public void setCursorPosition(int pos) {
+        preferredCursorX = -1;
         this.selectStart = pos;
         int i = this.text.length();
         this.selectStart = MathHelper.clamp_int(this.selectStart, 0, i);
@@ -386,7 +407,13 @@ public class PanelTextField<T> implements IGuiPanel {
     public boolean onKeyTyped(char typedChar, int keyCode) {
         if (!this.isFocused) {
             return false;
-        } else if (keyCode == 30 && isKeyComboCtrl()) // Ctrl + A
+        }
+
+        if (keyCode != 200 && keyCode != 208) {
+            preferredCursorX = -1;
+        }
+
+        if (keyCode == 30 && isKeyComboCtrl()) // Ctrl + A
         {
             this.setCursorPosition(text.length());
             this.setSelectionPos(0);
@@ -487,12 +514,12 @@ public class PanelTextField<T> implements IGuiPanel {
                 }
                 case 200: // Up arrow
                 {
-                    // TODO: Move cursor up one line
+                    moveCursorVertically(-1, GuiScreen.isShiftKeyDown());
                     return true;
                 }
                 case 208: // Down arrow
                 {
-                    // TODO: Move cursor down one line
+                    moveCursorVertically(1, GuiScreen.isShiftKeyDown());
                     return true;
                 }
                 case 211: // Delete
@@ -527,6 +554,77 @@ public class PanelTextField<T> implements IGuiPanel {
             && !(Keyboard.isKeyDown(56) || Keyboard.isKeyDown(184));
     }
 
+    private List<String> getVisualLines(FontRenderer font) {
+        int width = Math.max(1, getTransform().getWidth() - 8);
+        if (visualLinesWidth != width) {
+            visualLines = RenderUtils.splitStringWithoutFormat(text, width, font);
+            visualLinesWidth = width;
+        }
+        return visualLines;
+    }
+
+    private void invalidateVisualLines() {
+        visualLines = Collections.emptyList();
+        visualLinesWidth = -1;
+    }
+
+    private void moveCursorVertically(int direction, boolean extendSelection) {
+        if (!canWrap || text.isEmpty()) {
+            return;
+        }
+
+        FontRenderer font = Minecraft.getMinecraft().fontRenderer;
+        List<String> lines = getVisualLines(font);
+        int currentPosition = selectEnd;
+        int currentLine = 0;
+        int currentLineStart = 0;
+        String activeFormatting = "";
+
+        for (; currentLine < lines.size(); currentLine++) {
+            String line = lines.get(currentLine);
+            int currentLineEnd = currentLineStart + line.length();
+            if (currentPosition < currentLineEnd || currentLine == lines.size() - 1) {
+                break;
+            }
+            currentLineStart = currentLineEnd;
+            activeFormatting = RenderUtils.getFormatFromString(activeFormatting + line);
+        }
+
+        int targetLine = MathHelper.clamp_int(currentLine + direction, 0, lines.size() - 1);
+        if (targetLine == currentLine) {
+            return;
+        }
+
+        String currentLineText = lines.get(currentLine);
+        int currentLineOffset = MathHelper.clamp_int(currentPosition - currentLineStart, 0, currentLineText.length());
+        int targetColumn = preferredCursorX;
+        if (targetColumn < 0) {
+            targetColumn = RenderUtils
+                .getStringWidth(activeFormatting + currentLineText.substring(0, currentLineOffset), font);
+            preferredCursorX = targetColumn;
+        }
+
+        int targetLineStart = 0;
+        String targetFormatting = "";
+        for (int index = 0; index < targetLine; index++) {
+            String line = lines.get(index);
+            targetLineStart += line.length();
+            targetFormatting = RenderUtils.getFormatFromString(targetFormatting + line);
+        }
+
+        String targetLineText = lines.get(targetLine);
+        int targetLineOffset = RenderUtils.getCursorPos(targetFormatting + targetLineText, targetColumn, font)
+            - targetFormatting.length();
+        int targetPosition = targetLineStart + MathHelper.clamp_int(targetLineOffset, 0, targetLineText.length());
+
+        if (extendSelection) {
+            setSelectionPos(targetPosition);
+        } else {
+            setCursorPosition(targetPosition);
+        }
+        preferredCursorX = targetColumn;
+    }
+
     /**
      * Sets the position of the selection anchor (the selection anchor and the cursor position mark the edges of the
      * selection). If the anchor is set beyond the bounds of the current text, it will be put back inside.
@@ -548,7 +646,7 @@ public class PanelTextField<T> implements IGuiPanel {
             FontRenderer font = Minecraft.getMinecraft().fontRenderer;
 
             if (canWrap) {
-                List<String> lines = RenderUtils.splitStringWithoutFormat(text, getTransform().getWidth() - 8, font);
+                List<String> lines = getVisualLines(font);
                 String lastFormat = "";
                 int idx = 0;
                 int y = 0;
@@ -679,30 +777,33 @@ public class PanelTextField<T> implements IGuiPanel {
             }
         } else {
             IGuiColor c = colStates[state];
+            String renderedText = displayText.getText();
+            int displaySelectionStart = displayText.getDisplayIndex(selectStart);
+            int displaySelectionEnd = displayText.getDisplayIndex(selectEnd);
 
             if (!canWrap) {
                 RenderUtils.drawHighlightedString(
                     mc.fontRenderer,
-                    text,
+                    renderedText,
                     bounds.getX() + 4,
                     bounds.getY() + 4,
                     c.getRGB(),
                     false,
                     colHighlight.getRGB(),
-                    selectStart,
-                    selectEnd);
+                    displaySelectionStart,
+                    displaySelectionEnd);
             } else {
                 RenderUtils.drawHighlightedSplitString(
                     mc.fontRenderer,
-                    text,
+                    renderedText,
                     bounds.getX() + 4,
                     bounds.getY() + 4,
                     bounds.getWidth() - 8,
                     c.getRGB(),
                     false,
                     colHighlight.getRGB(),
-                    selectStart,
-                    selectEnd);
+                    displaySelectionStart,
+                    displaySelectionEnd);
             }
         }
 
@@ -753,6 +854,8 @@ public class PanelTextField<T> implements IGuiPanel {
             this.isFocused = false;
             this.text = filter.parseValue(this.text)
                 .toString();
+            invalidateVisualLines();
+            updateDisplayText();
             // setCursorPosition(0);
         }
 
@@ -787,5 +890,39 @@ public class PanelTextField<T> implements IGuiPanel {
     @Override
     public List<String> getTooltip(int mx, int my) {
         return null;
+    }
+
+    private void updateDisplayText() {
+        displayText = Objects.requireNonNull(displayFormatter.apply(text), "displayFormatter result");
+    }
+
+    public static class TextDisplayText {
+
+        private final String text;
+        private final int[] sourceToDisplay;
+
+        public TextDisplayText(String text, int[] sourceToDisplay) {
+            this.text = Objects.requireNonNull(text, "text");
+            this.sourceToDisplay = Objects.requireNonNull(sourceToDisplay, "sourceToDisplay");
+            if (sourceToDisplay.length == 0) {
+                throw new IllegalArgumentException("sourceToDisplay must contain the end position");
+            }
+        }
+
+        public static TextDisplayText identity(String source) {
+            int[] sourceToDisplay = new int[source.length() + 1];
+            for (int index = 0; index < sourceToDisplay.length; index++) {
+                sourceToDisplay[index] = index;
+            }
+            return new TextDisplayText(source, sourceToDisplay);
+        }
+
+        public String getText() {
+            return text;
+        }
+
+        public int getDisplayIndex(int sourceIndex) {
+            return sourceToDisplay[MathHelper.clamp_int(sourceIndex, 0, sourceToDisplay.length - 1)];
+        }
     }
 }

--- a/src/main/java/betterquesting/api2/client/gui/controls/PanelTextField.java
+++ b/src/main/java/betterquesting/api2/client/gui/controls/PanelTextField.java
@@ -205,6 +205,7 @@ public class PanelTextField<T> implements IGuiPanel {
     public PanelTextField<T> setDisplayFormatter(Function<String, TextDisplayText> formatter) {
         this.displayFormatter = Objects.requireNonNull(formatter, "formatter");
         updateDisplayText();
+        updateScrollBounds();
         return this;
     }
 
@@ -557,7 +558,7 @@ public class PanelTextField<T> implements IGuiPanel {
     private List<String> getVisualLines(FontRenderer font) {
         int width = Math.max(1, getTransform().getWidth() - 8);
         if (visualLinesWidth != width) {
-            visualLines = RenderUtils.splitStringWithoutFormat(text, width, font);
+            visualLines = RenderUtils.splitStringWithoutFormat(displayText.getText(), width, font);
             visualLinesWidth = width;
         }
         return visualLines;
@@ -575,7 +576,7 @@ public class PanelTextField<T> implements IGuiPanel {
 
         FontRenderer font = Minecraft.getMinecraft().fontRenderer;
         List<String> lines = getVisualLines(font);
-        int currentPosition = selectEnd;
+        int currentPosition = displayText.getDisplayIndex(selectEnd);
         int currentLine = 0;
         int currentLineStart = 0;
         String activeFormatting = "";
@@ -615,7 +616,8 @@ public class PanelTextField<T> implements IGuiPanel {
         String targetLineText = lines.get(targetLine);
         int targetLineOffset = RenderUtils.getCursorPos(targetFormatting + targetLineText, targetColumn, font)
             - targetFormatting.length();
-        int targetPosition = targetLineStart + MathHelper.clamp_int(targetLineOffset, 0, targetLineText.length());
+        int targetPosition = displayText
+            .getSourceIndex(targetLineStart + MathHelper.clamp_int(targetLineOffset, 0, targetLineText.length()));
 
         if (extendSelection) {
             setSelectionPos(targetPosition);
@@ -647,6 +649,7 @@ public class PanelTextField<T> implements IGuiPanel {
 
             if (canWrap) {
                 List<String> lines = getVisualLines(font);
+                int displaySelectionEnd = displayText.getDisplayIndex(selectEnd);
                 String lastFormat = "";
                 int idx = 0;
                 int y = 0;
@@ -655,8 +658,9 @@ public class PanelTextField<T> implements IGuiPanel {
                 for (; y < lines.size(); y++) {
                     String s = lines.get(y);
 
-                    if (selectEnd >= idx && selectEnd < idx + s.length() + (y == lines.size() - 1 ? 1 : 0)) {
-                        x = RenderUtils.getStringWidth(lastFormat + s.substring(0, selectEnd - idx), font);
+                    if (displaySelectionEnd >= idx
+                        && displaySelectionEnd < idx + s.length() + (y == lines.size() - 1 ? 1 : 0)) {
+                        x = RenderUtils.getStringWidth(lastFormat + s.substring(0, displaySelectionEnd - idx), font);
                         break;
                     }
 
@@ -678,7 +682,11 @@ public class PanelTextField<T> implements IGuiPanel {
                 cursorLine.w = 1;
                 cursorLine.h = font.FONT_HEIGHT;
             } else {
-                int x = RenderUtils.getStringWidth(text.substring(0, selectEnd), font);
+                int displaySelectionEnd = displayText.getDisplayIndex(selectEnd);
+                int x = RenderUtils.getStringWidth(
+                    displayText.getText()
+                        .substring(0, displaySelectionEnd),
+                    font);
                 int sx = getScrollX();
 
                 if (x < sx) {
@@ -703,12 +711,13 @@ public class PanelTextField<T> implements IGuiPanel {
 
         if (!canWrap) {
             scrollHeight = 0;
-            scrollWidth = Math.max(0, RenderUtils.getStringWidth(text, font) - (transform.getWidth() - 8));
+            scrollWidth = Math
+                .max(0, RenderUtils.getStringWidth(displayText.getText(), font) - (transform.getWidth() - 8));
         } else {
             scrollWidth = 0;
             scrollHeight = Math.max(
                 0,
-                (RenderUtils.splitString(text, transform.getWidth() - 8, font)
+                (RenderUtils.splitString(displayText.getText(), transform.getWidth() - 8, font)
                     .size() * font.FONT_HEIGHT) - (transform.getHeight() - 8));
         }
 
@@ -743,15 +752,20 @@ public class PanelTextField<T> implements IGuiPanel {
         if (isActive && dragging && Mouse.isButtonDown(0)) {
             if (canWrap) {
                 setSelectionPos(
-                    RenderUtils.getCursorPos(
-                        text,
-                        mx - (transform.getX() + 4) + getScrollX(),
-                        my - (transform.getY() + 4) + getScrollY(),
-                        transform.getWidth() - 8,
-                        mc.fontRenderer));
+                    displayText.getSourceIndex(
+                        RenderUtils.getCursorPos(
+                            displayText.getText(),
+                            mx - (transform.getX() + 4) + getScrollX(),
+                            my - (transform.getY() + 4) + getScrollY(),
+                            transform.getWidth() - 8,
+                            mc.fontRenderer)));
             } else {
                 setSelectionPos(
-                    RenderUtils.getCursorPos(text, mx - (transform.getX() + 4) + getScrollX(), mc.fontRenderer));
+                    displayText.getSourceIndex(
+                        RenderUtils.getCursorPos(
+                            displayText.getText(),
+                            mx - (transform.getX() + 4) + getScrollX(),
+                            mc.fontRenderer)));
             }
         } else if (dragging) {
             dragging = false;
@@ -834,18 +848,20 @@ public class PanelTextField<T> implements IGuiPanel {
 
             if (canWrap) {
                 setCursorPosition(
-                    RenderUtils.getCursorPos(
-                        text,
-                        mx - (transform.getX() + 4) + getScrollX(),
-                        my - (transform.getY() + 4) + getScrollY(),
-                        transform.getWidth() - 8,
-                        Minecraft.getMinecraft().fontRenderer));
+                    displayText.getSourceIndex(
+                        RenderUtils.getCursorPos(
+                            displayText.getText(),
+                            mx - (transform.getX() + 4) + getScrollX(),
+                            my - (transform.getY() + 4) + getScrollY(),
+                            transform.getWidth() - 8,
+                            Minecraft.getMinecraft().fontRenderer)));
             } else {
                 setCursorPosition(
-                    RenderUtils.getCursorPos(
-                        text,
-                        mx - (transform.getX() + 4) + getScrollX(),
-                        Minecraft.getMinecraft().fontRenderer));
+                    displayText.getSourceIndex(
+                        RenderUtils.getCursorPos(
+                            displayText.getText(),
+                            mx - (transform.getX() + 4) + getScrollX(),
+                            Minecraft.getMinecraft().fontRenderer)));
             }
             dragging = true;
 
@@ -894,6 +910,7 @@ public class PanelTextField<T> implements IGuiPanel {
 
     private void updateDisplayText() {
         displayText = Objects.requireNonNull(displayFormatter.apply(text), "displayFormatter result");
+        invalidateVisualLines();
     }
 
     public static class TextDisplayText {
@@ -923,6 +940,26 @@ public class PanelTextField<T> implements IGuiPanel {
 
         public int getDisplayIndex(int sourceIndex) {
             return sourceToDisplay[MathHelper.clamp_int(sourceIndex, 0, sourceToDisplay.length - 1)];
+        }
+
+        public int getSourceIndex(int displayIndex) {
+            int low = 0;
+            int high = sourceToDisplay.length - 1;
+            int clampedIndex = MathHelper.clamp_int(displayIndex, sourceToDisplay[0], sourceToDisplay[high]);
+
+            while (low <= high) {
+                int middle = (low + high) >>> 1;
+                int mappedIndex = sourceToDisplay[middle];
+                if (mappedIndex < clampedIndex) {
+                    low = middle + 1;
+                } else if (mappedIndex > clampedIndex) {
+                    high = middle - 1;
+                } else {
+                    return middle;
+                }
+            }
+
+            return Math.max(0, high);
         }
     }
 }

--- a/src/main/java/betterquesting/api2/client/gui/controls/PanelTextField.java
+++ b/src/main/java/betterquesting/api2/client/gui/controls/PanelTextField.java
@@ -410,7 +410,7 @@ public class PanelTextField<T> implements IGuiPanel {
             return false;
         }
 
-        if (keyCode != 200 && keyCode != 208) {
+        if (keyCode != 200 && keyCode != 208) { // Up and down arrows
             preferredCursorX = -1;
         }
 
@@ -552,7 +552,7 @@ public class PanelTextField<T> implements IGuiPanel {
 
     private static boolean isKeyComboCtrl() {
         return GuiScreen.isCtrlKeyDown() && !GuiScreen.isShiftKeyDown()
-            && !(Keyboard.isKeyDown(56) || Keyboard.isKeyDown(184));
+            && !(Keyboard.isKeyDown(56) || Keyboard.isKeyDown(184)); // Left or right Alt
     }
 
     private List<String> getVisualLines(FontRenderer font) {

--- a/src/main/java/betterquesting/api2/client/gui/editors/TextEditorAction.java
+++ b/src/main/java/betterquesting/api2/client/gui/editors/TextEditorAction.java
@@ -1,0 +1,23 @@
+package betterquesting.api2.client.gui.editors;
+
+import java.util.Objects;
+import java.util.function.Consumer;
+
+public class TextEditorAction {
+
+    private final String translationKey;
+    private final Consumer<TextEditorActionContext> executor;
+
+    public TextEditorAction(String translationKey, Consumer<TextEditorActionContext> executor) {
+        this.translationKey = Objects.requireNonNull(translationKey, "translationKey");
+        this.executor = Objects.requireNonNull(executor, "executor");
+    }
+
+    public String getTranslationKey() {
+        return translationKey;
+    }
+
+    public void execute(TextEditorActionContext context) {
+        executor.accept(Objects.requireNonNull(context, "context"));
+    }
+}

--- a/src/main/java/betterquesting/api2/client/gui/editors/TextEditorActionContext.java
+++ b/src/main/java/betterquesting/api2/client/gui/editors/TextEditorActionContext.java
@@ -1,0 +1,51 @@
+package betterquesting.api2.client.gui.editors;
+
+import java.util.Objects;
+
+import betterquesting.api2.client.gui.panels.IGuiPanel;
+import betterquesting.api2.client.gui.popups.PopColorInput;
+import betterquesting.api2.utils.QuestTranslation;
+import betterquesting.client.gui2.editors.GuiTextEditor;
+
+public class TextEditorActionContext {
+
+    private final GuiTextEditor editor;
+
+    public TextEditorActionContext(GuiTextEditor editor) {
+        this.editor = Objects.requireNonNull(editor, "editor");
+    }
+
+    public String getSelectedText() {
+        return editor.getSelectedText();
+    }
+
+    public void replaceSelectedText(String text) {
+        editor.replaceSelectedText(Objects.requireNonNull(text, "text"));
+    }
+
+    public void applyFormatting(String formatting) {
+        applyFormatting(Objects.requireNonNull(formatting, "formatting"), getSelectedText());
+    }
+
+    public void clearFormatting() {
+        String selectedText = getSelectedText();
+        replaceSelectedText(selectedText.isEmpty() ? "\u00a7r" : GuiTextEditor.stripFormatting(selectedText));
+    }
+
+    public void openPopup(IGuiPanel panel) {
+        editor.openPopup(Objects.requireNonNull(panel, "panel"));
+    }
+
+    public void openColorPicker(String titleKey, boolean gradient) {
+        String selectedText = getSelectedText();
+        openPopup(
+            new PopColorInput(
+                QuestTranslation.translate(titleKey),
+                gradient,
+                formatting -> applyFormatting(formatting, selectedText)));
+    }
+
+    private void applyFormatting(String formatting, String selectedText) {
+        replaceSelectedText(selectedText.isEmpty() ? formatting : formatting + selectedText + "\u00a7r");
+    }
+}

--- a/src/main/java/betterquesting/api2/client/gui/editors/TextEditorActionRegistry.java
+++ b/src/main/java/betterquesting/api2/client/gui/editors/TextEditorActionRegistry.java
@@ -1,0 +1,69 @@
+package betterquesting.api2.client.gui.editors;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import net.minecraft.util.ResourceLocation;
+
+public class TextEditorActionRegistry {
+
+    private static final Map<ResourceLocation, TextEditorAction> ACTIONS = new LinkedHashMap<>();
+
+    static {
+        register(
+            new ResourceLocation("betterquesting:hyperlink"),
+            new TextEditorMacro("betterquesting.editor.macro.hyperlink", "[url]", "[/url]"));
+        register(
+            new ResourceLocation("betterquesting:warning"),
+            new TextEditorMacro("betterquesting.editor.macro.warning", "[warn]", "[/warn]"));
+        register(
+            new ResourceLocation("betterquesting:note"),
+            new TextEditorMacro("betterquesting.editor.macro.note", "[note]", "[/note]"));
+        register(
+            new ResourceLocation("betterquesting:quest_title"),
+            new TextEditorMacro("betterquesting.editor.macro.quest_title", "[quest]", "[/quest]"));
+        register(
+            new ResourceLocation("betterquesting:hex_color"),
+            new TextEditorAction(
+                "betterquesting.editor.action.hex_color",
+                context -> context.openColorPicker("betterquesting.editor.color_picker.hex", false)));
+        register(
+            new ResourceLocation("betterquesting:rainbow"),
+            new TextEditorAction("betterquesting.editor.action.rainbow", context -> context.applyFormatting("&q")));
+        register(
+            new ResourceLocation("betterquesting:wave"),
+            new TextEditorAction("betterquesting.editor.action.wave", context -> context.applyFormatting("&z")));
+        register(
+            new ResourceLocation("betterquesting:flip"),
+            new TextEditorAction("betterquesting.editor.action.flip", context -> context.applyFormatting("&v")));
+        register(
+            new ResourceLocation("betterquesting:gradient"),
+            new TextEditorAction(
+                "betterquesting.editor.action.gradient",
+                context -> context.openColorPicker("betterquesting.editor.color_picker.gradient", true)));
+        register(
+            new ResourceLocation("betterquesting:clear_format"),
+            new TextEditorAction(
+                "betterquesting.editor.action.clear_format",
+                TextEditorActionContext::clearFormatting));
+    }
+
+    private TextEditorActionRegistry() {}
+
+    public static synchronized void register(ResourceLocation id, TextEditorAction action) {
+        Objects.requireNonNull(id, "id");
+        Objects.requireNonNull(action, "action");
+        if (ACTIONS.containsKey(id)) {
+            throw new IllegalArgumentException("Text editor action is already registered: " + id);
+        }
+        ACTIONS.put(id, action);
+    }
+
+    public static synchronized List<TextEditorAction> getAll() {
+        return Collections.unmodifiableList(new ArrayList<>(ACTIONS.values()));
+    }
+}

--- a/src/main/java/betterquesting/api2/client/gui/editors/TextEditorMacro.java
+++ b/src/main/java/betterquesting/api2/client/gui/editors/TextEditorMacro.java
@@ -1,0 +1,21 @@
+package betterquesting.api2.client.gui.editors;
+
+import java.util.Objects;
+
+public class TextEditorMacro extends TextEditorAction {
+
+    private final String openingText;
+    private final String closingText;
+
+    public TextEditorMacro(String translationKey, String openingText, String closingText) {
+        super(
+            translationKey,
+            context -> context.replaceSelectedText(openingText + context.getSelectedText() + closingText));
+        this.openingText = Objects.requireNonNull(openingText, "openingText");
+        this.closingText = Objects.requireNonNull(closingText, "closingText");
+    }
+
+    public String wrap(String text) {
+        return openingText + text + closingText;
+    }
+}

--- a/src/main/java/betterquesting/api2/client/gui/misc/URIHandlers.java
+++ b/src/main/java/betterquesting/api2/client/gui/misc/URIHandlers.java
@@ -1,8 +1,10 @@
 package betterquesting.api2.client.gui.misc;
 
 import java.net.URI;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
 import java.util.function.Predicate;
 
 import net.minecraft.client.Minecraft;
@@ -17,6 +19,7 @@ public class URIHandlers {
     private URIHandlers() {}
 
     private static final Map<String, Predicate<URI>> handlers = new ConcurrentHashMap<>();
+    private static final Map<String, Function<URI, List<String>>> tooltipHandlers = new ConcurrentHashMap<>();
 
     static {
         register("http", new HTTPHandler());
@@ -30,6 +33,16 @@ public class URIHandlers {
 
     public static Predicate<URI> get(String scheme) {
         return handlers.get(scheme);
+    }
+
+    public static synchronized void registerTooltip(String scheme, Function<URI, List<String>> tooltipHandler) {
+        if (tooltipHandlers.containsKey(scheme)) throw new IllegalArgumentException("duplicate tooltip handler");
+        tooltipHandlers.put(scheme, tooltipHandler);
+    }
+
+    public static List<String> getTooltip(URI uri) {
+        Function<URI, List<String>> tooltipHandler = tooltipHandlers.get(uri.getScheme());
+        return tooltipHandler != null ? tooltipHandler.apply(uri) : null;
     }
 
     private static class HTTPHandler implements Predicate<URI> {

--- a/src/main/java/betterquesting/api2/client/gui/panels/content/PanelTextBox.java
+++ b/src/main/java/betterquesting/api2/client/gui/panels/content/PanelTextBox.java
@@ -4,20 +4,27 @@ import static betterquesting.api.storage.BQ_Settings.textWidthCorrection;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.Deque;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Scanner;
 import java.util.Set;
 import java.util.UUID;
+import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.util.MathHelper;
+import net.minecraft.util.ResourceLocation;
 
 import org.apache.commons.lang3.StringUtils;
 import org.lwjgl.opengl.GL11;
@@ -55,6 +62,9 @@ public class PanelTextBox implements IGuiPanel {
 
     private static final String defaultUrlProtocol = "https";
     private static final Set<String> supportedUrlProtocol = ImmutableSet.of("http", "https");
+    private static final String INTERACTION_SCHEME = "bqinteraction";
+    private static final Map<ResourceLocation, Function<String, String>> textProcessors = new LinkedHashMap<>();
+    private static final Map<ResourceLocation, TextInteraction> textInteractions = new LinkedHashMap<>();
     private final GuiRectText transform;
     private final List<linkRange> linkRanges = new ArrayList<>();
     private final List<HotZone> hotZones = new ArrayList<>();
@@ -97,6 +107,7 @@ public class PanelTextBox implements IGuiPanel {
     }
 
     public PanelTextBox setText(String text) {
+        text = processText(text);
         if (hyperlinkAware) {
             StringBuilder textBuilder = new StringBuilder();
             linkRanges.clear();
@@ -246,6 +257,39 @@ public class PanelTextBox implements IGuiPanel {
 
     public void setGUI(GuiQuest questGUI) {
         this.questGUI = questGUI;
+    }
+
+    public static synchronized void registerTextProcessor(ResourceLocation id, Function<String, String> textProcessor) {
+        Objects.requireNonNull(id, "id");
+        Objects.requireNonNull(textProcessor, "textProcessor");
+        if (textProcessors.containsKey(id)) throw new IllegalArgumentException("duplicate text processor");
+        textProcessors.put(id, textProcessor);
+    }
+
+    public static synchronized void registerTextInteraction(ResourceLocation id, TextInteraction textInteraction) {
+        Objects.requireNonNull(id, "id");
+        Objects.requireNonNull(textInteraction, "textInteraction");
+        if (textInteractions.containsKey(id)) throw new IllegalArgumentException("duplicate text interaction");
+        textInteractions.put(id, textInteraction);
+    }
+
+    public static String createInteractiveText(ResourceLocation interactionId, String target, String text) {
+        Objects.requireNonNull(interactionId, "interactionId");
+        Objects.requireNonNull(target, "target");
+        Objects.requireNonNull(text, "text");
+        String payload = interactionId + "\u0000" + target;
+        String encodedPayload = Base64.getUrlEncoder()
+            .withoutPadding()
+            .encodeToString(payload.getBytes(StandardCharsets.UTF_8));
+        return "[url link=" + INTERACTION_SCHEME + ":" + encodedPayload + "]" + text + "[/url]";
+    }
+
+    private static synchronized String processText(String text) {
+        String processedText = text;
+        for (Function<String, String> textProcessor : textProcessors.values()) {
+            processedText = Objects.requireNonNull(textProcessor.apply(processedText), "text processor result");
+        }
+        return processedText;
     }
 
     private void bakeHotZones(List<String> lines) {
@@ -426,19 +470,14 @@ public class PanelTextBox implements IGuiPanel {
         for (HotZone hotZone : hotZones) {
             if (hotZone.location.contains(mxt, myt)) {
                 if (hotZone.link instanceof String) {
-                    URI uri;
-                    try {
-                        URI tmp;
-                        tmp = new URI((String) hotZone.link);
-                        if (tmp.getScheme() == null) tmp = new URI(defaultUrlProtocol + "://" + hotZone.link);
-                        uri = tmp;
-                    } catch (URISyntaxException ex) {
-                        return false;
-                    }
+                    URI uri = parseUri((String) hotZone.link);
+                    if (uri == null) return false;
+                    TextInteractionInvocation interaction = getTextInteraction(uri);
+                    if (interaction != null) return interaction.textInteraction.onClick(interaction.target);
                     Predicate<URI> handler = URIHandlers.get(uri.getScheme());
                     if (handler == null) return false;
                     return handler.test(uri);
-                } else if (hotZone.link instanceof UUID) {
+                } else if (hotZone.link instanceof UUID && questGUI != null) {
                     questGUI.navigateToQuest((UUID) hotZone.link);
                     return true;
                 }
@@ -477,7 +516,67 @@ public class PanelTextBox implements IGuiPanel {
 
     @Override
     public List<String> getTooltip(int mx, int my) {
+        int mxt = mx + getTransform().getX(), myt = my + getTransform().getY();
+        for (HotZone hotZone : hotZones) {
+            if (hotZone.location.contains(mxt, myt)) {
+                if (!(hotZone.link instanceof String)) return null;
+                URI uri = parseUri((String) hotZone.link);
+                if (uri == null) return null;
+                TextInteractionInvocation interaction = getTextInteraction(uri);
+                if (interaction != null) return interaction.textInteraction.getTooltip(interaction.target);
+                List<String> tooltip = URIHandlers.getTooltip(uri);
+                if (tooltip != null && !tooltip.isEmpty()) return tooltip;
+            }
+        }
         return null;
+    }
+
+    private static URI parseUri(String url) {
+        try {
+            URI uri = new URI(url);
+            return uri.getScheme() != null ? uri : new URI(defaultUrlProtocol + "://" + url);
+        } catch (URISyntaxException ex) {
+            return null;
+        }
+    }
+
+    private static synchronized TextInteractionInvocation getTextInteraction(URI uri) {
+        if (!INTERACTION_SCHEME.equals(uri.getScheme())) return null;
+        String payload = uri.getRawSchemeSpecificPart();
+        if (payload == null || payload.isEmpty()) return null;
+        try {
+            String decodedPayload = new String(
+                Base64.getUrlDecoder()
+                    .decode(payload),
+                StandardCharsets.UTF_8);
+            int separatorIndex = decodedPayload.indexOf('\u0000');
+            if (separatorIndex <= 0) return null;
+            ResourceLocation id = new ResourceLocation(decodedPayload.substring(0, separatorIndex));
+            TextInteraction textInteraction = textInteractions.get(id);
+            return textInteraction != null
+                ? new TextInteractionInvocation(textInteraction, decodedPayload.substring(separatorIndex + 1))
+                : null;
+        } catch (IllegalArgumentException ex) {
+            return null;
+        }
+    }
+
+    public interface TextInteraction {
+
+        boolean onClick(String target);
+
+        List<String> getTooltip(String target);
+    }
+
+    private static class TextInteractionInvocation {
+
+        private final TextInteraction textInteraction;
+        private final String target;
+
+        private TextInteractionInvocation(TextInteraction textInteraction, String target) {
+            this.textInteraction = textInteraction;
+            this.target = target;
+        }
     }
 
     private static class GuiRectText implements IGuiRect {

--- a/src/main/java/betterquesting/api2/client/gui/panels/content/PanelTextBox.java
+++ b/src/main/java/betterquesting/api2/client/gui/panels/content/PanelTextBox.java
@@ -487,7 +487,7 @@ public class PanelTextBox implements IGuiPanel {
         return false;
     }
 
-    private static void openURL(URI p_146407_1_) {
+    public static void openURL(URI p_146407_1_) {
         try {
             Class<?> oclass = Class.forName("java.awt.Desktop");
             Object object = oclass.getMethod("getDesktop")
@@ -531,7 +531,7 @@ public class PanelTextBox implements IGuiPanel {
         return null;
     }
 
-    private static URI parseUri(String url) {
+    public static URI parseUri(String url) {
         try {
             URI uri = new URI(url);
             return uri.getScheme() != null ? uri : new URI(defaultUrlProtocol + "://" + url);
@@ -540,7 +540,7 @@ public class PanelTextBox implements IGuiPanel {
         }
     }
 
-    private static synchronized TextInteractionInvocation getTextInteraction(URI uri) {
+    public static synchronized TextInteractionInvocation getTextInteraction(URI uri) {
         if (!INTERACTION_SCHEME.equals(uri.getScheme())) return null;
         String payload = uri.getRawSchemeSpecificPart();
         if (payload == null || payload.isEmpty()) return null;
@@ -568,18 +568,18 @@ public class PanelTextBox implements IGuiPanel {
         List<String> getTooltip(String target);
     }
 
-    private static class TextInteractionInvocation {
+    public static class TextInteractionInvocation {
 
-        private final TextInteraction textInteraction;
-        private final String target;
+        public final TextInteraction textInteraction;
+        public final String target;
 
-        private TextInteractionInvocation(TextInteraction textInteraction, String target) {
+        public TextInteractionInvocation(TextInteraction textInteraction, String target) {
             this.textInteraction = textInteraction;
             this.target = target;
         }
     }
 
-    private static class GuiRectText implements IGuiRect {
+    public static class GuiRectText implements IGuiRect {
 
         private final IGuiRect proxy;
         private final boolean useH;
@@ -648,11 +648,11 @@ public class PanelTextBox implements IGuiPanel {
         }
     }
 
-    private static class linkRange {
+    public static class linkRange {
 
-        final int start;
-        final int end;
-        final Object link;
+        public final int start;
+        public final int end;
+        public final Object link;
 
         public linkRange(int start, int end, String link) {
             this.start = start;
@@ -667,10 +667,10 @@ public class PanelTextBox implements IGuiPanel {
         }
     }
 
-    private static class HotZone {
+    public static class HotZone {
 
-        final IGuiRect location;
-        final Object link;
+        public final IGuiRect location;
+        public final Object link;
 
         public HotZone(IGuiRect location, Object link) {
             this.location = location;

--- a/src/main/java/betterquesting/client/gui2/editors/GuiTextEditor.java
+++ b/src/main/java/betterquesting/client/gui2/editors/GuiTextEditor.java
@@ -104,6 +104,7 @@ public class GuiTextEditor extends GuiScreenCanvas implements IPEventListener, I
             new GuiTransform(GuiAlign.FULL_BOX, new GuiPadding(124, 32, 24, 32), 0),
             flText != null ? flText.getRawText() : textIn,
             FieldFilterString.INSTANCE);
+        flText.setDisplayFormatter(new TextEditorSyntaxHighlighter());
         cvBackground.addPanel(flText);
         flText.setMaxLength(Integer.MAX_VALUE);
         flText.enableWrapping(true);

--- a/src/main/java/betterquesting/client/gui2/editors/GuiTextEditor.java
+++ b/src/main/java/betterquesting/client/gui2/editors/GuiTextEditor.java
@@ -26,6 +26,10 @@ import betterquesting.api2.client.gui.controls.PanelButton;
 import betterquesting.api2.client.gui.controls.PanelButtonStorage;
 import betterquesting.api2.client.gui.controls.PanelTextField;
 import betterquesting.api2.client.gui.controls.filters.FieldFilterString;
+import betterquesting.api2.client.gui.editors.TextEditorAction;
+import betterquesting.api2.client.gui.editors.TextEditorActionContext;
+import betterquesting.api2.client.gui.editors.TextEditorActionRegistry;
+import betterquesting.api2.client.gui.editors.TextEditorMacro;
 import betterquesting.api2.client.gui.events.IPEventListener;
 import betterquesting.api2.client.gui.events.PEventBroadcaster;
 import betterquesting.api2.client.gui.events.PanelEvent;
@@ -38,7 +42,6 @@ import betterquesting.api2.client.gui.panels.CanvasTextured;
 import betterquesting.api2.client.gui.panels.bars.PanelVScrollBar;
 import betterquesting.api2.client.gui.panels.content.PanelTextBox;
 import betterquesting.api2.client.gui.panels.lists.CanvasScrolling;
-import betterquesting.api2.client.gui.popups.PopColorInput;
 import betterquesting.api2.client.gui.popups.PopWaitExternalEvent;
 import betterquesting.api2.client.gui.themes.presets.PresetColor;
 import betterquesting.api2.client.gui.themes.presets.PresetTexture;
@@ -48,6 +51,11 @@ import betterquesting.misc.QuestResourcesFile;
 import betterquesting.misc.QuestResourcesFolder;
 
 public class GuiTextEditor extends GuiScreenCanvas implements IPEventListener, IVolatileScreen {
+
+    private static final TextEditorMacro IMAGE_MACRO = new TextEditorMacro(
+        "betterquesting.editor.macro.image",
+        "[img height=100]",
+        "[/img]");
 
     private final ICallback<String> callback;
     private final boolean imageSupport;
@@ -110,52 +118,16 @@ public class GuiTextEditor extends GuiScreenCanvas implements IPEventListener, I
         int macroCount = 0;
 
         if (imageSupport) {
-            cvFormatList
-                .addPanel(new PanelButton(new GuiRectangle(0, 16 * macroCount++, 100, 16), 3, "§2§nSelect Image§r"));
             cvFormatList.addPanel(
-                new PanelButtonStorage<>(
+                new PanelButton(
                     new GuiRectangle(0, 16 * macroCount++, 100, 16),
-                    2,
-                    "§2§n Image§r",
-                    "[img height=100] [/img]"));
+                    3,
+                    QuestTranslation.translate("betterquesting.editor.macro.select_image")));
+            cvFormatList.addPanel(createActionButton(macroCount++, IMAGE_MACRO));
         }
-        cvFormatList.addPanel(
-            new PanelButtonStorage<>(
-                new GuiRectangle(0, 16 * macroCount++, 100, 16),
-                2,
-                "§9§nHyperlink§r",
-                "[url] [/url]"));
-        cvFormatList.addPanel(
-            new PanelButtonStorage<>(
-                new GuiRectangle(0, 16 * macroCount++, 100, 16),
-                2,
-                "§4§lWarning§r",
-                "[warn] [/warn]"));
-        cvFormatList.addPanel(
-            new PanelButtonStorage<>(new GuiRectangle(0, 16 * macroCount++, 100, 16), 2, "§3Note§r", "[note] [/note]"));
-        cvFormatList.addPanel(
-            new PanelButtonStorage<>(
-                new GuiRectangle(0, 16 * macroCount++, 100, 16),
-                2,
-                "§2§nQuest Title§r",
-                "[quest] [/quest]"));
-
-        // RGB color buttons
-        cvFormatList
-            .addPanel(new PanelButton(new GuiRectangle(0, 16 * macroCount++, 100, 16), 4, "\u00a7cHex Color\u00a7r"));
-        cvFormatList.addPanel(
-            new PanelButtonStorage<>(
-                new GuiRectangle(0, 16 * macroCount++, 100, 16),
-                1,
-                "\u00a7qRainbow\u00a7r",
-                "&q"));
-        cvFormatList.addPanel(
-            new PanelButtonStorage<>(new GuiRectangle(0, 16 * macroCount++, 100, 16), 1, "\u00a76Wave\u00a7r", "&z"));
-        cvFormatList.addPanel(
-            new PanelButtonStorage<>(new GuiRectangle(0, 16 * macroCount++, 100, 16), 1, "\u00a75Flip\u00a7r", "&v"));
-        cvFormatList
-            .addPanel(new PanelButton(new GuiRectangle(0, 16 * macroCount++, 100, 16), 5, "\u00a7bGradient\u00a7r"));
-        cvFormatList.addPanel(new PanelButton(new GuiRectangle(0, 16 * macroCount++, 100, 16), 6, "Clear Format"));
+        for (TextEditorAction action : TextEditorActionRegistry.getAll()) {
+            cvFormatList.addPanel(createActionButton(macroCount++, action));
+        }
 
         for (int i = 0; i < tfValues.length; i++) {
             cvFormatList.addPanel(
@@ -200,10 +172,8 @@ public class GuiTextEditor extends GuiScreenCanvas implements IPEventListener, I
                 flText.writeText(format + selected + "\u00a7r");
             }
         } else if (btn.getButtonID() == 2 && btn instanceof PanelButtonStorage) {
-            String[] tagPair = ((PanelButtonStorage<String>) btn).getStoredValue()
-                .split(" ");
-            String format = tagPair[0] + flText.getSelectedText() + tagPair[1];
-            flText.writeText(format);
+            TextEditorAction action = ((PanelButtonStorage<TextEditorAction>) btn).getStoredValue();
+            action.execute(new TextEditorActionContext(this));
         } else if (btn.getButtonID() == 3) {
             PopWaitExternalEvent<String> popup = new PopWaitExternalEvent<String>(
                 I18n.format("betterquesting.title.choose_image_swing")) {
@@ -235,38 +205,26 @@ public class GuiTextEditor extends GuiScreenCanvas implements IPEventListener, I
                     popup.ensureDone();
                 }
             });
-        } else if (btn.getButtonID() == 4) {
-            // Hex Color picker
-            String selected = flText.getSelectedText();
-            this.openPopup(new PopColorInput("Hex Color", false, colorCode -> {
-                if (selected.isEmpty()) {
-                    flText.writeText(colorCode);
-                } else {
-                    flText.writeText(colorCode + selected + "\u00a7r");
-                }
-            }));
-        } else if (btn.getButtonID() == 5) {
-            // Gradient picker
-            String selected = flText.getSelectedText();
-            this.openPopup(new PopColorInput("Gradient", true, colorCode -> {
-                if (selected.isEmpty()) {
-                    flText.writeText(colorCode);
-                } else {
-                    flText.writeText(colorCode + selected + "\u00a7r");
-                }
-            }));
-        } else if (btn.getButtonID() == 6) {
-            // Clear Format
-            String selected = flText.getSelectedText();
-            if (selected.isEmpty()) {
-                flText.writeText("\u00a7r");
-            } else {
-                flText.writeText(stripFormatting(selected));
-            }
         }
     }
 
-    static boolean isHex6(String str, int start) {
+    private static PanelButtonStorage<TextEditorAction> createActionButton(int index, TextEditorAction action) {
+        return new PanelButtonStorage<>(
+            new GuiRectangle(0, 16 * index, 100, 16),
+            2,
+            QuestTranslation.translate(action.getTranslationKey()),
+            action);
+    }
+
+    public String getSelectedText() {
+        return flText.getSelectedText();
+    }
+
+    public void replaceSelectedText(String text) {
+        flText.writeText(text);
+    }
+
+    private static boolean isHex6(String str, int start) {
         if (start + 6 > str.length()) return false;
         for (int k = 0; k < 6; k++) {
             char c = str.charAt(start + k);
@@ -275,7 +233,7 @@ public class GuiTextEditor extends GuiScreenCanvas implements IPEventListener, I
         return true;
     }
 
-    static String stripFormatting(String text) {
+    public static String stripFormatting(String text) {
         StringBuilder sb = new StringBuilder();
         int len = text.length();
         for (int i = 0; i < len; i++) {

--- a/src/main/java/betterquesting/client/gui2/editors/TextEditorSyntaxHighlighter.java
+++ b/src/main/java/betterquesting/client/gui2/editors/TextEditorSyntaxHighlighter.java
@@ -65,11 +65,16 @@ public class TextEditorSyntaxHighlighter implements Function<String, PanelTextFi
         while (index < end) {
             String formatting = getAmpersandFormatting(text, index, end);
             if (formatting != null) {
-                renderedText.append(formatting);
-                int formattingLength = formatting.startsWith("\u00a7x") ? 8 : 2;
-                appendRaw(text, index, index + formattingLength, renderedText, sourceToDisplay);
+                int sourceFormattingLength = formatting.startsWith("\u00a7x") ? 8 : 2;
+                appendAmpersandFormatting(
+                    text,
+                    index,
+                    index + sourceFormattingLength,
+                    formatting,
+                    renderedText,
+                    sourceToDisplay);
                 activeFormatting = RenderUtils.getFormatFromString(activeFormatting + formatting);
-                index += formattingLength;
+                index += sourceFormattingLength;
                 continue;
             }
 
@@ -88,6 +93,14 @@ public class TextEditorSyntaxHighlighter implements Function<String, PanelTextFi
         }
         sourceToDisplay[end] = renderedText.length();
         return activeFormatting;
+    }
+
+    private static void appendAmpersandFormatting(String text, int start, int end, String formatting,
+        StringBuilder renderedText, int[] sourceToDisplay) {
+        renderedText.append(formatting);
+        appendRaw(text, start, start + 1, renderedText, sourceToDisplay);
+        renderedText.append(formatting);
+        appendRaw(text, start + 1, end, renderedText, sourceToDisplay);
     }
 
     private static void appendRaw(String text, int start, int end, StringBuilder renderedText, int[] sourceToDisplay) {

--- a/src/main/java/betterquesting/client/gui2/editors/TextEditorSyntaxHighlighter.java
+++ b/src/main/java/betterquesting/client/gui2/editors/TextEditorSyntaxHighlighter.java
@@ -1,0 +1,146 @@
+package betterquesting.client.gui2.editors;
+
+import java.util.function.Function;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import betterquesting.api.utils.RenderUtils;
+import betterquesting.api2.client.gui.controls.PanelTextField;
+import betterquesting.api2.client.gui.panels.content.FormattingTag;
+
+public class TextEditorSyntaxHighlighter implements Function<String, PanelTextField.TextDisplayText> {
+
+    private static final String RESET = "\u00a7r";
+    private static final String TAG_COLOR = "\u00a7c";
+    private static final Pattern TAG_CANDIDATE = Pattern.compile("\\[[^\\]\\r\\n]*]");
+    private static final Pattern IMAGE_OPENING_TAG = Pattern.compile("\\[img height=[1-9]\\d*]");
+    private static final String IMAGE_CLOSING_TAG = "[/img]";
+
+    @Override
+    public PanelTextField.TextDisplayText apply(String text) {
+        int[] sourceToDisplay = new int[text.length() + 1];
+        StringBuilder renderedText = new StringBuilder(text.length() + 32);
+        Matcher matcher = TAG_CANDIDATE.matcher(text);
+        String activeFormatting = "";
+        int sourceIndex = 0;
+
+        while (matcher.find()) {
+            if (!isSupportedTag(matcher.group())) {
+                continue;
+            }
+
+            activeFormatting = appendSource(
+                text,
+                sourceIndex,
+                matcher.start(),
+                renderedText,
+                sourceToDisplay,
+                activeFormatting);
+
+            renderedText.append(TAG_COLOR);
+            appendRaw(text, matcher.start(), matcher.end(), renderedText, sourceToDisplay);
+            renderedText.append(RESET)
+                .append(activeFormatting);
+            sourceToDisplay[matcher.end()] = renderedText.length();
+            sourceIndex = matcher.end();
+        }
+
+        appendSource(text, sourceIndex, text.length(), renderedText, sourceToDisplay, activeFormatting);
+        return new PanelTextField.TextDisplayText(renderedText.toString(), sourceToDisplay);
+    }
+
+    private static boolean isSupportedTag(String tag) {
+        return FormattingTag.parseOpeningTag(tag)
+            .isPresent()
+            || FormattingTag.parseClosingTag(tag)
+                .isPresent()
+            || IMAGE_OPENING_TAG.matcher(tag)
+                .matches()
+            || IMAGE_CLOSING_TAG.equals(tag);
+    }
+
+    private static String appendSource(String text, int start, int end, StringBuilder renderedText,
+        int[] sourceToDisplay, String activeFormatting) {
+        int index = start;
+        while (index < end) {
+            String formatting = getAmpersandFormatting(text, index, end);
+            if (formatting != null) {
+                renderedText.append(formatting);
+                int formattingLength = formatting.startsWith("\u00a7x") ? 8 : 2;
+                appendRaw(text, index, index + formattingLength, renderedText, sourceToDisplay);
+                activeFormatting = RenderUtils.getFormatFromString(activeFormatting + formatting);
+                index += formattingLength;
+                continue;
+            }
+
+            int sectionFormattingLength = getSectionFormattingLength(text, index, end);
+            if (sectionFormattingLength > 0) {
+                appendRaw(text, index, index + sectionFormattingLength, renderedText, sourceToDisplay);
+                activeFormatting = RenderUtils
+                    .getFormatFromString(activeFormatting + text.substring(index, index + sectionFormattingLength));
+                index += sectionFormattingLength;
+                continue;
+            }
+
+            sourceToDisplay[index] = renderedText.length();
+            renderedText.append(text.charAt(index));
+            index++;
+        }
+        sourceToDisplay[end] = renderedText.length();
+        return activeFormatting;
+    }
+
+    private static void appendRaw(String text, int start, int end, StringBuilder renderedText, int[] sourceToDisplay) {
+        for (int index = start; index < end; index++) {
+            sourceToDisplay[index] = renderedText.length();
+            renderedText.append(text.charAt(index));
+        }
+        sourceToDisplay[end] = renderedText.length();
+    }
+
+    private static String getAmpersandFormatting(String text, int index, int end) {
+        if (text.charAt(index) != '&' || index + 1 >= end) {
+            return null;
+        }
+
+        char code = Character.toLowerCase(text.charAt(index + 1));
+        if (code == '#' && index + 8 <= end && isHex(text, index + 2)) {
+            return toSectionHex(text.substring(index + 2, index + 8));
+        }
+        if ((code >= '0' && code <= '9') || (code >= 'a' && code <= 'f')
+            || (code >= 'k' && code <= 'o')
+            || code == 'r') {
+            return "\u00a7" + code;
+        }
+        return null;
+    }
+
+    private static int getSectionFormattingLength(String text, int index, int end) {
+        if (text.charAt(index) != '\u00a7' || index + 1 >= end) {
+            return 0;
+        }
+        if (Character.toLowerCase(text.charAt(index + 1)) == 'x' && index + 14 <= end
+            && RenderUtils.isValidSectionX(text, index)) {
+            return 14;
+        }
+        return 2;
+    }
+
+    private static boolean isHex(String text, int start) {
+        for (int index = start; index < start + 6; index++) {
+            if (Character.digit(text.charAt(index), 16) < 0) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static String toSectionHex(String hex) {
+        StringBuilder result = new StringBuilder("\u00a7x");
+        for (int index = 0; index < hex.length(); index++) {
+            result.append('\u00a7')
+                .append(hex.charAt(index));
+        }
+        return result.toString();
+    }
+}

--- a/src/main/resources/assets/betterquesting/lang/en_US.lang
+++ b/src/main/resources/assets/betterquesting/lang/en_US.lang
@@ -25,6 +25,21 @@ betterquesting.title.choose_image.dst=Select destination
 betterquesting.title.choose_image_swing=Please select an image in the opened file chooser
 betterquesting.title.valid_items=Valid Items
 
+betterquesting.editor.macro.select_image=§2§nSelect Image§r
+betterquesting.editor.macro.image=§2§nImage§r
+betterquesting.editor.macro.hyperlink=§9§nHyperlink§r
+betterquesting.editor.macro.warning=§4§lWarning§r
+betterquesting.editor.macro.note=§3Note§r
+betterquesting.editor.macro.quest_title=§2§nQuest Title§r
+betterquesting.editor.action.hex_color=§cHex Color§r
+betterquesting.editor.action.rainbow=§qRainbow§r
+betterquesting.editor.action.wave=§6Wave§r
+betterquesting.editor.action.flip=§5Flip§r
+betterquesting.editor.action.gradient=§bGradient§r
+betterquesting.editor.action.clear_format=Clear Format
+betterquesting.editor.color_picker.hex=Hex Color
+betterquesting.editor.color_picker.gradient=Gradient
+
 betterquesting.btn.rewards=Rewards
 betterquesting.btn.tasks=Tasks
 betterquesting.btn.advanced=Advanced

--- a/src/main/resources/assets/betterquesting/lang/zh_CN.lang
+++ b/src/main/resources/assets/betterquesting/lang/zh_CN.lang
@@ -21,6 +21,21 @@ betterquesting.title.submit_station=提交站
 betterquesting.title.completion=完成度: %d/%d (%s%%)
 betterquesting.title.completion_total=总计: %d/%d (%s%%)
 
+betterquesting.editor.macro.select_image=§2§n选择图片§r
+betterquesting.editor.macro.image=§2§n图片§r
+betterquesting.editor.macro.hyperlink=§9§n超链接§r
+betterquesting.editor.macro.warning=§4§l警告§r
+betterquesting.editor.macro.note=§3提示§r
+betterquesting.editor.macro.quest_title=§2§n任务标题§r
+betterquesting.editor.action.hex_color=§c十六进制颜色§r
+betterquesting.editor.action.rainbow=§q彩虹§r
+betterquesting.editor.action.wave=§6波浪§r
+betterquesting.editor.action.flip=§5翻转§r
+betterquesting.editor.action.gradient=§b渐变§r
+betterquesting.editor.action.clear_format=清除格式
+betterquesting.editor.color_picker.hex=十六进制颜色
+betterquesting.editor.color_picker.gradient=渐变
+
 betterquesting.btn.rewards=任务奖励
 betterquesting.btn.tasks=任务目标
 betterquesting.btn.advanced=全局设置


### PR DESCRIPTION
## Summary

- Adds extensible, localized actions to the text editor so other mods can add their own editor tools without patching the GUI
- Moves the built-in text macros and color tools into the shared action registry
- Adds syntax highlighting for valid BQ tags, image tags, Minecraft formatting codes, and hex colors
- Improves multi-line cursor navigation with cached visual lines and VS Code-like Up/Down behavior

## Showcase
<img width="2560" height="1540" alt="image" src="https://github.com/user-attachments/assets/412dc2b4-957b-45d5-89f2-67fa97bfc439" />

## Checklist

- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge