### PR TITLE
Add Silent Quest Completion Setting

### DIFF
--- a/src/main/java/betterquesting/handlers/EventHandler.java
+++ b/src/main/java/betterquesting/handlers/EventHandler.java
@@ -317,7 +317,7 @@ public class EventHandler {
     }
 
     // TODO: Create a new message inbox system for these things. On screen popups aren't ideal in combat
-    private static void postPresetNotice(IQuest quest, EntityPlayer player, int preset) {
+    public static void postPresetNotice(IQuest quest, EntityPlayer player, int preset) {
         if (!(player instanceof EntityPlayerMP)) return;
         final BigItemStack stack = quest.getProperty(NativeProps.ICON);
         if (stack == null) return;

--- a/src/main/java/bq_standard/rewards/RewardQuestCompletion.java
+++ b/src/main/java/bq_standard/rewards/RewardQuestCompletion.java
@@ -19,6 +19,7 @@ import betterquesting.api.utils.UuidConverter;
 import betterquesting.api2.cache.QuestCache;
 import betterquesting.api2.client.gui.misc.IGuiRect;
 import betterquesting.api2.client.gui.panels.IGuiPanel;
+import betterquesting.handlers.EventHandler;
 import betterquesting.questing.QuestDatabase;
 import bq_standard.client.gui.rewards.PanelRewardQuestCompletion;
 import bq_standard.rewards.factory.FactoryRewardQuestCompletion;
@@ -26,6 +27,7 @@ import bq_standard.rewards.factory.FactoryRewardQuestCompletion;
 public class RewardQuestCompletion extends AbstractReward implements IReward {
 
     public UUID questNum = null;
+    public boolean isSilent = false;
 
     @Override
     public ResourceLocation getFactoryID() {
@@ -73,12 +75,15 @@ public class RewardQuestCompletion extends AbstractReward implements IReward {
         if (!targetQuest.isComplete(uuid)) {
             targetQuest.setComplete(uuid, System.currentTimeMillis());
             qc.markQuestDirty(questId);
+            qc.updateCache(player);
+            if (!isSilent) EventHandler.postPresetNotice(targetQuest, player, 2);
         }
     }
 
     @Override
     public void readFromNBT(NBTTagCompound nbt) {
         super.readFromNBT(nbt);
+        isSilent = nbt.getBoolean("isSilent");
         Optional<UUID> uuid = NBTConverter.UuidValueType.QUEST.tryReadIdString(nbt);
         if (uuid.isPresent()) {
             questNum = uuid.get();
@@ -93,6 +98,7 @@ public class RewardQuestCompletion extends AbstractReward implements IReward {
     @Override
     public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
         super.writeToNBT(nbt);
+        nbt.setBoolean("isSilent", isSilent);
         NBTConverter.UuidValueType.QUEST.writeIdString(questNum, nbt);
         return nbt;
     }


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->
This allows for quest completion awards to be made silent apart from the quests that grant them. This will be invaluable for cleaning up the way trigger quests function in game.

## Checklist
- [x] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
