### PR TITLE
Huge performance improvements

### DIFF
--- a/src/main/java/betterquesting/api/storage/BQ_Settings.java
+++ b/src/main/java/betterquesting/api/storage/BQ_Settings.java
@@ -40,6 +40,8 @@ public class BQ_Settings {
 
     public static float zoomSpeed = 1.25f;
     public static float zoomTimeInMs = 100f;
+    public static int questIconCacheMode = 1;
+    public static int questIconCacheFps = 16;
 
     public static boolean zoomInToCursor = true;
     public static boolean zoomOutToCursor = false;

--- a/src/main/java/betterquesting/api2/client/gui/GuiScreenCanvas.java
+++ b/src/main/java/betterquesting/api2/client/gui/GuiScreenCanvas.java
@@ -29,6 +29,7 @@ import betterquesting.api2.client.gui.misc.GuiRectangle;
 import betterquesting.api2.client.gui.misc.GuiTransform;
 import betterquesting.api2.client.gui.misc.IGuiRect;
 import betterquesting.api2.client.gui.panels.IGuiPanel;
+import betterquesting.api2.client.gui.panels.lists.CanvasQuestLine;
 import betterquesting.api2.client.gui.popups.PopChoice;
 import betterquesting.api2.client.gui.themes.presets.PresetIcon;
 import betterquesting.api2.utils.QuestTranslation;
@@ -136,6 +137,7 @@ public class GuiScreenCanvas extends GuiScreen implements IScene {
         super.onGuiClosed();
 
         Keyboard.enableRepeatEvents(false);
+        CanvasQuestLine.releaseButtonCache();
     }
 
     @Override

--- a/src/main/java/betterquesting/api2/client/gui/controls/PanelButtonQuest.java
+++ b/src/main/java/betterquesting/api2/client/gui/controls/PanelButtonQuest.java
@@ -132,6 +132,10 @@ public class PanelButtonQuest extends PanelButtonStorage<Map.Entry<UUID, IQuest>
         isBookmarked = state;
     }
 
+    public boolean isBookmarked() {
+        return isBookmarked;
+    }
+
     @Override
     public List<String> getTooltip(int mx, int my) {
         if (!this.getTransform()

--- a/src/main/java/betterquesting/api2/client/gui/controls/PanelButtonQuest.java
+++ b/src/main/java/betterquesting/api2/client/gui/controls/PanelButtonQuest.java
@@ -96,7 +96,7 @@ public class PanelButtonQuest extends PanelButtonStorage<Map.Entry<UUID, IQuest>
                 txFrame = null;
         }
 
-        IGuiTexture btnTx = new GuiTextureColored(txFrame, txIconCol);
+        IGuiTexture btnTx = new GuiTextureColored(QuestFrameCache.wrap(txFrame), txIconCol);
         setTextures(btnTx, btnTx, btnTx);
         setIcon(
             new OreDictTexture(

--- a/src/main/java/betterquesting/api2/client/gui/controls/QuestFrameCache.java
+++ b/src/main/java/betterquesting/api2/client/gui/controls/QuestFrameCache.java
@@ -1,0 +1,198 @@
+package betterquesting.api2.client.gui.controls;
+
+import java.util.ArrayDeque;
+import java.util.IdentityHashMap;
+import java.util.Map;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.resources.IReloadableResourceManager;
+import net.minecraft.util.ResourceLocation;
+
+import org.lwjgl.opengl.GL11;
+
+import betterquesting.api2.client.gui.misc.GuiPadding;
+import betterquesting.api2.client.gui.misc.IGuiRect;
+import betterquesting.api2.client.gui.resources.colors.GuiColorStatic;
+import betterquesting.api2.client.gui.resources.colors.IGuiColor;
+import betterquesting.api2.client.gui.resources.textures.IGuiTexture;
+import betterquesting.api2.client.gui.resources.textures.SimpleTexture;
+import betterquesting.api2.client.gui.resources.textures.SlicedTexture;
+
+final class QuestFrameCache implements IGuiTexture {
+
+    private static final int FRAME_SIZE = 24;
+    private static final int MAX_ENTRIES = 128;
+    private static final Map<IGuiTexture, QuestFrameCache> CACHE = new IdentityHashMap<>();
+    private static final ArrayDeque<IGuiTexture> INSERTION_ORDER = new ArrayDeque<>();
+    private static final IGuiColor WHITE_COLOR = new GuiColorStatic(0xFFFFFFFF);
+    private static final IGuiColor NO_OP_COLOR = new GuiColorStatic(0xFFFFFFFF) {
+
+        @Override
+        public void applyGlColor() {}
+    };
+
+    static {
+        ((IReloadableResourceManager) Minecraft.getMinecraft()
+            .getResourceManager()).registerReloadListener(resourceManager -> clear());
+    }
+
+    private final IGuiTexture texture;
+    private int displayList;
+    private RenderState renderState;
+    private boolean active = true;
+
+    private QuestFrameCache(IGuiTexture texture) {
+        this.texture = texture;
+    }
+
+    static IGuiTexture wrap(IGuiTexture texture) {
+        if (texture == null || (texture.getClass() != SimpleTexture.class && texture.getClass() != SlicedTexture.class))
+            return texture;
+
+        QuestFrameCache cached = CACHE.get(texture);
+        if (cached != null) return cached;
+
+        if (CACHE.size() >= MAX_ENTRIES) {
+            QuestFrameCache evicted = CACHE.remove(INSERTION_ORDER.removeFirst());
+            evicted.active = false;
+            evicted.deleteDisplayList();
+        }
+
+        QuestFrameCache created = new QuestFrameCache(texture);
+        CACHE.put(texture, created);
+        INSERTION_ORDER.addLast(texture);
+        return created;
+    }
+
+    @Override
+    public void drawTexture(int x, int y, int width, int height, float zDepth, float partialTick) {
+        drawTexture(x, y, width, height, zDepth, partialTick, WHITE_COLOR);
+    }
+
+    @Override
+    public void drawTexture(int x, int y, int width, int height, float zDepth, float partialTick, IGuiColor color) {
+        if (!active || width != FRAME_SIZE || height != FRAME_SIZE) {
+            texture.drawTexture(x, y, width, height, zDepth, partialTick, color);
+            return;
+        }
+
+        if (displayList == 0 || !renderState.matches(texture)) compileDisplayList();
+        if (displayList == 0) {
+            texture.drawTexture(x, y, width, height, zDepth, partialTick, color);
+            return;
+        }
+
+        GL11.glPushMatrix();
+        GL11.glTranslatef(x, y, zDepth);
+        color.applyGlColor();
+        GL11.glCallList(displayList);
+        GL11.glPopMatrix();
+    }
+
+    @Override
+    public ResourceLocation getTexture() {
+        return texture.getTexture();
+    }
+
+    @Override
+    public IGuiRect getBounds() {
+        return texture.getBounds();
+    }
+
+    private void compileDisplayList() {
+        deleteDisplayList();
+        RenderState newState = new RenderState(texture);
+        Minecraft.getMinecraft().renderEngine.bindTexture(texture.getTexture());
+        int newDisplayList = GL11.glGenLists(1);
+        if (newDisplayList == 0) {
+            active = false;
+            return;
+        }
+
+        GL11.glColor4f(1F, 1F, 1F, 1F);
+        GL11.glNewList(newDisplayList, GL11.GL_COMPILE);
+        boolean compiled = false;
+        try {
+            texture.drawTexture(0, 0, FRAME_SIZE, FRAME_SIZE, 0F, 0F, NO_OP_COLOR);
+            compiled = true;
+        } finally {
+            GL11.glEndList();
+            if (!compiled) GL11.glDeleteLists(newDisplayList, 1);
+        }
+
+        displayList = newDisplayList;
+        renderState = newState;
+    }
+
+    private void deleteDisplayList() {
+        if (displayList != 0) GL11.glDeleteLists(displayList, 1);
+        displayList = 0;
+        renderState = null;
+    }
+
+    private static void clear() {
+        for (QuestFrameCache cached : CACHE.values()) {
+            cached.deleteDisplayList();
+        }
+    }
+
+    private static final class RenderState {
+
+        private final int x;
+        private final int y;
+        private final int width;
+        private final int height;
+        private final int left;
+        private final int top;
+        private final int right;
+        private final int bottom;
+        private final int mode;
+
+        private RenderState(IGuiTexture texture) {
+            IGuiRect bounds = texture.getBounds();
+            x = bounds.getX();
+            y = bounds.getY();
+            width = bounds.getWidth();
+            height = bounds.getHeight();
+
+            if (texture instanceof SlicedTexture) {
+                SlicedTexture sliced = (SlicedTexture) texture;
+                GuiPadding border = sliced.getBorder();
+                left = border.getLeft();
+                top = border.getTop();
+                right = border.getRight();
+                bottom = border.getBottom();
+                mode = getMode(sliced);
+            } else {
+                left = 0;
+                top = 0;
+                right = 0;
+                bottom = 0;
+                mode = ((SimpleTexture) texture).isMaintainingAspect() ? 1 : 0;
+            }
+        }
+
+        private boolean matches(IGuiTexture texture) {
+            IGuiRect bounds = texture.getBounds();
+            if (x != bounds.getX() || y != bounds.getY() || width != bounds.getWidth() || height != bounds.getHeight())
+                return false;
+
+            if (texture instanceof SlicedTexture) {
+                SlicedTexture sliced = (SlicedTexture) texture;
+                GuiPadding border = sliced.getBorder();
+                return left == border.getLeft() && top == border.getTop()
+                    && right == border.getRight()
+                    && bottom == border.getBottom()
+                    && mode == getMode(sliced);
+            }
+
+            return mode == (((SimpleTexture) texture).isMaintainingAspect() ? 1 : 0);
+        }
+
+        private static int getMode(SlicedTexture texture) {
+            return texture.getSliceMode() == null ? -1
+                : texture.getSliceMode()
+                    .ordinal();
+        }
+    }
+}

--- a/src/main/java/betterquesting/api2/client/gui/panels/content/PanelLine.java
+++ b/src/main/java/betterquesting/api2/client/gui/panels/content/PanelLine.java
@@ -2,12 +2,15 @@ package betterquesting.api2.client.gui.panels.content;
 
 import java.util.List;
 
+import net.minecraft.client.renderer.Tessellator;
+
 import org.lwjgl.opengl.GL11;
 
 import betterquesting.api2.client.gui.misc.GuiRectangle;
 import betterquesting.api2.client.gui.misc.IGuiRect;
 import betterquesting.api2.client.gui.panels.IGuiPanel;
 import betterquesting.api2.client.gui.resources.colors.IGuiColor;
+import betterquesting.api2.client.gui.resources.lines.DirectionalLine;
 import betterquesting.api2.client.gui.resources.lines.IGuiLine;
 
 public class PanelLine implements IGuiPanel {
@@ -59,6 +62,19 @@ public class PanelLine implements IGuiPanel {
     @Override
     public boolean isEnabled() {
         return this.enabled;
+    }
+
+    public boolean isBatchable() {
+        return line.getClass() == DirectionalLine.class;
+    }
+
+    public boolean addToBatch(Tessellator tessellator, int mx, int my, float partialTick) {
+        if (!isBatchable()) return false;
+        if (enabled && (shouldDraw == null || shouldDraw.shouldDraw(mx, my, partialTick))) {
+            boolean shouldAnimate = animatePredicate != null && animatePredicate.shouldDraw(mx, my, partialTick);
+            ((DirectionalLine) line).addLine(tessellator, start, end, width, color, shouldAnimate);
+        }
+        return true;
     }
 
     @Override

--- a/src/main/java/betterquesting/api2/client/gui/panels/content/PanelLine.java
+++ b/src/main/java/betterquesting/api2/client/gui/panels/content/PanelLine.java
@@ -68,13 +68,13 @@ public class PanelLine implements IGuiPanel {
         return line.getClass() == DirectionalLine.class;
     }
 
-    public boolean addToBatch(Tessellator tessellator, int mx, int my, float partialTick) {
-        if (!isBatchable()) return false;
+    public int addToBatch(Tessellator tessellator, int mx, int my, float partialTick, int batchQuads) {
+        if (!isBatchable()) return batchQuads;
         if (enabled && (shouldDraw == null || shouldDraw.shouldDraw(mx, my, partialTick))) {
             boolean shouldAnimate = animatePredicate != null && animatePredicate.shouldDraw(mx, my, partialTick);
-            ((DirectionalLine) line).addLine(tessellator, start, end, width, color, shouldAnimate);
+            return ((DirectionalLine) line).addLine(tessellator, start, end, width, color, shouldAnimate, batchQuads);
         }
-        return true;
+        return batchQuads;
     }
 
     @Override

--- a/src/main/java/betterquesting/api2/client/gui/panels/lists/CanvasCullingManager.java
+++ b/src/main/java/betterquesting/api2/client/gui/panels/lists/CanvasCullingManager.java
@@ -2,6 +2,7 @@ package betterquesting.api2.client.gui.panels.lists;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -19,6 +20,8 @@ public class CanvasCullingManager {
 
     private final List<IGuiPanel> cachedPanels = new CopyOnWriteArrayList<>(); // The last updated list of visible
                                                                                // panels
+    private final Map<IGuiPanel, Integer> panelOrder = new IdentityHashMap<>();
+    private int nextPanelOrder;
 
     private final int gridSize;
 
@@ -34,9 +37,12 @@ public class CanvasCullingManager {
         dynamicPanels.clear();
         panelRegions.clear();
         cachedPanels.clear();
+        panelOrder.clear();
+        nextPanelOrder = 0;
     }
 
     public void addPanel(IGuiPanel panel, boolean useBlocks) {
+        if (!panelOrder.containsKey(panel)) panelOrder.put(panel, nextPanelOrder++);
         if (!useBlocks) {
             if (!dynamicPanels.contains(panel)) {
                 dynamicPanels.add(panel);
@@ -84,7 +90,7 @@ public class CanvasCullingManager {
 
                     if (cbl.enabled) {
                         cachedPanels.add(panel);
-                        cachedPanels.sort(ComparatorGuiDepth.INSTANCE);
+                        sortCachedPanels();
                     }
                 }
 
@@ -135,6 +141,7 @@ public class CanvasCullingManager {
         } else {
             cachedPanels.remove(panel);
         }
+        panelOrder.remove(panel);
     }
 
     public List<IGuiPanel> getVisiblePanels() {
@@ -160,8 +167,15 @@ public class CanvasCullingManager {
         }
 
         if (changed) {
-            cachedPanels.sort(ComparatorGuiDepth.INSTANCE);
+            sortCachedPanels();
         }
+    }
+
+    private void sortCachedPanels() {
+        cachedPanels.sort((first, second) -> {
+            int depth = ComparatorGuiDepth.INSTANCE.compare(first, second);
+            return depth != 0 ? depth : Integer.compare(panelOrder.get(first), panelOrder.get(second));
+        });
     }
 
     // TODO: Move this to a utility class

--- a/src/main/java/betterquesting/api2/client/gui/panels/lists/CanvasQuestLine.java
+++ b/src/main/java/betterquesting/api2/client/gui/panels/lists/CanvasQuestLine.java
@@ -528,7 +528,7 @@ public class CanvasQuestLine extends CanvasScrolling {
                 invalidate();
                 if (mode == 0) release();
             }
-            return mode > 0 && OpenGlHelper.framebufferSupported && System.currentTimeMillis() >= retryAt;
+            return mode > 0 && OpenGlHelper.isFramebufferEnabled() && System.currentTimeMillis() >= retryAt;
         }
 
         private void invalidate() {

--- a/src/main/java/betterquesting/api2/client/gui/panels/lists/CanvasQuestLine.java
+++ b/src/main/java/betterquesting/api2/client/gui/panels/lists/CanvasQuestLine.java
@@ -54,7 +54,6 @@ public class CanvasQuestLine extends CanvasScrolling {
     public CanvasQuestLine(IGuiRect rect, int buttonId) {
         super(rect);
         this.setupAdvanceScroll(true, true, 3000);
-        this.enableBlocking(false);
         this.buttonId = buttonId;
     }
 
@@ -106,10 +105,11 @@ public class CanvasQuestLine extends CanvasScrolling {
 
         if (!StringUtils.isNullOrEmpty(bgString)) {
             int bgSize = line.getProperty(NativeProps.BG_SIZE);
-            this.addPanel(
+            this.addCulledPanel(
                 new PanelGeneric(
                     new GuiRectangle(0, 0, bgSize, bgSize, 1),
-                    new SimpleTexture(new ResourceLocation(bgString), new GuiRectangle(0, 0, 256, 256))));
+                    new SimpleTexture(new ResourceLocation(bgString), new GuiRectangle(0, 0, 256, 256))),
+                false);
         }
 
         HashMap<UUID, PanelButtonQuest> questBtns = new HashMap<>();
@@ -131,7 +131,6 @@ public class CanvasQuestLine extends CanvasScrolling {
                     .getSizeY());
             PanelButtonQuest paBtn = new PanelButtonQuest(rect, buttonId, "", Maps.immutableEntry(qle.getKey(), quest));
 
-            this.addPanel(paBtn);
             this.btnList.add(paBtn);
             questBtns.put(qle.getKey(), paBtn);
         }
@@ -217,7 +216,7 @@ public class CanvasQuestLine extends CanvasScrolling {
                             continue;
                     }
 
-                    this.addPanel(
+                    this.addCulledPanel(
                         new PanelLine(
                             parBtn.getTransform(),
                             entry.getValue()
@@ -227,9 +226,14 @@ public class CanvasQuestLine extends CanvasScrolling {
                             txLineCol,
                             1,
                             predicate,
-                            animatePredicate));
+                            animatePredicate),
+                        false);
                 }
             }
+        }
+
+        for (PanelButtonQuest button : btnList) {
+            this.addPanel(button);
         }
 
         fitToWindow();

--- a/src/main/java/betterquesting/api2/client/gui/panels/lists/CanvasQuestLine.java
+++ b/src/main/java/betterquesting/api2/client/gui/panels/lists/CanvasQuestLine.java
@@ -20,7 +20,6 @@ import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.StringUtils;
 
 import org.lwjgl.input.Keyboard;
-import org.lwjgl.input.Mouse;
 import org.lwjgl.opengl.GL11;
 
 import com.google.common.collect.Maps;
@@ -125,7 +124,7 @@ public class CanvasQuestLine extends CanvasScrolling {
                     lsx,
                     lsy,
                     getZoom(),
-                    getButtonStateHash(mx, my),
+                    getButtonStateHash(),
                     () -> drawQuestButtons(mx, my, partialTick, true),
                     () -> drawQuestButtons(mx, my, partialTick, false));
             } catch (RuntimeException e) {
@@ -153,11 +152,7 @@ public class CanvasQuestLine extends CanvasScrolling {
         return foundButton;
     }
 
-    private int getButtonStateHash(int mx, int my) {
-        float zs = getZoom();
-        IGuiRect bounds = getTransform();
-        int smx = (int) ((mx - bounds.getX()) / zs) + lsx;
-        int smy = (int) ((my - bounds.getY()) / zs) + lsy;
+    private int getButtonStateHash() {
         int hash = 1;
         for (IGuiPanel panel : getVisiblePanels()) {
             if (panel instanceof PanelButtonQuest) {
@@ -166,10 +161,9 @@ public class CanvasQuestLine extends CanvasScrolling {
                 hash = 31 * hash + (button.isEnabled() ? 1 : 0);
                 hash = 31 * hash + (button.isActive() ? 1 : 0);
                 hash = 31 * hash + (button.isBookmarked() ? 1 : 0);
-                hash = 31 * hash + (button.rect.contains(smx, smy) ? 1 : 0);
             }
         }
-        return 31 * hash + (Mouse.isButtonDown(0) ? 1 : 0);
+        return hash;
     }
 
     private void drawQuestButtons(int mx, int my, float partialTick, boolean clip) {

--- a/src/main/java/betterquesting/api2/client/gui/panels/lists/CanvasQuestLine.java
+++ b/src/main/java/betterquesting/api2/client/gui/panels/lists/CanvasQuestLine.java
@@ -544,8 +544,11 @@ public class CanvasQuestLine extends CanvasScrolling {
         }
 
         private void fail(RuntimeException e) {
-            invalidate();
-            retryAt = System.currentTimeMillis() + 5000L;
+            release();
+            Minecraft.getMinecraft()
+                .getFramebuffer()
+                .bindFramebuffer(false);
+            retryAt = Long.MAX_VALUE;
             BetterQuesting.logger.warn("Unable to cache quest icons", e);
         }
 

--- a/src/main/java/betterquesting/api2/client/gui/panels/lists/CanvasQuestLine.java
+++ b/src/main/java/betterquesting/api2/client/gui/panels/lists/CanvasQuestLine.java
@@ -111,6 +111,7 @@ public class CanvasQuestLine extends CanvasScrolling {
     public void drawPanel(int mx, int my, float partialTick) {
         boolean batchLines = isBlockingEnabled() && areLinesBatchable();
         boolean cacheButtons = isBlockingEnabled() && BUTTON_CACHE.isEnabled() && areButtonsTopLayer();
+        boolean cacheLines = batchLines && cacheButtons;
         suppressButtonRendering = cacheButtons || batchLines;
         suppressLineRendering = batchLines;
         try {
@@ -121,8 +122,8 @@ public class CanvasQuestLine extends CanvasScrolling {
         }
 
         float zoom = lsz;
-        if (batchLines) {
-            drawQuestLines(mx, my, partialTick, zoom);
+        if (batchLines && !cacheLines) {
+            drawQuestLines(mx, my, partialTick, zoom, true);
             if (!cacheButtons) drawQuestButtons(mx, my, partialTick, zoom, true);
         }
 
@@ -135,11 +136,11 @@ public class CanvasQuestLine extends CanvasScrolling {
                     lsy,
                     zoom,
                     getButtonStateHash(),
-                    () -> drawQuestButtons(mx, my, partialTick, zoom, true),
-                    () -> drawQuestButtons(mx, my, partialTick, zoom, false));
+                    () -> drawQuestContent(mx, my, partialTick, zoom, cacheLines, true),
+                    () -> drawQuestContent(mx, my, partialTick, zoom, cacheLines, false));
             } catch (RuntimeException e) {
                 BUTTON_CACHE.fail(e);
-                drawQuestButtons(mx, my, partialTick, zoom, true);
+                drawQuestContent(mx, my, partialTick, zoom, cacheLines, true);
             }
         }
     }
@@ -194,7 +195,33 @@ public class CanvasQuestLine extends CanvasScrolling {
         return hash;
     }
 
-    private void drawQuestLines(int mx, int my, float partialTick, float zs) {
+    private void drawQuestContent(int mx, int my, float partialTick, float zs, boolean includeLines, boolean clip) {
+        if (includeLines) {
+            if (!clip) {
+                GL11.glEnable(GL11.GL_BLEND);
+                OpenGlHelper.glBlendFunc(
+                    GL11.GL_SRC_ALPHA,
+                    GL11.GL_ONE_MINUS_SRC_ALPHA,
+                    GL11.GL_ONE,
+                    GL11.GL_ONE_MINUS_SRC_ALPHA);
+            }
+            try {
+                drawQuestLines(mx, my, partialTick, zs, clip);
+            } finally {
+                if (!clip) {
+                    GL11.glDisable(GL11.GL_BLEND);
+                    OpenGlHelper.glBlendFunc(
+                        GL11.GL_SRC_ALPHA,
+                        GL11.GL_ONE_MINUS_SRC_ALPHA,
+                        GL11.GL_SRC_ALPHA,
+                        GL11.GL_ONE_MINUS_SRC_ALPHA);
+                }
+            }
+        }
+        drawQuestButtons(mx, my, partialTick, zs, clip);
+    }
+
+    private void drawQuestLines(int mx, int my, float partialTick, float zs, boolean clip) {
         IGuiRect bounds = getTransform();
         int tx = bounds.getX();
         int ty = bounds.getY();
@@ -202,7 +229,7 @@ public class CanvasQuestLine extends CanvasScrolling {
         int smy = (int) ((my - ty) / zs) + lsy;
 
         GL11.glPushMatrix();
-        RenderUtils.startScissor(bounds);
+        if (clip) RenderUtils.startScissor(bounds);
         try {
             GL11.glTranslatef(tx - lsx * zs, ty - lsy * zs, 0F);
             GL11.glScalef(zs, zs, zs);
@@ -232,7 +259,7 @@ public class CanvasQuestLine extends CanvasScrolling {
         } finally {
             GL11.glEnable(GL11.GL_TEXTURE_2D);
             GL11.glColor4f(1F, 1F, 1F, 1F);
-            RenderUtils.endScissor();
+            if (clip) RenderUtils.endScissor();
             GL11.glPopMatrix();
         }
     }

--- a/src/main/java/betterquesting/api2/client/gui/panels/lists/CanvasQuestLine.java
+++ b/src/main/java/betterquesting/api2/client/gui/panels/lists/CanvasQuestLine.java
@@ -63,6 +63,7 @@ public class CanvasQuestLine extends CanvasScrolling {
     private IQuestLine lastQL;
     private int zoomToFitMargin = 24;
     private boolean suppressButtonRendering;
+    private boolean suppressLineRendering;
 
     public CanvasQuestLine(IGuiRect rect, int buttonId) {
         super(rect);
@@ -108,12 +109,21 @@ public class CanvasQuestLine extends CanvasScrolling {
 
     @Override
     public void drawPanel(int mx, int my, float partialTick) {
+        boolean batchLines = isBlockingEnabled() && areLinesBatchable();
         boolean cacheButtons = isBlockingEnabled() && BUTTON_CACHE.isEnabled() && areButtonsTopLayer();
-        suppressButtonRendering = cacheButtons;
+        suppressButtonRendering = cacheButtons || batchLines;
+        suppressLineRendering = batchLines;
         try {
             super.drawPanel(mx, my, partialTick);
         } finally {
             suppressButtonRendering = false;
+            suppressLineRendering = false;
+        }
+
+        float zoom = lsz;
+        if (batchLines) {
+            drawQuestLines(mx, my, partialTick, zoom);
+            if (!cacheButtons) drawQuestButtons(mx, my, partialTick, zoom, true);
         }
 
         if (cacheButtons) {
@@ -123,20 +133,38 @@ public class CanvasQuestLine extends CanvasScrolling {
                     getTransform(),
                     lsx,
                     lsy,
-                    getZoom(),
+                    zoom,
                     getButtonStateHash(),
-                    () -> drawQuestButtons(mx, my, partialTick, true),
-                    () -> drawQuestButtons(mx, my, partialTick, false));
+                    () -> drawQuestButtons(mx, my, partialTick, zoom, true),
+                    () -> drawQuestButtons(mx, my, partialTick, zoom, false));
             } catch (RuntimeException e) {
                 BUTTON_CACHE.fail(e);
-                drawQuestButtons(mx, my, partialTick, true);
+                drawQuestButtons(mx, my, partialTick, zoom, true);
             }
         }
     }
 
     @Override
     protected boolean shouldDrawPanel(IGuiPanel panel) {
-        return !suppressButtonRendering || !(panel instanceof PanelButtonQuest);
+        return (!suppressButtonRendering || !(panel instanceof PanelButtonQuest))
+            && (!suppressLineRendering || !(panel instanceof PanelLine));
+    }
+
+    private boolean areLinesBatchable() {
+        boolean foundLine = false;
+        boolean foundButton = false;
+        for (IGuiPanel panel : getChildren()) {
+            if (!panel.isEnabled()) continue;
+            if (panel instanceof PanelLine) {
+                if (foundButton || !((PanelLine) panel).isBatchable()) return false;
+                foundLine = true;
+            } else if (panel instanceof PanelButtonQuest) {
+                foundButton = true;
+            } else if (foundLine) {
+                return false;
+            }
+        }
+        return foundLine;
     }
 
     private boolean areButtonsTopLayer() {
@@ -166,8 +194,40 @@ public class CanvasQuestLine extends CanvasScrolling {
         return hash;
     }
 
-    private void drawQuestButtons(int mx, int my, float partialTick, boolean clip) {
-        float zs = getZoom();
+    private void drawQuestLines(int mx, int my, float partialTick, float zs) {
+        IGuiRect bounds = getTransform();
+        int tx = bounds.getX();
+        int ty = bounds.getY();
+        int smx = (int) ((mx - tx) / zs) + lsx;
+        int smy = (int) ((my - ty) / zs) + lsy;
+
+        GL11.glPushMatrix();
+        RenderUtils.startScissor(bounds);
+        try {
+            GL11.glTranslatef(tx - lsx * zs, ty - lsy * zs, 0F);
+            GL11.glScalef(zs, zs, zs);
+            GL11.glDisable(GL11.GL_TEXTURE_2D);
+
+            Tessellator tessellator = Tessellator.instance;
+            tessellator.startDrawingQuads();
+            try {
+                for (IGuiPanel panel : getVisiblePanels()) {
+                    if (panel instanceof PanelLine && panel.isEnabled()) {
+                        ((PanelLine) panel).addToBatch(tessellator, smx, smy, partialTick);
+                    }
+                }
+            } finally {
+                tessellator.draw();
+            }
+        } finally {
+            GL11.glEnable(GL11.GL_TEXTURE_2D);
+            GL11.glColor4f(1F, 1F, 1F, 1F);
+            RenderUtils.endScissor();
+            GL11.glPopMatrix();
+        }
+    }
+
+    private void drawQuestButtons(int mx, int my, float partialTick, float zs, boolean clip) {
         IGuiRect bounds = getTransform();
         int tx = bounds.getX();
         int ty = bounds.getY();

--- a/src/main/java/betterquesting/api2/client/gui/panels/lists/CanvasQuestLine.java
+++ b/src/main/java/betterquesting/api2/client/gui/panels/lists/CanvasQuestLine.java
@@ -157,7 +157,8 @@ public class CanvasQuestLine extends CanvasScrolling {
         for (IGuiPanel panel : getChildren()) {
             if (!panel.isEnabled()) continue;
             if (panel instanceof PanelLine) {
-                if (foundButton || !((PanelLine) panel).isBatchable()) return false;
+                if (panel.getClass() != PanelLine.class || foundButton || !((PanelLine) panel).isBatchable())
+                    return false;
                 foundLine = true;
             } else if (panel instanceof PanelButtonQuest) {
                 foundButton = true;
@@ -173,6 +174,7 @@ public class CanvasQuestLine extends CanvasScrolling {
         for (IGuiPanel panel : getChildren()) {
             if (!panel.isEnabled()) continue;
             if (panel instanceof PanelButtonQuest) {
+                if (panel.getClass() != PanelButtonQuest.class) return false;
                 foundButton = true;
             } else if (foundButton) {
                 return false;

--- a/src/main/java/betterquesting/api2/client/gui/panels/lists/CanvasQuestLine.java
+++ b/src/main/java/betterquesting/api2/client/gui/panels/lists/CanvasQuestLine.java
@@ -135,7 +135,7 @@ public class CanvasQuestLine extends CanvasScrolling {
                     lsx,
                     lsy,
                     zoom,
-                    getButtonStateHash(),
+                    getContentStateHash(cacheLines),
                     () -> drawQuestContent(mx, my, partialTick, zoom, cacheLines, true),
                     () -> drawQuestContent(mx, my, partialTick, zoom, cacheLines, false));
             } catch (RuntimeException e) {
@@ -183,8 +183,8 @@ public class CanvasQuestLine extends CanvasScrolling {
         return foundButton;
     }
 
-    private int getButtonStateHash() {
-        int hash = 1;
+    private int getContentStateHash(boolean includeLines) {
+        int hash = includeLines ? 1 : 0;
         for (IGuiPanel panel : getVisiblePanels()) {
             if (panel instanceof PanelButtonQuest) {
                 PanelButtonQuest button = (PanelButtonQuest) panel;
@@ -192,6 +192,9 @@ public class CanvasQuestLine extends CanvasScrolling {
                 hash = 31 * hash + (button.isEnabled() ? 1 : 0);
                 hash = 31 * hash + (button.isActive() ? 1 : 0);
                 hash = 31 * hash + (button.isBookmarked() ? 1 : 0);
+            } else if (includeLines && panel instanceof PanelLine) {
+                hash = 31 * hash + System.identityHashCode(panel);
+                hash = 31 * hash + (panel.isEnabled() ? 1 : 0);
             }
         }
         return hash;

--- a/src/main/java/betterquesting/api2/client/gui/panels/lists/CanvasQuestLine.java
+++ b/src/main/java/betterquesting/api2/client/gui/panels/lists/CanvasQuestLine.java
@@ -1,5 +1,6 @@
 package betterquesting.api2.client.gui.panels.lists;
 
+import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -9,11 +10,18 @@ import java.util.Map;
 import java.util.UUID;
 
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.ScaledResolution;
+import net.minecraft.client.renderer.OpenGlHelper;
+import net.minecraft.client.renderer.Tessellator;
+import net.minecraft.client.resources.IReloadableResourceManager;
+import net.minecraft.client.shader.Framebuffer;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.StringUtils;
 
 import org.lwjgl.input.Keyboard;
+import org.lwjgl.input.Mouse;
+import org.lwjgl.opengl.GL11;
 
 import com.google.common.collect.Maps;
 
@@ -26,10 +34,12 @@ import betterquesting.api.questing.IQuest.RequirementType;
 import betterquesting.api.questing.IQuestLine;
 import betterquesting.api.questing.IQuestLineEntry;
 import betterquesting.api.storage.BQ_Settings;
+import betterquesting.api.utils.RenderUtils;
 import betterquesting.api2.cache.QuestCache;
 import betterquesting.api2.client.gui.controls.PanelButtonQuest;
 import betterquesting.api2.client.gui.misc.GuiRectangle;
 import betterquesting.api2.client.gui.misc.IGuiRect;
+import betterquesting.api2.client.gui.panels.IGuiPanel;
 import betterquesting.api2.client.gui.panels.content.PanelGeneric;
 import betterquesting.api2.client.gui.panels.content.PanelLine;
 import betterquesting.api2.client.gui.panels.content.PanelLine.ShouldDrawPredicate;
@@ -39,17 +49,21 @@ import betterquesting.api2.client.gui.resources.lines.IGuiLine;
 import betterquesting.api2.client.gui.resources.textures.SimpleTexture;
 import betterquesting.api2.client.gui.themes.presets.PresetColor;
 import betterquesting.api2.client.gui.themes.presets.PresetLine;
+import betterquesting.core.BetterQuesting;
 
 /**
  * My class for lazy quest line setup on a scrolling canvas
  */
 public class CanvasQuestLine extends CanvasScrolling {
 
+    private static final QuestButtonCache BUTTON_CACHE = new QuestButtonCache();
+
     private final List<PanelButtonQuest> btnList = new ArrayList<>();
 
     private final int buttonId;
     private IQuestLine lastQL;
     private int zoomToFitMargin = 24;
+    private boolean suppressButtonRendering;
 
     public CanvasQuestLine(IGuiRect rect, int buttonId) {
         super(rect);
@@ -59,6 +73,10 @@ public class CanvasQuestLine extends CanvasScrolling {
 
     public Collection<PanelButtonQuest> getQuestButtons() {
         return Collections.unmodifiableCollection(this.btnList);
+    }
+
+    public static void releaseButtonCache() {
+        BUTTON_CACHE.release();
     }
 
     public PanelButtonQuest getButtonAt(int mx, int my) {
@@ -81,6 +99,101 @@ public class CanvasQuestLine extends CanvasScrolling {
 
     public void refreshQuestLine() {
         setQuestLine(lastQL);
+    }
+
+    @Override
+    public void resetCanvas() {
+        BUTTON_CACHE.invalidate();
+        super.resetCanvas();
+    }
+
+    @Override
+    public void drawPanel(int mx, int my, float partialTick) {
+        boolean cacheButtons = isBlockingEnabled() && BUTTON_CACHE.isEnabled() && areButtonsTopLayer();
+        suppressButtonRendering = cacheButtons;
+        try {
+            super.drawPanel(mx, my, partialTick);
+        } finally {
+            suppressButtonRendering = false;
+        }
+
+        if (cacheButtons) {
+            try {
+                BUTTON_CACHE.draw(
+                    this,
+                    getTransform(),
+                    lsx,
+                    lsy,
+                    getZoom(),
+                    getButtonStateHash(mx, my),
+                    () -> drawQuestButtons(mx, my, partialTick));
+            } catch (RuntimeException e) {
+                BUTTON_CACHE.fail(e);
+                drawQuestButtons(mx, my, partialTick);
+            }
+        }
+    }
+
+    @Override
+    protected boolean shouldDrawPanel(IGuiPanel panel) {
+        return !suppressButtonRendering || !(panel instanceof PanelButtonQuest);
+    }
+
+    private boolean areButtonsTopLayer() {
+        boolean foundButton = false;
+        for (IGuiPanel panel : getChildren()) {
+            if (!panel.isEnabled()) continue;
+            if (panel instanceof PanelButtonQuest) {
+                foundButton = true;
+            } else if (foundButton) {
+                return false;
+            }
+        }
+        return foundButton;
+    }
+
+    private int getButtonStateHash(int mx, int my) {
+        float zs = getZoom();
+        IGuiRect bounds = getTransform();
+        int smx = (int) ((mx - bounds.getX()) / zs) + lsx;
+        int smy = (int) ((my - bounds.getY()) / zs) + lsy;
+        int hash = 1;
+        for (IGuiPanel panel : getVisiblePanels()) {
+            if (panel instanceof PanelButtonQuest) {
+                PanelButtonQuest button = (PanelButtonQuest) panel;
+                hash = 31 * hash + System.identityHashCode(button);
+                hash = 31 * hash + (button.isEnabled() ? 1 : 0);
+                hash = 31 * hash + (button.isActive() ? 1 : 0);
+                hash = 31 * hash + (button.isBookmarked() ? 1 : 0);
+                hash = 31 * hash + (button.rect.contains(smx, smy) ? 1 : 0);
+            }
+        }
+        return 31 * hash + (Mouse.isButtonDown(0) ? 1 : 0);
+    }
+
+    private void drawQuestButtons(int mx, int my, float partialTick) {
+        float zs = getZoom();
+        IGuiRect bounds = getTransform();
+        int tx = bounds.getX();
+        int ty = bounds.getY();
+        int smx = (int) ((mx - tx) / zs) + lsx;
+        int smy = (int) ((my - ty) / zs) + lsy;
+
+        GL11.glPushMatrix();
+        RenderUtils.startScissor(bounds);
+        try {
+            GL11.glTranslatef(tx - lsx * zs, ty - lsy * zs, 0F);
+            GL11.glScalef(zs, zs, zs);
+
+            for (IGuiPanel panel : getVisiblePanels()) {
+                if (panel instanceof PanelButtonQuest && panel.isEnabled()) {
+                    panel.drawPanel(smx, smy, partialTick);
+                }
+            }
+        } finally {
+            RenderUtils.endScissor();
+            GL11.glPopMatrix();
+        }
     }
 
     /**
@@ -291,5 +404,183 @@ public class CanvasQuestLine extends CanvasScrolling {
 
         this.setScrollX(btnCenterX - scrollWindow.w / 2);
         this.setScrollY(btnCenterY - scrollWindow.h / 2);
+    }
+
+    private static final class QuestButtonCache {
+
+        private Framebuffer framebuffer;
+        private boolean valid;
+        private int lastMode = -1;
+        private long nextRefresh;
+        private long retryAt;
+        private WeakReference<Object> lastOwner = new WeakReference<>(null);
+        private int lastX;
+        private int lastY;
+        private int lastWidth;
+        private int lastHeight;
+        private int lastScrollX;
+        private int lastScrollY;
+        private int lastContentHash;
+        private float lastZoom;
+
+        private QuestButtonCache() {
+            ((IReloadableResourceManager) Minecraft.getMinecraft()
+                .getResourceManager()).registerReloadListener(resourceManager -> invalidate());
+        }
+
+        private boolean isEnabled() {
+            int mode = Math.max(0, Math.min(2, BQ_Settings.questIconCacheMode));
+            if (mode != lastMode) {
+                lastMode = mode;
+                retryAt = 0;
+                invalidate();
+                if (mode == 0) release();
+            }
+            return mode > 0 && OpenGlHelper.framebufferSupported && System.currentTimeMillis() >= retryAt;
+        }
+
+        private void invalidate() {
+            valid = false;
+            nextRefresh = 0;
+        }
+
+        private void release() {
+            invalidate();
+            if (framebuffer != null) framebuffer.deleteFramebuffer();
+            framebuffer = null;
+            lastOwner.clear();
+        }
+
+        private void fail(RuntimeException e) {
+            invalidate();
+            retryAt = System.currentTimeMillis() + 5000L;
+            BetterQuesting.logger.warn("Unable to cache quest icons", e);
+        }
+
+        private void draw(Object owner, IGuiRect bounds, int scrollX, int scrollY, float zoom, int contentHash,
+            Runnable drawButtons) {
+            int mode = Math.max(0, Math.min(2, BQ_Settings.questIconCacheMode));
+            boolean viewChanged = updateView(owner, bounds, scrollX, scrollY, zoom, contentHash);
+
+            if (viewChanged) {
+                invalidate();
+                drawButtons.run();
+                return;
+            }
+
+            Minecraft minecraft = Minecraft.getMinecraft();
+            Framebuffer cache = getFramebuffer(minecraft);
+            long now = System.currentTimeMillis();
+            if (!valid || cache.framebufferWidth != minecraft.displayWidth
+                || cache.framebufferHeight != minecraft.displayHeight
+                || mode == 1 && now >= nextRefresh) {
+                capture(cache, minecraft, drawButtons);
+                nextRefresh = mode == 1 ? now + 1000L / Math.max(1, BQ_Settings.questIconCacheFps) : Long.MAX_VALUE;
+                valid = true;
+            }
+
+            render(cache, minecraft, bounds);
+        }
+
+        private boolean updateView(Object owner, IGuiRect bounds, int scrollX, int scrollY, float zoom,
+            int contentHash) {
+            boolean changed = owner != lastOwner.get() || bounds.getX() != lastX
+                || bounds.getY() != lastY
+                || bounds.getWidth() != lastWidth
+                || bounds.getHeight() != lastHeight
+                || scrollX != lastScrollX
+                || scrollY != lastScrollY
+                || contentHash != lastContentHash
+                || Float.floatToIntBits(zoom) != Float.floatToIntBits(lastZoom);
+            lastOwner = new WeakReference<>(owner);
+            lastX = bounds.getX();
+            lastY = bounds.getY();
+            lastWidth = bounds.getWidth();
+            lastHeight = bounds.getHeight();
+            lastScrollX = scrollX;
+            lastScrollY = scrollY;
+            lastContentHash = contentHash;
+            lastZoom = zoom;
+            return changed;
+        }
+
+        private Framebuffer getFramebuffer(Minecraft minecraft) {
+            if (framebuffer == null) {
+                framebuffer = new Framebuffer(1, 1, true);
+                framebuffer.setFramebufferColor(0F, 0F, 0F, 0F);
+                minecraft.getFramebuffer()
+                    .bindFramebuffer(false);
+            }
+            return framebuffer;
+        }
+
+        private void capture(Framebuffer cache, Minecraft minecraft, Runnable drawButtons) {
+            GL11.glPushAttrib(GL11.GL_ENABLE_BIT | GL11.GL_COLOR_BUFFER_BIT | GL11.GL_DEPTH_BUFFER_BIT);
+            try {
+                GL11.glDisable(GL11.GL_SCISSOR_TEST);
+                if (cache.framebufferWidth != minecraft.displayWidth
+                    || cache.framebufferHeight != minecraft.displayHeight) {
+                    cache.createBindFramebuffer(minecraft.displayWidth, minecraft.displayHeight);
+                    cache.setFramebufferFilter(GL11.GL_NEAREST);
+                } else {
+                    cache.framebufferClear();
+                }
+                cache.bindFramebuffer(false);
+                GL11.glDisable(GL11.GL_BLEND);
+                GL11.glDepthMask(true);
+                OpenGlHelper.glBlendFunc(
+                    GL11.GL_SRC_ALPHA,
+                    GL11.GL_ONE_MINUS_SRC_ALPHA,
+                    GL11.GL_SRC_ALPHA,
+                    GL11.GL_ONE_MINUS_SRC_ALPHA);
+                GL11.glColor4f(1F, 1F, 1F, 1F);
+                drawButtons.run();
+            } finally {
+                GL11.glPopAttrib();
+                minecraft.getFramebuffer()
+                    .bindFramebuffer(false);
+            }
+        }
+
+        private void render(Framebuffer cache, Minecraft minecraft, IGuiRect bounds) {
+            ScaledResolution resolution = new ScaledResolution(
+                minecraft,
+                minecraft.displayWidth,
+                minecraft.displayHeight);
+            double screenWidth = resolution.getScaledWidth_double();
+            double screenHeight = resolution.getScaledHeight_double();
+            double left = bounds.getX();
+            double top = bounds.getY();
+            double right = left + bounds.getWidth();
+            double bottom = top + bounds.getHeight();
+            double u0 = left / screenWidth;
+            double u1 = right / screenWidth;
+            double v0 = 1D - bottom / screenHeight;
+            double v1 = 1D - top / screenHeight;
+
+            GL11.glPushAttrib(GL11.GL_ENABLE_BIT | GL11.GL_COLOR_BUFFER_BIT | GL11.GL_DEPTH_BUFFER_BIT);
+            cache.bindFramebufferTexture();
+            try {
+                GL11.glEnable(GL11.GL_BLEND);
+                GL11.glDisable(GL11.GL_DEPTH_TEST);
+                GL11.glDepthMask(false);
+                OpenGlHelper
+                    .glBlendFunc(GL11.GL_ONE, GL11.GL_ONE_MINUS_SRC_ALPHA, GL11.GL_ONE, GL11.GL_ONE_MINUS_SRC_ALPHA);
+                GL11.glColor4f(1F, 1F, 1F, 1F);
+                GL11.glEnable(GL11.GL_TEXTURE_2D);
+
+                Tessellator tessellator = Tessellator.instance;
+                tessellator.startDrawingQuads();
+                tessellator.addVertexWithUV(left, bottom, 0D, u0, v0);
+                tessellator.addVertexWithUV(right, bottom, 0D, u1, v0);
+                tessellator.addVertexWithUV(right, top, 0D, u1, v1);
+                tessellator.addVertexWithUV(left, top, 0D, u0, v1);
+                tessellator.draw();
+            } finally {
+                cache.unbindFramebufferTexture();
+                GL11.glPopAttrib();
+                GL11.glColor4f(1F, 1F, 1F, 1F);
+            }
+        }
     }
 }

--- a/src/main/java/betterquesting/api2/client/gui/panels/lists/CanvasQuestLine.java
+++ b/src/main/java/betterquesting/api2/client/gui/panels/lists/CanvasQuestLine.java
@@ -606,16 +606,23 @@ public class CanvasQuestLine extends CanvasScrolling {
 
         private Framebuffer getFramebuffer(Minecraft minecraft) {
             if (framebuffer == null) {
-                framebuffer = new Framebuffer(1, 1, true);
-                framebuffer.setFramebufferColor(0F, 0F, 0F, 0F);
-                minecraft.getFramebuffer()
-                    .bindFramebuffer(false);
+                GL11.glPushAttrib(
+                    GL11.GL_ENABLE_BIT | GL11.GL_COLOR_BUFFER_BIT | GL11.GL_DEPTH_BUFFER_BIT | GL11.GL_VIEWPORT_BIT);
+                try {
+                    framebuffer = new Framebuffer(minecraft.displayWidth, minecraft.displayHeight, true);
+                    framebuffer.setFramebufferColor(0F, 0F, 0F, 0F);
+                } finally {
+                    GL11.glPopAttrib();
+                    minecraft.getFramebuffer()
+                        .bindFramebuffer(false);
+                }
             }
             return framebuffer;
         }
 
         private void capture(Framebuffer cache, Minecraft minecraft, Runnable drawButtons) {
-            GL11.glPushAttrib(GL11.GL_ENABLE_BIT | GL11.GL_COLOR_BUFFER_BIT | GL11.GL_DEPTH_BUFFER_BIT);
+            GL11.glPushAttrib(
+                GL11.GL_ENABLE_BIT | GL11.GL_COLOR_BUFFER_BIT | GL11.GL_DEPTH_BUFFER_BIT | GL11.GL_VIEWPORT_BIT);
             try {
                 GL11.glDisable(GL11.GL_SCISSOR_TEST);
                 if (cache.framebufferWidth != minecraft.displayWidth
@@ -627,6 +634,7 @@ public class CanvasQuestLine extends CanvasScrolling {
                 }
                 cache.bindFramebuffer(false);
                 GL11.glDisable(GL11.GL_BLEND);
+                GL11.glDisable(GL11.GL_DEPTH_TEST);
                 GL11.glDepthMask(true);
                 OpenGlHelper.glBlendFunc(
                     GL11.GL_SRC_ALPHA,

--- a/src/main/java/betterquesting/api2/client/gui/panels/lists/CanvasQuestLine.java
+++ b/src/main/java/betterquesting/api2/client/gui/panels/lists/CanvasQuestLine.java
@@ -210,14 +210,24 @@ public class CanvasQuestLine extends CanvasScrolling {
 
             Tessellator tessellator = Tessellator.instance;
             tessellator.startDrawingQuads();
+            RuntimeException failure = null;
             try {
+                int batchQuads = 0;
                 for (IGuiPanel panel : getVisiblePanels()) {
                     if (panel instanceof PanelLine && panel.isEnabled()) {
-                        ((PanelLine) panel).addToBatch(tessellator, smx, smy, partialTick);
+                        batchQuads = ((PanelLine) panel).addToBatch(tessellator, smx, smy, partialTick, batchQuads);
                     }
                 }
+            } catch (RuntimeException e) {
+                failure = e;
+                throw e;
             } finally {
-                tessellator.draw();
+                try {
+                    tessellator.draw();
+                } catch (RuntimeException e) {
+                    if (failure == null) throw e;
+                    failure.addSuppressed(e);
+                }
             }
         } finally {
             GL11.glEnable(GL11.GL_TEXTURE_2D);

--- a/src/main/java/betterquesting/api2/client/gui/panels/lists/CanvasQuestLine.java
+++ b/src/main/java/betterquesting/api2/client/gui/panels/lists/CanvasQuestLine.java
@@ -126,10 +126,11 @@ public class CanvasQuestLine extends CanvasScrolling {
                     lsy,
                     getZoom(),
                     getButtonStateHash(mx, my),
-                    () -> drawQuestButtons(mx, my, partialTick));
+                    () -> drawQuestButtons(mx, my, partialTick, true),
+                    () -> drawQuestButtons(mx, my, partialTick, false));
             } catch (RuntimeException e) {
                 BUTTON_CACHE.fail(e);
-                drawQuestButtons(mx, my, partialTick);
+                drawQuestButtons(mx, my, partialTick, true);
             }
         }
     }
@@ -171,7 +172,7 @@ public class CanvasQuestLine extends CanvasScrolling {
         return 31 * hash + (Mouse.isButtonDown(0) ? 1 : 0);
     }
 
-    private void drawQuestButtons(int mx, int my, float partialTick) {
+    private void drawQuestButtons(int mx, int my, float partialTick, boolean clip) {
         float zs = getZoom();
         IGuiRect bounds = getTransform();
         int tx = bounds.getX();
@@ -180,7 +181,7 @@ public class CanvasQuestLine extends CanvasScrolling {
         int smy = (int) ((my - ty) / zs) + lsy;
 
         GL11.glPushMatrix();
-        RenderUtils.startScissor(bounds);
+        if (clip) RenderUtils.startScissor(bounds);
         try {
             GL11.glTranslatef(tx - lsx * zs, ty - lsy * zs, 0F);
             GL11.glScalef(zs, zs, zs);
@@ -191,7 +192,7 @@ public class CanvasQuestLine extends CanvasScrolling {
                 }
             }
         } finally {
-            RenderUtils.endScissor();
+            if (clip) RenderUtils.endScissor();
             GL11.glPopMatrix();
         }
     }
@@ -458,7 +459,7 @@ public class CanvasQuestLine extends CanvasScrolling {
         }
 
         private void draw(Object owner, IGuiRect bounds, int scrollX, int scrollY, float zoom, int contentHash,
-            Runnable drawButtons) {
+            Runnable drawButtons, Runnable captureButtons) {
             int mode = Math.max(0, Math.min(2, BQ_Settings.questIconCacheMode));
             boolean viewChanged = updateView(owner, bounds, scrollX, scrollY, zoom, contentHash);
 
@@ -474,7 +475,7 @@ public class CanvasQuestLine extends CanvasScrolling {
             if (!valid || cache.framebufferWidth != minecraft.displayWidth
                 || cache.framebufferHeight != minecraft.displayHeight
                 || mode == 1 && now >= nextRefresh) {
-                capture(cache, minecraft, drawButtons);
+                capture(cache, minecraft, captureButtons);
                 nextRefresh = mode == 1 ? now + 1000L / Math.max(1, BQ_Settings.questIconCacheFps) : Long.MAX_VALUE;
                 valid = true;
             }

--- a/src/main/java/betterquesting/api2/client/gui/panels/lists/CanvasScrolling.java
+++ b/src/main/java/betterquesting/api2/client/gui/panels/lists/CanvasScrolling.java
@@ -122,13 +122,13 @@ public class CanvasScrolling implements IGuiCanvas {
     public void setScrollX(int sx) {
         if (scrollBounds.getWidth() <= 0) return;
         scrollX.writeValueRaw((sx - scrollBounds.getX()) / (float) scrollBounds.getWidth());
-        lsx = this.getScrollX();
+        updatePanelScroll();
     }
 
     public void setScrollY(int sy) {
         if (scrollBounds.getHeight() <= 0) return;
         scrollY.writeValueRaw((sy - scrollBounds.getY()) / (float) scrollBounds.getHeight());
-        lsy = this.getScrollY();
+        updatePanelScroll();
     }
 
     public void setZoom(float z) {
@@ -245,8 +245,7 @@ public class CanvasScrolling implements IGuiCanvas {
 
             }
 
-            lsx = getScrollX();
-            lsy = getScrollY();
+            this.updatePanelScroll();
             lsz = zs;
 
         } else if (lsx != getScrollX() || lsy != getScrollY()) // We can skip this if the above case ran

--- a/src/main/java/betterquesting/api2/client/gui/panels/lists/CanvasScrolling.java
+++ b/src/main/java/betterquesting/api2/client/gui/panels/lists/CanvasScrolling.java
@@ -264,7 +264,7 @@ public class CanvasScrolling implements IGuiCanvas {
         int smy = (int) ((my - ty) / zs) + lsy;
 
         for (IGuiPanel panel : getVisiblePanels()) {
-            if (panel.isEnabled()) {
+            if (panel.isEnabled() && shouldDrawPanel(panel)) {
                 panel.drawPanel(smx, smy, partialTick);
             }
         }
@@ -600,7 +600,15 @@ public class CanvasScrolling implements IGuiCanvas {
         refreshScrollBounds();
     }
 
-    private List<IGuiPanel> getVisiblePanels() {
+    protected boolean shouldDrawPanel(IGuiPanel panel) {
+        return true;
+    }
+
+    protected boolean isBlockingEnabled() {
+        return useBlocking;
+    }
+
+    protected List<IGuiPanel> getVisiblePanels() {
         return useBlocking ? cullingManager.getVisiblePanels() : guiPanels;
     }
 }

--- a/src/main/java/betterquesting/api2/client/gui/panels/lists/CanvasScrolling.java
+++ b/src/main/java/betterquesting/api2/client/gui/panels/lists/CanvasScrolling.java
@@ -167,6 +167,8 @@ public class CanvasScrolling implements IGuiCanvas {
     @Override
     public void drawPanel(int mx, int my, float partialTick) {
         float zs = zoomScale.readValue();
+        int viewportWidth = (int) Math.ceil(transform.getWidth() / zs);
+        int viewportHeight = (int) Math.ceil(transform.getHeight() / zs);
 
         int tx = transform.getX();
         int ty = transform.getY();
@@ -248,7 +250,9 @@ public class CanvasScrolling implements IGuiCanvas {
             this.updatePanelScroll();
             lsz = zs;
 
-        } else if (lsx != getScrollX() || lsy != getScrollY()) // We can skip this if the above case ran
+        } else if (lsx != getScrollX() || lsy != getScrollY()
+            || scrollWindow.w != viewportWidth
+            || scrollWindow.h != viewportHeight) // We can skip this if the above case ran
         {
             this.updatePanelScroll();
         }

--- a/src/main/java/betterquesting/api2/client/gui/resources/lines/DirectionalLine.java
+++ b/src/main/java/betterquesting/api2/client/gui/resources/lines/DirectionalLine.java
@@ -35,25 +35,33 @@ public class DirectionalLine implements IGuiLine {
     @Override
     public void drawLine(IGuiRect startRect, IGuiRect endRect, int width, IGuiColor color, float partialTick,
         boolean animate) {
-        float scaledWidth = width * widthScale;
         GL11.glPushMatrix();
         GL11.glDisable(GL11.GL_TEXTURE_2D);
+        Tessellator tessellator = Tessellator.instance;
+        tessellator.startDrawingQuads();
+        addLine(tessellator, startRect, endRect, width, color, animate);
+        tessellator.draw();
+        GL11.glEnable(GL11.GL_TEXTURE_2D);
+        GL11.glColor4f(1F, 1F, 1F, 1F);
+        GL11.glPopMatrix();
+    }
+
+    public void addLine(Tessellator tessellator, IGuiRect startRect, IGuiRect endRect, int width, IGuiColor color,
+        boolean animate) {
+        float scaledWidth = width * widthScale;
         float startX = startRect.getX() + startRect.getWidth() / 2f;
         float startY = startRect.getY() + startRect.getHeight() / 2f;
         float diffX = endRect.getX() + endRect.getWidth() / 2f - startX;
         float diffY = endRect.getY() + endRect.getHeight() / 2f - startY;
         float length = (float) Math.sqrt(diffX * diffX + diffY * diffY);
-        float angle = (float) Math.atan2(diffY, diffX);
+        float cos = length > 0F ? diffX / length : 1F;
+        float sin = length > 0F ? diffY / length : 0F;
         int argb = color.getRGB();
-        GL11.glTranslatef(startX, startY, 1);
-        GL11.glRotated(Math.toDegrees(angle), 0, 0, 1);
-        Tessellator tessellator = Tessellator.instance;
-        tessellator.startDrawingQuads();
         tessellator.setColorRGBA(argb >> 16 & 255, argb >> 8 & 255, argb & 255, argb >> 24 & 255);
-        tessellator.addVertex(0, scaledWidth / 2f, 0);
-        tessellator.addVertex(length, scaledWidth / 2f, 0);
-        tessellator.addVertex(length, -scaledWidth / 2f, 0);
-        tessellator.addVertex(0, -scaledWidth / 2f, 0);
+        addVertex(tessellator, startX, startY, cos, sin, 0F, scaledWidth / 2F);
+        addVertex(tessellator, startX, startY, cos, sin, length, scaledWidth / 2F);
+        addVertex(tessellator, startX, startY, cos, sin, length, -scaledWidth / 2F);
+        addVertex(tessellator, startX, startY, cos, sin, 0F, -scaledWidth / 2F);
 
         // Arrow
         if (BQ_Settings.showDependencyArrows && length > 0F) {
@@ -72,24 +80,26 @@ public class DirectionalLine implements IGuiLine {
                     progress %= 1;
                 }
                 float arrowX = length * progress;
+                float arrowLeft = arrowX - arrowWidth / 2F;
+                float arrowRight = arrowX + arrowWidth / 2F;
+                float tipLeft = arrowX + arrowSize - arrowWidth / 2F;
+                float tipRight = arrowX + arrowSize + arrowWidth / 2F;
+                addVertex(tessellator, startX, startY, cos, sin, arrowLeft, scaledWidth / 2F);
+                addVertex(tessellator, startX, startY, cos, sin, arrowRight, scaledWidth / 2F);
+                addVertex(tessellator, startX, startY, cos, sin, tipRight, 0F);
+                addVertex(tessellator, startX, startY, cos, sin, tipLeft, 0F);
 
-                tessellator.addVertex(arrowX - arrowWidth / 2f, scaledWidth / 2f, 0);
-                tessellator.addVertex(arrowX + arrowWidth / 2f, scaledWidth / 2f, 0);
-                tessellator.addVertex(arrowX + arrowSize + arrowWidth / 2f, 0, 0);
-                tessellator.addVertex(arrowX + arrowSize - arrowWidth / 2f, 0, 0);
-
-                tessellator.addVertex(arrowX - arrowWidth / 2f, -scaledWidth / 2f, 0);
-                tessellator.addVertex(arrowX + arrowSize - arrowWidth / 2f, 0, 0);
-                tessellator.addVertex(arrowX + arrowSize + arrowWidth / 2f, 0, 0);
-                tessellator.addVertex(arrowX + arrowWidth / 2f, -scaledWidth / 2f, 0);
+                addVertex(tessellator, startX, startY, cos, sin, arrowLeft, -scaledWidth / 2F);
+                addVertex(tessellator, startX, startY, cos, sin, tipLeft, 0F);
+                addVertex(tessellator, startX, startY, cos, sin, tipRight, 0F);
+                addVertex(tessellator, startX, startY, cos, sin, arrowRight, -scaledWidth / 2F);
             }
         }
+    }
 
-        tessellator.draw();
-        GL11.glEnable(GL11.GL_TEXTURE_2D);
-        GL11.glColor4f(1F, 1F, 1F, 1F);
-
-        GL11.glPopMatrix();
+    private static void addVertex(Tessellator tessellator, float startX, float startY, float cos, float sin, float x,
+        float y) {
+        tessellator.addVertex(startX + x * cos - y * sin, startY + x * sin + y * cos, 1D);
     }
 
     @Override

--- a/src/main/java/betterquesting/api2/client/gui/resources/lines/DirectionalLine.java
+++ b/src/main/java/betterquesting/api2/client/gui/resources/lines/DirectionalLine.java
@@ -11,6 +11,9 @@ import betterquesting.api2.client.gui.resources.colors.IGuiColor;
 
 public class DirectionalLine implements IGuiLine {
 
+    // The 4096th quad forces Tessellator past its retained 0x20000-int buffer.
+    private static final int MAX_BATCH_QUADS = 4095;
+
     public static final float DefArrowWidth = 0.5f;
     public static final float DefArrowSize = 0.75f;
     public static final float DefArrowOpacity = 0.2f;
@@ -39,15 +42,15 @@ public class DirectionalLine implements IGuiLine {
         GL11.glDisable(GL11.GL_TEXTURE_2D);
         Tessellator tessellator = Tessellator.instance;
         tessellator.startDrawingQuads();
-        addLine(tessellator, startRect, endRect, width, color, animate);
+        addLine(tessellator, startRect, endRect, width, color, animate, 0);
         tessellator.draw();
         GL11.glEnable(GL11.GL_TEXTURE_2D);
         GL11.glColor4f(1F, 1F, 1F, 1F);
         GL11.glPopMatrix();
     }
 
-    public void addLine(Tessellator tessellator, IGuiRect startRect, IGuiRect endRect, int width, IGuiColor color,
-        boolean animate) {
+    public int addLine(Tessellator tessellator, IGuiRect startRect, IGuiRect endRect, int width, IGuiColor color,
+        boolean animate, int batchQuads) {
         float scaledWidth = width * widthScale;
         float startX = startRect.getX() + startRect.getWidth() / 2f;
         float startY = startRect.getY() + startRect.getHeight() / 2f;
@@ -57,7 +60,8 @@ public class DirectionalLine implements IGuiLine {
         float cos = length > 0F ? diffX / length : 1F;
         float sin = length > 0F ? diffY / length : 0F;
         int argb = color.getRGB();
-        tessellator.setColorRGBA(argb >> 16 & 255, argb >> 8 & 255, argb & 255, argb >> 24 & 255);
+        setColor(tessellator, argb);
+        batchQuads = beginQuad(tessellator, batchQuads, argb);
         addVertex(tessellator, startX, startY, cos, sin, 0F, scaledWidth / 2F);
         addVertex(tessellator, startX, startY, cos, sin, length, scaledWidth / 2F);
         addVertex(tessellator, startX, startY, cos, sin, length, -scaledWidth / 2F);
@@ -65,7 +69,9 @@ public class DirectionalLine implements IGuiLine {
 
         // Arrow
         if (BQ_Settings.showDependencyArrows && length > 0F) {
-            tessellator.setColorRGBA(0, 0, 0, Math.round(arrowOpacity * (argb >> 24 & 255)));
+            int arrowAlpha = Math.max(0, Math.min(255, Math.round(arrowOpacity * (argb >> 24 & 255))));
+            int arrowColor = arrowAlpha << 24;
+            setColor(tessellator, arrowColor);
             int numberOfArrows = MathHelper.ceiling_float_int(length / 20f);
 
             float arrowSize = scaledWidth * arrowSizeBase;
@@ -84,17 +90,32 @@ public class DirectionalLine implements IGuiLine {
                 float arrowRight = arrowX + arrowWidth / 2F;
                 float tipLeft = arrowX + arrowSize - arrowWidth / 2F;
                 float tipRight = arrowX + arrowSize + arrowWidth / 2F;
+                batchQuads = beginQuad(tessellator, batchQuads, arrowColor);
                 addVertex(tessellator, startX, startY, cos, sin, arrowLeft, scaledWidth / 2F);
                 addVertex(tessellator, startX, startY, cos, sin, arrowRight, scaledWidth / 2F);
                 addVertex(tessellator, startX, startY, cos, sin, tipRight, 0F);
                 addVertex(tessellator, startX, startY, cos, sin, tipLeft, 0F);
 
+                batchQuads = beginQuad(tessellator, batchQuads, arrowColor);
                 addVertex(tessellator, startX, startY, cos, sin, arrowLeft, -scaledWidth / 2F);
                 addVertex(tessellator, startX, startY, cos, sin, tipLeft, 0F);
                 addVertex(tessellator, startX, startY, cos, sin, tipRight, 0F);
                 addVertex(tessellator, startX, startY, cos, sin, arrowRight, -scaledWidth / 2F);
             }
         }
+        return batchQuads;
+    }
+
+    private static int beginQuad(Tessellator tessellator, int batchQuads, int color) {
+        if (batchQuads < MAX_BATCH_QUADS) return batchQuads + 1;
+        tessellator.draw();
+        tessellator.startDrawingQuads();
+        setColor(tessellator, color);
+        return 1;
+    }
+
+    private static void setColor(Tessellator tessellator, int argb) {
+        tessellator.setColorRGBA(argb >> 16 & 255, argb >> 8 & 255, argb & 255, argb >> 24 & 255);
     }
 
     private static void addVertex(Tessellator tessellator, float startX, float startY, float cos, float sin, float x,

--- a/src/main/java/betterquesting/api2/client/gui/resources/lines/DirectionalLine.java
+++ b/src/main/java/betterquesting/api2/client/gui/resources/lines/DirectionalLine.java
@@ -1,9 +1,9 @@
 package betterquesting.api2.client.gui.resources.lines;
 
+import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.util.MathHelper;
 
 import org.lwjgl.opengl.GL11;
-import org.lwjgl.util.vector.Vector2f;
 
 import betterquesting.api.storage.BQ_Settings;
 import betterquesting.api2.client.gui.misc.IGuiRect;
@@ -38,27 +38,26 @@ public class DirectionalLine implements IGuiLine {
         float scaledWidth = width * widthScale;
         GL11.glPushMatrix();
         GL11.glDisable(GL11.GL_TEXTURE_2D);
-        Vector2f start = new Vector2f(
-            startRect.getX() + startRect.getWidth() / 2f,
-            startRect.getY() + startRect.getHeight() / 2f);
-        Vector2f end = new Vector2f(
-            endRect.getX() + endRect.getWidth() / 2f,
-            endRect.getY() + endRect.getHeight() / 2f);
-        Vector2f diff = Vector2f.sub(end, start, null);
-        float length = diff.length();
-        float angle = (float) Math.atan2(diff.y, diff.x);
-        color.applyGlColor();
-        GL11.glTranslatef(start.x, start.y, 1);
+        float startX = startRect.getX() + startRect.getWidth() / 2f;
+        float startY = startRect.getY() + startRect.getHeight() / 2f;
+        float diffX = endRect.getX() + endRect.getWidth() / 2f - startX;
+        float diffY = endRect.getY() + endRect.getHeight() / 2f - startY;
+        float length = (float) Math.sqrt(diffX * diffX + diffY * diffY);
+        float angle = (float) Math.atan2(diffY, diffX);
+        int argb = color.getRGB();
+        GL11.glTranslatef(startX, startY, 1);
         GL11.glRotated(Math.toDegrees(angle), 0, 0, 1);
-        GL11.glBegin(GL11.GL_QUADS);
-        GL11.glVertex2f(0, scaledWidth / 2f);
-        GL11.glVertex2f(length, scaledWidth / 2f);
-        GL11.glVertex2f(length, -scaledWidth / 2f);
-        GL11.glVertex2f(0, -scaledWidth / 2f);
+        Tessellator tessellator = Tessellator.instance;
+        tessellator.startDrawingQuads();
+        tessellator.setColorRGBA(argb >> 16 & 255, argb >> 8 & 255, argb & 255, argb >> 24 & 255);
+        tessellator.addVertex(0, scaledWidth / 2f, 0);
+        tessellator.addVertex(length, scaledWidth / 2f, 0);
+        tessellator.addVertex(length, -scaledWidth / 2f, 0);
+        tessellator.addVertex(0, -scaledWidth / 2f, 0);
 
         // Arrow
-        if (BQ_Settings.showDependencyArrows) {
-            GL11.glColor4f(0, 0, 0, arrowOpacity * color.getAlpha());
+        if (BQ_Settings.showDependencyArrows && length > 0F) {
+            tessellator.setColorRGBA(0, 0, 0, Math.round(arrowOpacity * (argb >> 24 & 255)));
             int numberOfArrows = MathHelper.ceiling_float_int(length / 20f);
 
             float arrowSize = scaledWidth * arrowSizeBase;
@@ -74,19 +73,19 @@ public class DirectionalLine implements IGuiLine {
                 }
                 float arrowX = length * progress;
 
-                GL11.glVertex2f(arrowX - arrowWidth / 2f, scaledWidth / 2f);
-                GL11.glVertex2f(arrowX + arrowWidth / 2f, scaledWidth / 2f);
-                GL11.glVertex2f(arrowX + arrowSize + arrowWidth / 2f, 0f);
-                GL11.glVertex2f(arrowX + arrowSize - arrowWidth / 2f, 0f);
+                tessellator.addVertex(arrowX - arrowWidth / 2f, scaledWidth / 2f, 0);
+                tessellator.addVertex(arrowX + arrowWidth / 2f, scaledWidth / 2f, 0);
+                tessellator.addVertex(arrowX + arrowSize + arrowWidth / 2f, 0, 0);
+                tessellator.addVertex(arrowX + arrowSize - arrowWidth / 2f, 0, 0);
 
-                GL11.glVertex2f(arrowX - arrowWidth / 2f, -scaledWidth / 2f);
-                GL11.glVertex2f(arrowX + arrowSize - arrowWidth / 2f, 0f);
-                GL11.glVertex2f(arrowX + arrowSize + arrowWidth / 2f, 0f);
-                GL11.glVertex2f(arrowX + arrowWidth / 2f, -scaledWidth / 2f);
+                tessellator.addVertex(arrowX - arrowWidth / 2f, -scaledWidth / 2f, 0);
+                tessellator.addVertex(arrowX + arrowSize - arrowWidth / 2f, 0, 0);
+                tessellator.addVertex(arrowX + arrowSize + arrowWidth / 2f, 0, 0);
+                tessellator.addVertex(arrowX + arrowWidth / 2f, -scaledWidth / 2f, 0);
             }
         }
 
-        GL11.glEnd();
+        tessellator.draw();
         GL11.glEnable(GL11.GL_TEXTURE_2D);
         GL11.glColor4f(1F, 1F, 1F, 1F);
 

--- a/src/main/java/betterquesting/api2/client/gui/resources/textures/SimpleTexture.java
+++ b/src/main/java/betterquesting/api2/client/gui/resources/textures/SimpleTexture.java
@@ -29,6 +29,10 @@ public class SimpleTexture implements IGuiTexture {
         return this;
     }
 
+    public boolean isMaintainingAspect() {
+        return maintainAspect;
+    }
+
     @Override
     public void drawTexture(int x, int y, int width, int height, float zLevel, float partialTick) {
         drawTexture(x, y, width, height, zLevel, partialTick, defColor);

--- a/src/main/java/betterquesting/api2/client/gui/resources/textures/SlicedTexture.java
+++ b/src/main/java/betterquesting/api2/client/gui/resources/textures/SlicedTexture.java
@@ -2,6 +2,7 @@ package betterquesting.api2.client.gui.resources.textures;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.OpenGlHelper;
+import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.util.ResourceLocation;
 
 import org.lwjgl.opengl.GL11;
@@ -18,6 +19,9 @@ import cpw.mods.fml.client.config.GuiUtils;
 
 public class SlicedTexture implements IGuiTexture {
 
+    // The 4096th textured quad forces Tessellator past its retained 0x20000-int buffer.
+    private static final int MAX_BATCH_QUADS = 4095;
+    private static final float TEXEL = 1F / 256F;
     private static final IGuiColor defColor = new GuiColorStatic(255, 255, 255, 255);
 
     private final ResourceLocation texture;
@@ -79,126 +83,144 @@ public class SlicedTexture implements IGuiTexture {
             int iv = texBounds.getY() + texBorder.getTop();
             int iw = texBounds.getWidth() - texBorder.getLeft() - texBorder.getRight();
             int ih = texBounds.getHeight() - texBorder.getTop() - texBorder.getBottom();
-
-            float sx = (float) (w - (texBounds.getWidth() - iw)) / (float) iw;
-            float sy = (float) (h - (texBounds.getHeight() - ih)) / (float) ih;
+            if (iw < 0 || ih < 0) {
+                GL11.glPopMatrix();
+                return;
+            }
+            int sw = w - texBorder.getLeft() - texBorder.getRight();
+            int sh = h - texBorder.getTop() - texBorder.getBottom();
 
             Minecraft.getMinecraft().renderEngine.bindTexture(texture);
+            Tessellator tessellator = Tessellator.instance;
+            tessellator.startDrawingQuads();
+            int batchSize = 0;
 
             // TOP LEFT
-            GL11.glPushMatrix();
-            GL11.glTranslatef(dx, dy, 0F);
-            GuiUtils.drawTexturedModalRect(
-                0,
-                0,
+            batchSize = addTexturedQuad(
+                tessellator,
+                batchSize,
+                dx,
+                dy,
+                texBorder.getLeft(),
+                texBorder.getTop(),
                 texBounds.getX(),
                 texBounds.getY(),
                 texBorder.getLeft(),
                 texBorder.getTop(),
                 zLevel);
-            GL11.glPopMatrix();
 
             // TOP SIDE
-            GL11.glPushMatrix();
-            GL11.glTranslatef(dx + texBorder.getLeft(), dy, 0F);
-            GL11.glScalef(sx, 1F, 1F);
-            GuiUtils.drawTexturedModalRect(
-                0,
-                0,
+            batchSize = addTexturedQuad(
+                tessellator,
+                batchSize,
+                dx + texBorder.getLeft(),
+                dy,
+                sw,
+                texBorder.getTop(),
                 texBounds.getX() + texBorder.getLeft(),
                 texBounds.getY(),
                 iw,
                 texBorder.getTop(),
                 zLevel);
-            GL11.glPopMatrix();
 
             // TOP RIGHT
-            GL11.glPushMatrix();
-            GL11.glTranslatef(dx + w - texBorder.getRight(), dy, 0F);
-            GuiUtils.drawTexturedModalRect(
-                0,
-                0,
+            batchSize = addTexturedQuad(
+                tessellator,
+                batchSize,
+                dx + w - texBorder.getRight(),
+                dy,
+                texBorder.getRight(),
+                texBorder.getTop(),
                 texBounds.getX() + texBorder.getLeft() + iw,
                 texBounds.getY(),
                 texBorder.getRight(),
                 texBorder.getTop(),
                 zLevel);
-            GL11.glPopMatrix();
 
             // LEFT SIDE
-            GL11.glPushMatrix();
-            GL11.glTranslatef(dx, dy + texBorder.getTop(), 0F);
-            GL11.glScalef(1F, sy, 1F);
-            GuiUtils.drawTexturedModalRect(
-                0,
-                0,
+            batchSize = addTexturedQuad(
+                tessellator,
+                batchSize,
+                dx,
+                dy + texBorder.getTop(),
+                texBorder.getLeft(),
+                sh,
                 texBounds.getX(),
                 texBounds.getY() + texBorder.getTop(),
                 texBorder.getLeft(),
                 ih,
                 zLevel);
-            GL11.glPopMatrix();
 
             // MIDDLE
-            GL11.glPushMatrix();
-            GL11.glTranslatef(dx + texBorder.getLeft(), dy + texBorder.getTop(), 0F);
-            GL11.glScalef(sx, sy, 1F);
-            GuiUtils.drawTexturedModalRect(0, 0, iu, iv, iw, ih, zLevel);
-            GL11.glPopMatrix();
+            batchSize = addTexturedQuad(
+                tessellator,
+                batchSize,
+                dx + texBorder.getLeft(),
+                dy + texBorder.getTop(),
+                sw,
+                sh,
+                iu,
+                iv,
+                iw,
+                ih,
+                zLevel);
 
             // RIGHT SIDE
-            GL11.glPushMatrix();
-            GL11.glTranslatef(dx + w - texBorder.getRight(), dy + texBorder.getTop(), 0F);
-            GL11.glScalef(1F, sy, 1F);
-            GuiUtils.drawTexturedModalRect(
-                0,
-                0,
+            batchSize = addTexturedQuad(
+                tessellator,
+                batchSize,
+                dx + w - texBorder.getRight(),
+                dy + texBorder.getTop(),
+                texBorder.getRight(),
+                sh,
                 texBounds.getX() + texBorder.getLeft() + iw,
                 texBounds.getY() + texBorder.getTop(),
                 texBorder.getRight(),
                 ih,
                 zLevel);
-            GL11.glPopMatrix();
 
             // BOTTOM LEFT
-            GL11.glPushMatrix();
-            GL11.glTranslatef(dx, dy + h - texBorder.getBottom(), 0F);
-            GuiUtils.drawTexturedModalRect(
-                0,
-                0,
+            batchSize = addTexturedQuad(
+                tessellator,
+                batchSize,
+                dx,
+                dy + h - texBorder.getBottom(),
+                texBorder.getLeft(),
+                texBorder.getBottom(),
                 texBounds.getX(),
                 texBounds.getY() + texBorder.getTop() + ih,
                 texBorder.getLeft(),
                 texBorder.getBottom(),
                 zLevel);
-            GL11.glPopMatrix();
 
             // BOTTOM SIDE
-            GL11.glPushMatrix();
-            GL11.glTranslatef(dx + texBorder.getLeft(), dy + h - texBorder.getBottom(), 0F);
-            GL11.glScalef(sx, 1F, 1F);
-            GuiUtils.drawTexturedModalRect(
-                0,
-                0,
+            batchSize = addTexturedQuad(
+                tessellator,
+                batchSize,
+                dx + texBorder.getLeft(),
+                dy + h - texBorder.getBottom(),
+                sw,
+                texBorder.getBottom(),
                 texBounds.getX() + texBorder.getLeft(),
                 texBounds.getY() + texBorder.getTop() + ih,
                 iw,
                 texBorder.getBottom(),
                 zLevel);
-            GL11.glPopMatrix();
 
             // BOTTOM RIGHT
-            GL11.glPushMatrix();
-            GL11.glTranslatef(dx + w - texBorder.getRight(), dy + h - texBorder.getBottom(), 0F);
-            GuiUtils.drawTexturedModalRect(
-                0,
-                0,
+            addTexturedQuad(
+                tessellator,
+                batchSize,
+                dx + w - texBorder.getRight(),
+                dy + h - texBorder.getBottom(),
+                texBorder.getRight(),
+                texBorder.getBottom(),
                 texBounds.getX() + texBorder.getLeft() + iw,
                 texBounds.getY() + texBorder.getTop() + ih,
                 texBorder.getRight(),
                 texBorder.getBottom(),
                 zLevel);
-            GL11.glPopMatrix();
+            tessellator.draw();
         } else {
             float sx = (float) w / (float) texBounds.getWidth();
             float sy = (float) h / (float) texBounds.getHeight();
@@ -234,6 +256,10 @@ public class SlicedTexture implements IGuiTexture {
 
     public GuiPadding getBorder() {
         return this.texBorder;
+    }
+
+    public SliceMode getSliceMode() {
+        return sliceMode;
     }
 
     /**
@@ -291,12 +317,17 @@ public class SlicedTexture implements IGuiTexture {
         int remainderWidth = canvasWidth % fillerWidth;
         int yPasses = canvasHeight / fillerHeight;
         int remainderHeight = canvasHeight % fillerHeight;
+        Tessellator tessellator = Tessellator.instance;
+        tessellator.startDrawingQuads();
+        int batchSize = 0;
 
         // Draw Border
         // Top Left
-        GuiUtils.drawTexturedModalRect(x, y, u, v, leftBorder, topBorder, zLevel);
+        batchSize = addTexturedTile(tessellator, batchSize, x, y, u, v, leftBorder, topBorder, zLevel);
         // Top Right
-        GuiUtils.drawTexturedModalRect(
+        batchSize = addTexturedTile(
+            tessellator,
+            batchSize,
             x + leftBorder + canvasWidth,
             y,
             u + leftBorder + fillerWidth,
@@ -305,7 +336,9 @@ public class SlicedTexture implements IGuiTexture {
             topBorder,
             zLevel);
         // Bottom Left
-        GuiUtils.drawTexturedModalRect(
+        batchSize = addTexturedTile(
+            tessellator,
+            batchSize,
             x,
             y + topBorder + canvasHeight,
             u,
@@ -314,7 +347,9 @@ public class SlicedTexture implements IGuiTexture {
             bottomBorder,
             zLevel);
         // Bottom Right
-        GuiUtils.drawTexturedModalRect(
+        batchSize = addTexturedTile(
+            tessellator,
+            batchSize,
             x + leftBorder + canvasWidth,
             y + topBorder + canvasHeight,
             u + leftBorder + fillerWidth,
@@ -324,57 +359,98 @@ public class SlicedTexture implements IGuiTexture {
             zLevel);
 
         for (int i = 0; i < xPasses + (remainderWidth > 0 ? 1 : 0); i++) {
+            int drawWidth = i == xPasses ? remainderWidth : fillerWidth;
             // Top Border
-            GuiUtils.drawTexturedModalRect(
+            batchSize = addTexturedTile(
+                tessellator,
+                batchSize,
                 x + leftBorder + (i * fillerWidth),
                 y,
                 u + leftBorder,
                 v,
-                (i == xPasses ? remainderWidth : fillerWidth),
+                drawWidth,
                 topBorder,
                 zLevel);
             // Bottom Border
-            GuiUtils.drawTexturedModalRect(
+            batchSize = addTexturedTile(
+                tessellator,
+                batchSize,
                 x + leftBorder + (i * fillerWidth),
                 y + topBorder + canvasHeight,
                 u + leftBorder,
                 v + topBorder + fillerHeight,
-                (i == xPasses ? remainderWidth : fillerWidth),
+                drawWidth,
                 bottomBorder,
                 zLevel);
 
             // Throw in some filler for good measure
-            for (int j = 0; j < yPasses + (remainderHeight > 0 ? 1 : 0); j++) GuiUtils.drawTexturedModalRect(
-                x + leftBorder + (i * fillerWidth),
-                y + topBorder + (j * fillerHeight),
-                u + leftBorder,
-                v + topBorder,
-                (i == xPasses ? remainderWidth : fillerWidth),
-                (j == yPasses ? remainderHeight : fillerHeight),
-                zLevel);
+            for (int j = 0; j < yPasses + (remainderHeight > 0 ? 1 : 0); j++) {
+                int drawHeight = j == yPasses ? remainderHeight : fillerHeight;
+                batchSize = addTexturedTile(
+                    tessellator,
+                    batchSize,
+                    x + leftBorder + (i * fillerWidth),
+                    y + topBorder + (j * fillerHeight),
+                    u + leftBorder,
+                    v + topBorder,
+                    drawWidth,
+                    drawHeight,
+                    zLevel);
+            }
         }
 
         // Side Borders
         for (int j = 0; j < yPasses + (remainderHeight > 0 ? 1 : 0); j++) {
+            int drawHeight = j == yPasses ? remainderHeight : fillerHeight;
             // Left Border
-            GuiUtils.drawTexturedModalRect(
+            batchSize = addTexturedTile(
+                tessellator,
+                batchSize,
                 x,
                 y + topBorder + (j * fillerHeight),
                 u,
                 v + topBorder,
                 leftBorder,
-                (j == yPasses ? remainderHeight : fillerHeight),
+                drawHeight,
                 zLevel);
             // Right Border
-            GuiUtils.drawTexturedModalRect(
+            batchSize = addTexturedTile(
+                tessellator,
+                batchSize,
                 x + leftBorder + canvasWidth,
                 y + topBorder + (j * fillerHeight),
                 u + leftBorder + fillerWidth,
                 v + topBorder,
                 rightBorder,
-                (j == yPasses ? remainderHeight : fillerHeight),
+                drawHeight,
                 zLevel);
         }
+        tessellator.draw();
+    }
+
+    private static int addTexturedTile(Tessellator tessellator, int batchSize, int x, int y, int u, int v, int width,
+        int height, float zLevel) {
+        return addTexturedQuad(tessellator, batchSize, x, y, width, height, u, v, width, height, zLevel);
+    }
+
+    private static int addTexturedQuad(Tessellator tessellator, int batchSize, int x, int y, int width, int height,
+        int u, int v, int textureWidth, int textureHeight, float zLevel) {
+        if (width <= 0 || height <= 0 || textureWidth <= 0 || textureHeight <= 0) return batchSize;
+        if (batchSize >= MAX_BATCH_QUADS) {
+            tessellator.draw();
+            tessellator.startDrawingQuads();
+            batchSize = 0;
+        }
+
+        float minU = u * TEXEL;
+        float minV = v * TEXEL;
+        float maxU = (u + textureWidth) * TEXEL;
+        float maxV = (v + textureHeight) * TEXEL;
+        tessellator.addVertexWithUV(x, y + height, zLevel, minU, maxV);
+        tessellator.addVertexWithUV(x + width, y + height, zLevel, maxU, maxV);
+        tessellator.addVertexWithUV(x + width, y, zLevel, maxU, minV);
+        tessellator.addVertexWithUV(x, y, zLevel, minU, minV);
+        return batchSize + 1;
     }
 
     public enum SliceMode {

--- a/src/main/java/betterquesting/client/gui2/editors/designer/GuiDesigner.java
+++ b/src/main/java/betterquesting/client/gui2/editors/designer/GuiDesigner.java
@@ -109,6 +109,7 @@ public class GuiDesigner extends GuiScreenCanvas implements IVolatileScreen, INe
         cvBackground.addPanel(pnFrame);
 
         cvQuest = new CanvasQuestLine(new GuiTransform(GuiAlign.FULL_BOX, new GuiPadding(16, 16, 16, 16), 0), 1);
+        cvQuest.enableBlocking(false); // Designer tools move panels without rebuilding culling regions.
         cvBackground.addPanel(cvQuest);
         cvQuest.setQuestLine(questLine);
 

--- a/src/main/java/betterquesting/handlers/ConfigHandler.java
+++ b/src/main/java/betterquesting/handlers/ConfigHandler.java
@@ -168,6 +168,21 @@ public class ConfigHandler {
             2000F,
             "Zoom smoothness in ms");
 
+        BQ_Settings.questIconCacheMode = config.getInt(
+            "Quest icon cache mode",
+            Configuration.CATEGORY_GENERAL,
+            1,
+            0,
+            2,
+            "Quest icon rendering cache: 0 = off, 1 = low FPS, 2 = freeze.");
+        BQ_Settings.questIconCacheFps = config.getInt(
+            "Quest icon cache FPS",
+            Configuration.CATEGORY_GENERAL,
+            16,
+            1,
+            144,
+            "Refresh rate used by quest icon cache mode 1.");
+
         BQ_Settings.zoomInToCursor = config.getBoolean(
             "Zoom in on cursor",
             Configuration.CATEGORY_GENERAL,


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->
Huge performance patch 😎 
Before:
<img width="1917" height="1017" alt="image" src="https://github.com/user-attachments/assets/f5b183f3-39f0-4f5d-9371-431660fb3daf" />

After:
<img width="1918" height="1018" alt="image" src="https://github.com/user-attachments/assets/0176a686-1bdb-402b-b78e-43b22fd2ca91" />

What was done:
- Batching dependency-line geometry through `Tessellator`.
- Batching sliced-texture geometry instead of issuing one draw per slice.
- Capping batches at 4,095 quads to reuse Tessellator buffers.
- Removing temporary vector allocations from dependency-line rendering.
- Caching static quest-frame geometry in display lists.
- Culling quest panels outside the visible viewport.
- Caching quest icons and dependency lines in a framebuffer.
- Borrowed from NEI: Adding off, low-FPS, and freeze cache modes with a configurable refresh rate (default on low-fps with 16 frames / s, just like the default pack config for NEI).

PR tested on daily 702.

## Checklist
- [ ] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
