### PR TITLE
allow the ability to hold backspace in the qb search bar

### DIFF
--- a/src/main/java/betterquesting/client/gui2/GuiQuestSearch.java
+++ b/src/main/java/betterquesting/client/gui2/GuiQuestSearch.java
@@ -4,6 +4,8 @@ import java.util.function.Consumer;
 
 import net.minecraft.client.gui.GuiScreen;
 
+import org.lwjgl.input.Keyboard;
+
 import betterquesting.api2.client.gui.GuiScreenCanvas;
 import betterquesting.api2.client.gui.controls.PanelButton;
 import betterquesting.api2.client.gui.controls.PanelTextField;
@@ -32,6 +34,7 @@ public class GuiQuestSearch extends GuiScreenCanvas {
     @Override
     public void initPanel() {
         super.initPanel();
+        Keyboard.enableRepeatEvents(true);
         CanvasTextured cvBackground = new CanvasTextured(
             new GuiTransform(GuiAlign.FULL_BOX, new GuiPadding(0, 0, 0, 0), 0),
             PresetTexture.PANEL_MAIN.getTexture());


### PR DESCRIPTION
allows backspace to be held in the search tab of the questbook

## Checklist
- [ ] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
