### PR TITLE
Only parse PanelTextField text when it's not empty

### DIFF
--- a/src/main/java/betterquesting/api2/client/gui/controls/PanelTextField.java
+++ b/src/main/java/betterquesting/api2/client/gui/controls/PanelTextField.java
@@ -868,8 +868,10 @@ public class PanelTextField<T> implements IGuiPanel {
             return true;
         } else if (this.isFocused && !lockFocus) {
             this.isFocused = false;
-            this.text = filter.parseValue(this.text)
-                .toString();
+            if (this.text != null && !this.text.isEmpty()) {
+                this.text = filter.parseValue(this.text)
+                    .toString();
+            }
             invalidateVisualLines();
             updateDisplayText();
             // setCursorPosition(0);


### PR DESCRIPTION
Prevents number fields from getting automatically filled with 0 when you unfocus them. They do still read as a value of 0 in this state.

https://github.com/user-attachments/assets/e95687a5-cdac-4379-bef4-ad9fff824831

https://github.com/user-attachments/assets/557123d5-43e9-4f04-83f3-6bd7b7bb10e5

