### PR TITLE
Cache enum `.values()`

### DIFF
--- a/src/main/java/betterquesting/api2/client/gui/resources/factories/textures/FactorySlicedTexture.java
+++ b/src/main/java/betterquesting/api2/client/gui/resources/factories/textures/FactorySlicedTexture.java
@@ -29,7 +29,7 @@ public class FactorySlicedTexture implements IFactoryData<IGuiTexture, JsonObjec
             JsonHelper.GetNumber(data, "sliceMode", 0)
                 .intValue(),
             0,
-            SliceMode.values().length);
+            SliceMode.VALUES.length);
 
         int[] bounds = new int[] { 0, 0, 16, 16 };
         JsonArray jAry = JsonHelper.GetArray(data, "bounds");
@@ -56,7 +56,7 @@ public class FactorySlicedTexture implements IFactoryData<IGuiTexture, JsonObjec
         return new SlicedTexture(
             atlas,
             new GuiRectangle(bounds[0], bounds[1], bounds[2], bounds[3]),
-            new GuiPadding(padding[0], padding[1], padding[2], padding[3])).setSliceMode(SliceMode.values()[sliceMode]);
+            new GuiPadding(padding[0], padding[1], padding[2], padding[3])).setSliceMode(SliceMode.VALUES[sliceMode]);
     }
 
     @Override

--- a/src/main/java/betterquesting/api2/client/gui/resources/textures/SlicedTexture.java
+++ b/src/main/java/betterquesting/api2/client/gui/resources/textures/SlicedTexture.java
@@ -378,10 +378,11 @@ public class SlicedTexture implements IGuiTexture {
     }
 
     public enum SliceMode {
+
         STRETCH,
         SLICED_TILE,
         SLICED_STRETCH;
-        
+
         public static final SliceMode[] VALUES = values();
     }
 }

--- a/src/main/java/betterquesting/api2/client/gui/resources/textures/SlicedTexture.java
+++ b/src/main/java/betterquesting/api2/client/gui/resources/textures/SlicedTexture.java
@@ -270,7 +270,7 @@ public class SlicedTexture implements IGuiTexture {
             .intValue();
 
         return new SlicedTexture(res, new GuiRectangle(ox, oy, ow, oh), new GuiPadding(il, it, ir, ib))
-            .setSliceMode(SliceMode.values()[slice % 3]);
+            .setSliceMode(SliceMode.VALUES[slice % 3]);
     }
 
     // Slightly modified version from GuiUtils.class
@@ -380,6 +380,8 @@ public class SlicedTexture implements IGuiTexture {
     public enum SliceMode {
         STRETCH,
         SLICED_TILE,
-        SLICED_STRETCH
+        SLICED_STRETCH;
+        
+        public static final SliceMode[] VALUES = values();
     }
 }


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->
caching enum values() calls that got called more than 500 times during my little playtest.

## Checklist
- [ ] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge