### PR TITLE
Fix LAN syncing

### DIFF
--- a/src/main/java/betterquesting/network/handlers/NetQuestSync.java
+++ b/src/main/java/betterquesting/network/handlers/NetQuestSync.java
@@ -189,8 +189,8 @@ public class NetQuestSync {
                 // If there we're not running the LAN server off this client then we overwrite always
                 quest.readProgressFromNBT(
                     questTag.getCompoundTag(TAG_QUEST_PROGRESS),
-                    !resetCompletion && (merge || Minecraft.getMinecraft()
-                        .isIntegratedServerRunning()));
+                    Minecraft.getMinecraft()
+                        .isIntegratedServerRunning() || (!resetCompletion && merge));
             }
         }
 


### PR DESCRIPTION
## Summary

fixes GTNewHorizons/GT-New-Horizons-Modpack/issues/19269, closes #207

Now LAN syncing works properly: all quests and tasks complete for both server holder and the other players, and there isn't any buggy looped "quest x completed" notification anymore

Checked on 11 first quests:
<img width="1512" height="982" alt="image" src="https://github.com/user-attachments/assets/aa5464a2-a2c0-4683-94a4-384edec6f865" />


## Checklist
- [ ] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
