### PR TITLE
Fix HQM location task importer using wrong location and visibility json keys

### DIFF
--- a/src/main/java/bq_standard/importers/hqm/converters/tasks/HQMTaskLocation.java
+++ b/src/main/java/bq_standard/importers/hqm/converters/tasks/HQMTaskLocation.java
@@ -21,18 +21,18 @@ public class HQMTaskLocation {
 
             TaskLocation task = new TaskLocation();
             task.name = JsonHelper.GetString(jLoc, "name", "New Location");
-            task.x = JsonHelper.GetNumber(jLoc, "posX", 0)
+            task.x = JsonHelper.GetNumber(jLoc, "x", 0)
                 .intValue();
-            task.y = JsonHelper.GetNumber(jLoc, "posY", 0)
+            task.y = JsonHelper.GetNumber(jLoc, "y", 0)
                 .intValue();
-            task.z = JsonHelper.GetNumber(jLoc, "posZ", 0)
+            task.z = JsonHelper.GetNumber(jLoc, "z", 0)
                 .intValue();
             task.dim = JsonHelper.GetNumber(jLoc, "dim", 0)
                 .intValue();
             task.range = JsonHelper.GetNumber(jLoc, "radius", -1)
                 .intValue();
-            task.hideInfo = JsonHelper.GetString(jLoc, "", "")
-                .equalsIgnoreCase("NONE");
+            task.hideInfo = JsonHelper.GetString(jLoc, "visible", "Location")
+                .equalsIgnoreCase("None");
             tList.add(task);
         }
 


### PR DESCRIPTION
Here's an example file. Import it with the HQM Quest Importer before and after to see the difference. Doesn't need HQM installed, just throw it in your config folder and pick it with the importer.

[Heavenly Heist.json](https://github.com/user-attachments/files/31864592/Heavenly.Heist.json)

Here is the location task working (ignore the pearl missing data, will be another pr):

<img width="942" height="667" alt="image" src="https://github.com/user-attachments/assets/dfce882a-692a-4a61-8a48-3adadad69d6b" />

<img width="2154" height="1255" alt="image" src="https://github.com/user-attachments/assets/c25693ce-06ee-4439-aadc-a75728dddb6e" />


