### PR TITLE
Fix HQM item converter's NBT parsing

### DIFF
--- a/src/main/java/bq_standard/importers/hqm/HQMUtilities.java
+++ b/src/main/java/bq_standard/importers/hqm/HQMUtilities.java
@@ -3,6 +3,8 @@ package bq_standard.importers.hqm;
 import java.util.HashMap;
 
 import net.minecraft.item.Item;
+import net.minecraft.nbt.JsonToNBT;
+import net.minecraft.nbt.NBTBase;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidRegistry;
@@ -12,7 +14,6 @@ import net.minecraftforge.oredict.OreDictionary;
 import org.apache.logging.log4j.Level;
 
 import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
 
 import betterquesting.api.placeholders.PlaceholderConverter;
 import betterquesting.api.utils.BigItemStack;
@@ -21,67 +22,36 @@ import betterquesting.core.BetterQuesting;
 import bq_standard.importers.hqm.converters.items.HQMItem;
 import bq_standard.importers.hqm.converters.items.HQMItemBag;
 import bq_standard.importers.hqm.converters.items.HQMItemHeart;
-import codechicken.nei.util.NBTJson;
 
 public class HQMUtilities {
 
     /**
      * Get HQM formatted item, Type 1
+     * Can return multiple stacks in the event the stack size exceeds 127
      */
-    public static BigItemStack HQMStackT1(JsonObject json) // This can return multiple stacks in the event the stack
-                                                           // size exceeds 127
-    {
-        final JsonParser parser = new JsonParser();
-        String iID = JsonHelper.GetString(json, "id", "minecraft:stone");
-        Item item = (Item) Item.itemRegistry.getObject(iID);
+    public static BigItemStack HQMStackT1(JsonObject json) {
+        String id = JsonHelper.GetString(json, "id", "minecraft:stone");
+        Item item = (Item) Item.itemRegistry.getObject(id);
         int amount = JsonHelper.GetNumber(json, "amount", 1)
             .intValue();
         int damage = JsonHelper.GetNumber(json, "damage", 0)
             .intValue();
-        NBTTagCompound tags = null;
+        NBTTagCompound tags = getNbtTagCompound(json);
 
-        if (json.has("nbt")) {
-            try {
-                String rawNbt = json.get("nbt")
-                    .toString(); // Must use this method. Gson formatting will damage it otherwise
-
-                // Hack job to fix backslashes (why are 2 Json formats being used in HQM?!)
-                rawNbt = rawNbt.replaceFirst("\"", ""); // Delete first quote
-                rawNbt = rawNbt.substring(0, rawNbt.length() - 1); // Delete last quote
-                rawNbt = rawNbt.replace(":\\\"", ":\""); // Fix start of strings
-                rawNbt = rawNbt.replace("\\\",", "\","); // Fix middle of lists
-                rawNbt = rawNbt.replace("\\\"}", "\"}"); // Fix end of strings
-                rawNbt = rawNbt.replace("\\\"]", "\"]"); // Fix end of lists
-                rawNbt = rawNbt.replace("[\\\"", "[\""); // Fix start of lists
-                rawNbt = rawNbt.replace("\\n", "\n");
-
-                tags = (NBTTagCompound) NBTJson.toNbt(
-                    parser.parse(rawNbt)
-                        .getAsJsonObject());
-            } catch (Exception e) {
-                BetterQuesting.logger.log(
-                    Level.ERROR,
-                    "Unable to convert HQM NBT data. This is likely a HQM Gson/Json formatting issue",
-                    e);
-            }
-        }
-
-        HQMItem hqm = itemConverters.get(iID.toLowerCase());
+        HQMItem hqm = itemConverters.get(id.toLowerCase());
         if (hqm != null) return hqm.convertItem(damage, amount, tags);
 
-        return PlaceholderConverter.convertItem(item, iID, amount, damage, "", tags);
+        return PlaceholderConverter.convertItem(item, id, amount, damage, "", tags);
     }
 
     /**
-     * Get HQM formatted item, Type 2
+     * Get HQM formatted item, Type 2.
+     * Can return multiple stacks in the event the stack size exceeds 127
      */
-    public static BigItemStack HQMStackT2(JsonObject rJson) // This can return multiple stacks in the event the stack
-                                                            // size exceeds 127
-    {
-        final JsonParser parser = new JsonParser();
+    public static BigItemStack HQMStackT2(JsonObject rJson) {
         JsonObject json = JsonHelper.GetObject(rJson, "item");
-        String iID = JsonHelper.GetString(json, "id", "minecraft:stone");
-        Item item = (Item) Item.itemRegistry.getObject(iID);
+        String id = JsonHelper.GetString(json, "id", "minecraft:stone");
+        Item item = (Item) Item.itemRegistry.getObject(id);
         int amount = JsonHelper.GetNumber(rJson, "required", 1)
             .intValue();
         int damage = JsonHelper.GetNumber(json, "damage", 0)
@@ -89,38 +59,12 @@ public class HQMUtilities {
         boolean oreDict = JsonHelper.GetString(rJson, "precision", "")
             .equalsIgnoreCase("ORE_DICTIONARY");
 
-        NBTTagCompound tags = null;
+        NBTTagCompound tags = getNbtTagCompound(json);
 
-        if (json.has("nbt")) {
-            try {
-                String rawNbt = json.get("nbt")
-                    .toString(); // Must use this method. Gson formatting will damage it otherwise
-
-                // Hack job to fix backslashes (why are 2 Json formats being used in HQM?!)
-                rawNbt = rawNbt.replaceFirst("\"", ""); // Delete first quote
-                rawNbt = rawNbt.substring(0, rawNbt.length() - 1); // Delete last quote
-                rawNbt = rawNbt.replace(":\\\"", ":\""); // Fix start of strings
-                rawNbt = rawNbt.replace("\\\",", "\","); // Fix middle of lists
-                rawNbt = rawNbt.replace("\\\"}", "\"}"); // Fix end of strings
-                rawNbt = rawNbt.replace("\\\"]", "\"]"); // Fix end of lists
-                rawNbt = rawNbt.replace("[\\\"", "[\""); // Fix start of lists
-                rawNbt = rawNbt.replace("\\n", "\n");
-
-                tags = (NBTTagCompound) NBTJson.toNbt(
-                    parser.parse(rawNbt)
-                        .getAsJsonObject());
-            } catch (Exception e) {
-                BetterQuesting.logger.log(
-                    Level.ERROR,
-                    "Unable to convert HQM NBT data. This is likely a HQM Gson/Json formatting issue",
-                    e);
-            }
-        }
-
-        HQMItem hqm = itemConverters.get(iID.toLowerCase());
+        HQMItem hqm = itemConverters.get(id.toLowerCase());
         if (hqm != null) return hqm.convertItem(damage, amount, tags);
 
-        BigItemStack stack = PlaceholderConverter.convertItem(item, iID, amount, damage, "", tags);
+        BigItemStack stack = PlaceholderConverter.convertItem(item, id, amount, damage, "", tags);
 
         if (oreDict && item != null) {
             int[] oreId = OreDictionary.getOreIDs(stack.getBaseStack());
@@ -137,6 +81,34 @@ public class HQMUtilities {
             .intValue();
 
         return PlaceholderConverter.convertFluid(fluid, name, amount, null);
+    }
+
+    private static NBTTagCompound getNbtTagCompound(JsonObject json) {
+        if (!json.has("nbt")) return null;
+        try {
+            String nbt = json.get("nbt")
+                .toString();
+            nbt = nbt.replaceFirst("\"", ""); // Delete first quote
+            nbt = nbt.substring(0, nbt.length() - 1); // Delete last quote
+            nbt = nbt.replace(":\\\"", ":\""); // Fix start of strings
+            nbt = nbt.replace("\\\",", "\","); // Fix middle of lists
+            nbt = nbt.replace("\\\"}", "\"}"); // Fix end of strings
+            nbt = nbt.replace("\\\"]", "\"]"); // Fix end of lists
+            nbt = nbt.replace("[\\\"", "[\""); // Fix start of lists
+            nbt = nbt.replace("\\n", "\n");
+            NBTBase nbtBase = JsonToNBT.func_150315_a(nbt);
+            if (nbtBase instanceof NBTTagCompound compound) {
+                return compound;
+            }
+        } catch (Exception e) {
+            BetterQuesting.logger.log(
+                Level.ERROR,
+                "Unable to convert HQM NBT data {}. This is likely a HQM Gson/Json formatting issue",
+                json.get("nbt")
+                    .toString(),
+                e);
+        }
+        return null;
     }
 
     private static final HashMap<String, HQMItem> itemConverters = new HashMap<>();


### PR DESCRIPTION
The main functional change is replacing
```java
                (NBTTagCompound) NBTJson.toNbt(
                    parser.parse(rawNbt)
                        .getAsJsonObject());
```
with
```java
                JsonToNBT.func_150315_a(nbt)
```
which is what HQM uses to decode these. Other changes are just to clean up var names and deduplicate the nbt reading.

See https://github.com/GTNewHorizons/BetterQuesting/pull/260 for an example quest to import

<img width="935" height="642" alt="image" src="https://github.com/user-attachments/assets/01a104b0-e402-44e5-8498-097264cd5b0d" />

<img width="697" height="166" alt="image" src="https://github.com/user-attachments/assets/5861b83e-8d3e-4977-9057-533e43f047ef" />
