### PR TITLE
Extend Text Format Stripping to Quest File Names on Save

### DIFF
--- a/src/main/java/betterquesting/api2/utils/TextFormattingUtils.java
+++ b/src/main/java/betterquesting/api2/utils/TextFormattingUtils.java
@@ -14,7 +14,10 @@ public final class TextFormattingUtils {
         int len = text.length();
         for (int i = 0; i < len; i++) {
             char ch = text.charAt(i);
-            if (ch == '&' && i + 1 < len) {
+            if (ch == '\\' && i + 1 < len && text.charAt(i + 1) == '&') {
+                sb.append('&');
+                i += 1;
+            } else if (ch == '&' && i + 1 < len) {
                 char next = text.charAt(i + 1);
                 char nextL = Character.toLowerCase(next);
                 // &g&#RRGGBB&#RRGGBB (18 chars)
@@ -41,6 +44,7 @@ public final class TextFormattingUtils {
                     || nextL == 'q'
                     || nextL == 'z'
                     || nextL == 'v'
+                    || nextL == 'u'
                     || nextL == 'g') {
                     i += 1;
                     continue;
@@ -70,6 +74,7 @@ public final class TextFormattingUtils {
                     || nextL == 'q'
                     || nextL == 'z'
                     || nextL == 'v'
+                    || nextL == 'u'
                     || nextL == 'g') {
                     i += 1;
                     continue;

--- a/src/main/java/betterquesting/api2/utils/TextFormattingUtils.java
+++ b/src/main/java/betterquesting/api2/utils/TextFormattingUtils.java
@@ -1,0 +1,106 @@
+package betterquesting.api2.utils;
+
+public final class TextFormattingUtils {
+
+    private TextFormattingUtils() {}
+
+    /**
+     * Removes & and § formatting codes, including hex colors and gradients.
+     */
+    public static String stripFormatting(String text) {
+        if (text == null || text.isEmpty()) return text;
+
+        StringBuilder sb = new StringBuilder(text.length());
+        int len = text.length();
+        for (int i = 0; i < len; i++) {
+            char ch = text.charAt(i);
+            if (ch == '&' && i + 1 < len) {
+                char next = text.charAt(i + 1);
+                char nextL = Character.toLowerCase(next);
+                // &g&#RRGGBB&#RRGGBB (18 chars)
+                if (nextL == 'g' && i + 18 <= len
+                    && text.charAt(i + 2) == '&'
+                    && text.charAt(i + 3) == '#'
+                    && isHex6(text, i + 4)
+                    && text.charAt(i + 10) == '&'
+                    && text.charAt(i + 11) == '#'
+                    && isHex6(text, i + 12)) {
+                    i += 17;
+                    continue;
+                }
+                // &#RRGGBB (8 chars)
+                if (next == '#' && isHex6(text, i + 2)) {
+                    i += 7;
+                    continue;
+                }
+                // &X single codes
+                if ((nextL >= '0' && nextL <= '9') || (nextL >= 'a' && nextL <= 'f')
+                    || (nextL >= 'k' && nextL <= 'o')
+                    || nextL == 'r'
+                    || nextL == 'x'
+                    || nextL == 'q'
+                    || nextL == 'z'
+                    || nextL == 'v'
+                    || nextL == 'g') {
+                    i += 1;
+                    continue;
+                }
+                // Literal &
+                sb.append(ch);
+            } else if (ch == '§' && i + 1 < len) {
+                char next = text.charAt(i + 1);
+                char nextL = Character.toLowerCase(next);
+                // §g + two §x sequences (30 chars)
+                if (nextL == 'g' && i + 30 <= len
+                    && isSectionHexColor(text, i + 2)
+                    && isSectionHexColor(text, i + 16)) {
+                    i += 29;
+                    continue;
+                }
+                // §x§R§R§G§G§B§B (14 chars)
+                if (nextL == 'x' && isSectionHexColor(text, i)) {
+                    i += 13;
+                    continue;
+                }
+                // §X (2 chars) — any known format code
+                if ((nextL >= '0' && nextL <= '9') || (nextL >= 'a' && nextL <= 'f')
+                    || (nextL >= 'k' && nextL <= 'o')
+                    || nextL == 'r'
+                    || nextL == 'x'
+                    || nextL == 'q'
+                    || nextL == 'z'
+                    || nextL == 'v'
+                    || nextL == 'g') {
+                    i += 1;
+                    continue;
+                }
+                // Unknown §, pass through
+                sb.append(ch);
+            } else {
+                sb.append(ch);
+            }
+        }
+        return sb.toString();
+    }
+
+    private static boolean isSectionHexColor(String text, int start) {
+        if (start + 14 > text.length()) return false;
+        if (text.charAt(start) != '§' || Character.toLowerCase(text.charAt(start + 1)) != 'x') return false;
+        for (int k = 0; k < 6; k++) {
+            int pos = start + 2 + k * 2;
+            char c = text.charAt(pos + 1);
+            if (text.charAt(pos) != '§'
+                || !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F'))) return false;
+        }
+        return true;
+    }
+
+    private static boolean isHex6(String text, int start) {
+        if (start + 6 > text.length()) return false;
+        for (int k = 0; k < 6; k++) {
+            char c = text.charAt(start + k);
+            if (!((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F'))) return false;
+        }
+        return true;
+    }
+}

--- a/src/main/java/betterquesting/client/gui2/editors/GuiTextEditor.java
+++ b/src/main/java/betterquesting/client/gui2/editors/GuiTextEditor.java
@@ -19,7 +19,6 @@ import org.lwjgl.input.Keyboard;
 
 import betterquesting.api.client.gui.misc.IVolatileScreen;
 import betterquesting.api.misc.ICallback;
-import betterquesting.api.utils.RenderUtils;
 import betterquesting.api2.client.gui.GuiScreenCanvas;
 import betterquesting.api2.client.gui.controls.IPanelButton;
 import betterquesting.api2.client.gui.controls.PanelButton;
@@ -46,6 +45,7 @@ import betterquesting.api2.client.gui.popups.PopWaitExternalEvent;
 import betterquesting.api2.client.gui.themes.presets.PresetColor;
 import betterquesting.api2.client.gui.themes.presets.PresetTexture;
 import betterquesting.api2.utils.QuestTranslation;
+import betterquesting.api2.utils.TextFormattingUtils;
 import betterquesting.core.BetterQuesting;
 import betterquesting.misc.QuestResourcesFile;
 import betterquesting.misc.QuestResourcesFolder;
@@ -224,87 +224,8 @@ public class GuiTextEditor extends GuiScreenCanvas implements IPEventListener, I
         flText.writeText(text);
     }
 
-    private static boolean isHex6(String str, int start) {
-        if (start + 6 > str.length()) return false;
-        for (int k = 0; k < 6; k++) {
-            char c = str.charAt(start + k);
-            if (!((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F'))) return false;
-        }
-        return true;
-    }
-
     public static String stripFormatting(String text) {
-        StringBuilder sb = new StringBuilder();
-        int len = text.length();
-        for (int i = 0; i < len; i++) {
-            char ch = text.charAt(i);
-            if (ch == '&' && i + 1 < len) {
-                char next = text.charAt(i + 1);
-                char nextL = Character.toLowerCase(next);
-                // &g&#RRGGBB&#RRGGBB (18 chars)
-                if (nextL == 'g' && i + 18 <= len
-                    && text.charAt(i + 2) == '&'
-                    && text.charAt(i + 3) == '#'
-                    && isHex6(text, i + 4)
-                    && text.charAt(i + 10) == '&'
-                    && text.charAt(i + 11) == '#'
-                    && isHex6(text, i + 12)) {
-                    i += 17;
-                    continue;
-                }
-                // &#RRGGBB (8 chars)
-                if (next == '#' && isHex6(text, i + 2)) {
-                    i += 7;
-                    continue;
-                }
-                // &X single codes
-                if ((nextL >= '0' && nextL <= '9') || (nextL >= 'a' && nextL <= 'f')
-                    || (nextL >= 'k' && nextL <= 'o')
-                    || nextL == 'r'
-                    || nextL == 'x'
-                    || nextL == 'q'
-                    || nextL == 'z'
-                    || nextL == 'v'
-                    || nextL == 'g') {
-                    i += 1;
-                    continue;
-                }
-                // Literal &
-                sb.append(ch);
-            } else if (ch == '\u00a7' && i + 1 < len) {
-                char next = text.charAt(i + 1);
-                char nextL = Character.toLowerCase(next);
-                // §g + two §x sequences (30 chars)
-                if (nextL == 'g' && i + 30 <= len
-                    && RenderUtils.isValidSectionX(text, i + 2)
-                    && RenderUtils.isValidSectionX(text, i + 16)) {
-                    i += 29;
-                    continue;
-                }
-                // §x§R§R§G§G§B§B (14 chars)
-                if (nextL == 'x' && RenderUtils.isValidSectionX(text, i)) {
-                    i += 13;
-                    continue;
-                }
-                // §X (2 chars) — any known format code
-                if ((nextL >= '0' && nextL <= '9') || (nextL >= 'a' && nextL <= 'f')
-                    || (nextL >= 'k' && nextL <= 'o')
-                    || nextL == 'r'
-                    || nextL == 'x'
-                    || nextL == 'q'
-                    || nextL == 'z'
-                    || nextL == 'v'
-                    || nextL == 'g') {
-                    i += 1;
-                    continue;
-                }
-                // Unknown §, pass through
-                sb.append(ch);
-            } else {
-                sb.append(ch);
-            }
-        }
-        return sb.toString();
+        return TextFormattingUtils.stripFormatting(text);
     }
 
     private void writeImageTag(String resourceLoc) {

--- a/src/main/java/betterquesting/commands/admin/QuestCommandDefaults.java
+++ b/src/main/java/betterquesting/commands/admin/QuestCommandDefaults.java
@@ -49,6 +49,7 @@ import betterquesting.api.utils.JsonHelper;
 import betterquesting.api.utils.NBTConverter;
 import betterquesting.api.utils.UuidConverter;
 import betterquesting.api2.utils.QuestTranslation;
+import betterquesting.api2.utils.TextFormattingUtils;
 import betterquesting.commands.QuestCommandBase;
 import betterquesting.core.BetterQuesting;
 import betterquesting.handlers.SaveLoadHandler;
@@ -661,6 +662,6 @@ public class QuestCommandDefaults extends QuestCommandBase {
     }
 
     private static String removeChatFormatting(String string) {
-        return string.replaceAll("§[0-9a-fk-orxgqzv]", "");
+        return TextFormattingUtils.stripFormatting(string);
     }
 }


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->
Implementing essentially so the new color formatting doesn't slip into the quest file names, but also just makes it an accessible utility for future usage.

Before:
<img width="451" height="158" alt="image" src="https://github.com/user-attachments/assets/95198abc-1e10-415c-b94a-837db7dece8a" />

After:
<img width="952" height="104" alt="image" src="https://github.com/user-attachments/assets/2d82ef29-d951-41f8-9af1-149f13a98345" />


## Checklist
- [ ] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
